### PR TITLE
Update FUNDING.yml: Removed examples and added GitHub sponsorship con…

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,2 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
+github: invisiblesloth
 custom: https://invisiblesloth.itch.io/roxy-engine


### PR DESCRIPTION
…nection

This commit updates the FUNDING.yml file by making the following changes:

- Removed all example placeholders: Cleaned up the FUNDING.yml by removing the default example entries (e.g., placeholders for Patreon, Ko-fi, Open Collective, etc.). 
- Added GitHub sponsorship connection: Connected the Invisible Sloth organization’s GitHub sponsorship profile, allowing users to sponsor directly through GitHub Sponsors.

These changes provide a cleaner setup and ensure a direct connection to the organization's GitHub Sponsors page.