### PR TITLE
[0.12.3] - Fix Tilemap Stutter and Improve Scene Cleanup Timing

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -7,7 +7,7 @@
     "enableVisualDebugChecks": false
   },
   "input": {
-    "buttonHoldBufferAmount": 3,
+    "buttonHoldBufferAmount": 0,
     "crankDirection": 1
   },
   "assets": {

--- a/core/modules/roxy_input.c
+++ b/core/modules/roxy_input.c
@@ -36,7 +36,7 @@ static PDButtons currentState = 0;
 // Track how long each button is held (in frames)
 static int buttonHoldCounts[NUM_BUTTONS] = {0};
 
-// Configurable from Lua: Number of frames a button must be held 
+// Configurable from Lua: Number of frames a button must be held
 // before triggering a hold event.
 static int buttonHoldBufferAmount = 3; // Default: 3 frames
 

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -143,7 +143,11 @@ end
 function RoxyScene:exit()
   if self._didExit then return end
   self._didExit = true
+
   Log.debug("[RoxyScene:exit] Exiting Scene: " .. self.name) --#DEBUG
+
+  collectgarbage("collect")
+  Log.debug("Heap: " .. collectgarbage("count") / 1024 .. " MB") --#DEBUG
 end
 
 -- ! Cleanup

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -96,6 +96,8 @@ function RoxyTransition:_onMidpoint()
   if stackOp == STACK_OP_POP then
     if oldScene then
       oldScene:cleanup()
+      collectgarbage("collect")
+      Log.debug("Heap: " .. collectgarbage("count") / 1024 .. " MB")
     end
     if newScene then
       newScene:resume()
@@ -110,6 +112,8 @@ function RoxyTransition:_onMidpoint()
   else -- Replace
     if oldScene then
       oldScene:cleanup()
+      collectgarbage("collect")
+      Log.debug("Heap: " .. collectgarbage("count") / 1024 .. " MB")
     end
     if newScene then
       newScene:enter()

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -96,8 +96,6 @@ function RoxyTransition:_onMidpoint()
   if stackOp == STACK_OP_POP then
     if oldScene then
       oldScene:cleanup()
-      collectgarbage("collect")
-      Log.debug("Heap: " .. collectgarbage("count") / 1024 .. " MB")
     end
     if newScene then
       newScene:resume()
@@ -112,8 +110,6 @@ function RoxyTransition:_onMidpoint()
   else -- Replace
     if oldScene then
       oldScene:cleanup()
-      collectgarbage("collect")
-      Log.debug("Heap: " .. collectgarbage("count") / 1024 .. " MB")
     end
     if newScene then
       newScene:enter()

--- a/roxy.lua
+++ b/roxy.lua
@@ -240,6 +240,12 @@ function pd.update()
   local dt = getDeltaTime()
   r.deltaTime = dt
 
+  --#DEBUG START
+  if r.deltaTime > 0.05 then
+    Log.debug("long frame " .. r.deltaTime)
+  end
+  --#DEBUG END
+
   handleInput()
   updateSequences(dt)
   spriteUpdate()

--- a/roxy.lua
+++ b/roxy.lua
@@ -242,7 +242,7 @@ function pd.update()
 
   --#DEBUG START
   if r.deltaTime > 0.05 then
-    Log.debug("long frame " .. r.deltaTime)
+    Log.debug("Long frame: " .. r.deltaTime)
   end
   --#DEBUG END
 


### PR DESCRIPTION
### Overview
This patch release addresses performance stuttering when navigating large tilemaps by improving input responsiveness and memory management. It also ensures garbage collection is triggered safely during scene transitions, improving runtime stability and reducing potential timing issues.

### Key Changes
- Reduced `input.buttonHoldBufferAmount` to `0` for more immediate input response
- Added forced garbage collection after scene cleanup to reclaim memory earlier
- Added `collectgarbage()` to `RoxyScene:exit` to avoid timing conflicts
- Introduced debug logging for long frames to assist performance profiling
- Refined debug log format for long frame detection to improve clarity