### PR TITLE
[0.13.2] - Add Post-Sprite Draw Support and Optimize Update Loop

### DIFF
--- a/core/modules/Scene.lua
+++ b/core/modules/Scene.lua
@@ -13,7 +13,13 @@ local getDisplayImage <const> = Graphics.getDisplayImage
 local setBackgroundDrawing  <const> = Sprite.setBackgroundDrawingCallback
 local redrawBackground      <const> = Sprite.redrawBackground
 
+-- Cache a reference to your base scene class draw, if available
+local BaseSceneDraw <const> = (rawget(_G, "RoxyScene") and RoxyScene.draw) or nil
+
 local MAX_SCENE_DEPTH <const> = 32
+
+-- Shared no-op function to avoid per-activation allocations
+local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
 -- Global
 Scene.currentScene = nil
@@ -23,6 +29,7 @@ local scenes
 local stack
 local updateList
 local bgList
+local drawList
 
 -- ----------------------------------------
 -- Utilities
@@ -32,27 +39,90 @@ local bgList
 -- Rebuilds the update lists based on the current stack.
 local function rebuildLists()
   local currentScene = Scene.currentScene
-  local updateCount, bgCount = 0, 0
-  for i = 1, #stack do
-    local scene = stack[i]
+  local updateCount, bgCount = 0, 0 -- Counters for update lists
+  local drawCount = 0 -- Counter for draw list
+
+  -- Localize frequently used references for speed
+  local sceneStack = stack
+  local uList = updateList
+  local bList = bgList
+  local dList = drawList
+  local depth = #sceneStack
+
+  -- Early out for empty stack
+  if depth == 0 then
+    -- Trim tails in case previous state left items in the lists
+    if #uList > 0 then for i = 1, #uList do uList[i] = nil end end
+    if #bList > 0 then for i = 1, #bList do bList[i] = nil end end
+    if #dList > 0 then for i = 1, #dList do dList[i] = nil end end
+    Log.debug("[Scene.rebuildLists] update=0 bg=0 draw=0") --#DEBUG
+    return
+  end
+
+  -- (1) Build update and background lists
+  for i = 1, depth do
+    local scene = sceneStack[i]
     if scene == currentScene or scene.alwaysUpdate then
       updateCount += 1
-      updateList[updateCount] = scene
+      uList[updateCount] = scene
     elseif scene.updateBackground then
       bgCount += 1
-      bgList[bgCount] = scene
+      bList[bgCount] = scene
     end
   end
 
-  -- Trim tails
-  for i = updateCount + 1, #updateList do
-    updateList[i] = nil
-  end
-  for i = bgCount + 1, #bgList do
-    bgList[i] = nil
+  -- (2) Build draw list honoring scene stacking rules
+  -- Find the highest scene that blocks lower draw, scanning from top downward.
+  local startIndex = 1
+  for i = depth, 1, -1 do
+    local scene = sceneStack[i]
+    if scene and scene.blocksLowerDraw == true then
+      startIndex = i
+      break
+    end
   end
 
-  Log.debug("[Scene.rebuildLists] update=".. updateCount .. " bg=" .. bgCount) --#DEBUG
+  -- Collect visible scenes from startIndex --> top (bottom-to-top draw order)
+  for i = startIndex, depth do
+    local scene = sceneStack[i]
+    if scene and scene.isVisible ~= false then
+      -- Only include scenes that override draw (skip base no-op)
+      local cls = getmetatable(scene)
+      cls = cls and cls.__index or nil -- Class table for this instance
+      local fn = cls and cls.draw or nil -- Resolved draw for this class
+      local include = false
+
+      if type(fn) == "function" then
+        if BaseSceneDraw then
+          include = (fn ~= BaseSceneDraw) -- Different from base no-op
+        else
+          include = true -- Fallback if base unknown
+        end
+      end
+
+      if include then
+        drawCount += 1
+        dList[drawCount] = scene
+      end
+    end
+  end
+
+  -- (3) Trim tails
+  local uLen = #uList
+  local bLen = #bList
+  local dLen = #dList
+
+  if updateCount < uLen then
+    for i = updateCount + 1, uLen do uList[i] = nil end
+  end
+  if bgCount < bLen then
+    for i = bgCount + 1, bLen do bList[i] = nil end
+  end
+  if drawCount < dLen then
+    for i = drawCount + 1, dLen do dList[i] = nil end
+  end
+
+  Log.debug("[Scene.rebuildLists] update=" .. updateCount .. " bg=" .. bgCount .. " draw=" .. drawCount) --#DEBUG
 end
 
 -- ! Utility: Activate Scene
@@ -61,7 +131,7 @@ local function activateScene(scene)
   Scene.currentScene = scene
   if scene then
     scene:enter()
-    local backgroundDrawFn = scene.backgroundDrawFn or function(x, y, width, height) end
+    local backgroundDrawFn = scene.backgroundDrawFn or NO_OP_BG_DRAW
     setBackgroundDrawing(backgroundDrawFn)
     redrawBackground()
   end
@@ -77,6 +147,7 @@ function Scene.init()
   stack = {}      -- Scene stack
   updateList = {} -- Pre-filtered update list
   bgList = {}     -- Pre-filtered bg update lists
+  drawList = {}   -- Pre-filtered draw list
 
   Scene.currentScene = nil -- Currently active scene (top of stack)
 
@@ -165,8 +236,6 @@ function Scene.replaceScene(newScene)
     Log.error("[Scene.replaceScene] A valid scene table must be provided.", 2) --#DEBUG
     return
   end
-
-  local oldScene = Scene.currentScene
 
   -- Exit and cleanup all scenes on the stack before replacing
   for i = #stack, 1, -1 do
@@ -281,4 +350,10 @@ end
 -- ! Get Background List
 function Scene.getBackgroundList()
   return bgList
+end
+
+-- ! Get Draw List (Added)
+-- Returns the cached draw list honoring blocksLowerDraw and isVisible flags.
+function Scene.getDrawList()
+  return drawList
 end

--- a/core/modules/Scene.lua
+++ b/core/modules/Scene.lua
@@ -323,6 +323,12 @@ function Scene.popScene()
   activateScene(newScene)
 end
 
+-- ! Invalidate Lists
+-- Public access to rebuild lists utility
+function Scene.invalidateLists()
+  rebuildLists()
+end
+
 -- ----------------------------------------
 -- Scene State / Getters
 -- ----------------------------------------

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -24,12 +24,15 @@ local getTransitionConfig <const> = Config.getTransitionConfig
 
 local pushContext <const> = Graphics.pushContext
 local popContext  <const> = Graphics.popContext
+local setColor    <const> = Graphics.setColor
+local fillRect    <const> = Graphics.fillRect
 local newImage    <const> = Graphics.image.new
 local getDrawMode <const> = Graphics.getImageDrawMode
 local setDrawMode <const> = Graphics.setImageDrawMode
 
 local EMPTY_TABLE   <const> = {}
 
+local COLOR_WHITE     <const> = Graphics.kColorWhite
 local DRAW_MODE_COPY  <const> = Graphics.kDrawModeCopy
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
@@ -191,7 +194,7 @@ function Transition.transitionToScene(newSceneClass, transitionName, opts)
   end
 
   Transition.isTransitioning = true
-  local currentScene = Scene.currentScene
+  local scene = Scene.currentScene
 
   -- Use transition or fallback to default
   local config = getConfig("transitions") or EMPTY_TABLE
@@ -208,7 +211,7 @@ function Transition.transitionToScene(newSceneClass, transitionName, opts)
   -- Construct and execute the transition instance
   local transitionInstance = transitionClass(transitionOpts)
   Transition.currentTransition = transitionInstance
-  transitionInstance:execute(newScene, currentScene)
+  transitionInstance:execute(newScene, scene)
 end
 
 -- ----------------------------------------
@@ -218,34 +221,56 @@ end
 -- ! Prepare Transition Screenshot
 -- Prepares a screenshot for transitions if needed.
 function Transition.prepareTransitionScreenshot()
-  local currentTransition = Transition.currentTransition
-  if not currentTransition or not currentTransition.captureScreenshotsDuringTransition then return end
+  local transition = Transition.currentTransition
+  if not transition or not transition.captureScreenshot then return end
 
-  currentTransition.newSceneScreenshot = newImage(DISPLAY_WIDTH, DISPLAY_HEIGHT)
-  pushContext(currentTransition.newSceneScreenshot) -- Push context for capturing screenshot
-  currentTransition._screenshotContextPushed = true -- Track context state
+  -- Reuse the same image
+  local img = transition.newSceneScreenshot
+  if not img or img.width ~= DISPLAY_WIDTH or img.height ~= DISPLAY_HEIGHT then
+    img = newImage(DISPLAY_WIDTH, DISPLAY_HEIGHT)
+    transition.newSceneScreenshot = img
+  end
+
+  pushContext(img) -- Draw the whole frame into this image
+  transition._screenshotContextPushed = true
+end
+
+-- ! Clear Transition Screenshot
+-- Fills the current transition's screenshot image with a solid color.
+-- This is optional — most transitions fully redraw the frame anyway.
+function Transition.clearTransitionScreenshot(color)
+  local transition = Transition.currentTransition
+  if not transition or not transition.newSceneScreenshot then return end
+
+  -- Default to white if no color passed
+  local fillColor = color or COLOR_WHITE
+
+  pushContext(transition.newSceneScreenshot)
+    setColor(fillColor)
+    fillRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
+  popContext()
 end
 
 -- ! Execute Transition Drawing
 -- Executes rendering for the active transition effect, restoring draw mode afterward.
 function Transition.executeTransitionDrawing()
   if not Transition.isTransitioning then return end
-  local currentTransition = Transition.currentTransition
-  if not currentTransition then return end
+  local transition = Transition.currentTransition
+  if not transition then return end
 
-  -- Pop context only once after capture, not every frame!
-  if currentTransition.captureScreenshotsDuringTransition and currentTransition._screenshotContextPushed then
+  -- Pop only if we pushed this frame
+  if transition.captureScreenshot and transition._screenshotContextPushed then
     popContext()
-    currentTransition._screenshotContextPushed = false
+    transition._screenshotContextPushed = false
   end
 
-  local drawMode = currentTransition.drawMode or DRAW_MODE_COPY
-  local prevDrawMode = getDrawMode()
-  if prevDrawMode ~= drawMode then
+  local drawMode = transition.drawMode or DRAW_MODE_COPY
+  local prev = getDrawMode()
+  if prev ~= drawMode then
     setDrawMode(drawMode)
   end
-  currentTransition:draw()
-  if drawMode ~= prevDrawMode then
-    setDrawMode(prevDrawMode)
+  transition:draw()
+  if drawMode ~= prev then
+    setDrawMode(prev)
   end
 end

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -16,33 +16,40 @@ local setColor            <const> = Graphics.setColor
 local setDrawOffset       <const> = Graphics.setDrawOffset
 local setBackgroundColor  <const> = Graphics.setBackgroundColor
 local fillRect            <const> = Graphics.fillRect
+local setClipRect         <const> = Graphics.setClipRect
+local clearClipRect       <const> = Graphics.clearClipRect
 
-local redrawBackground    <const> = Sprite.redrawBackground
+local redrawBackground <const> = Sprite.redrawBackground
 
 local addHandler    <const> = r.Input.addHandler
 local removeHandler <const> = r.Input.removeHandler
 
 local resetCamera <const> = Camera.reset
 
-local COLOR_WHITE <const> = Graphics.kColorWhite
-local COLOR_BLACK <const> = Graphics.kColorBlack
-local CLEAR_COLOR <const> = COLOR_WHITE
+local COLOR_WHITE   <const> = Graphics.kColorWhite
+local COLOR_BLACK   <const> = Graphics.kColorBlack
+local CLEAR_COLOR   <const> = COLOR_WHITE
+
+local UNFLIPPED     <const> = Graphics.kImageUnflipped
+
+local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
 local _colorCallbacks = {} -- Cache: color --> fn
 local _imageCallbacks = setmetatable({}, { __mode = "k" }) -- Cache: image --> fn, weak keys
 
 --------------------------------------------------------------------------------
--- Helper
+-- Helpers
 --------------------------------------------------------------------------------
 
 -- ! Helper: Get Color Callback
--- builds (and returns) a drawing callback for a solid color
+-- Builds (and returns) a drawing callback for a solid color.
 local function _getColorCallback(color)
   local fn = _colorCallbacks[color]
   if fn == nil then
     fn = function(x, y, width, height)
+      -- Draw only the dirty rect
       setColor(color)
-      fillRect(x, y, width, height) -- Draw only the dirty rect
+      fillRect(x, y, width, height)
     end
     _colorCallbacks[color] = fn
   end
@@ -50,12 +57,15 @@ local function _getColorCallback(color)
 end
 
 -- ! Helper: Get Image Callback
--- Helper for static image
+-- Helper for static image. Draws only the dirty rect via clipping.
 local function _getImageCallback(img)
   local fn = _imageCallbacks[img]
   if fn == nil then
     fn = function(x, y, width, height)
-      img:draw(x, y, nil, x, y, width, height)
+      -- Set a clip to the dirty rect, then draw the full image once.
+      setClipRect(x, y, width, height)  -- Only redraw the dirty rect
+      img:draw(0, 0, UNFLIPPED)         -- Avoid per-call src rect; let clip do the work
+      clearClipRect()                   -- Restore clip
     end
     _imageCallbacks[img] = fn
   end
@@ -83,9 +93,13 @@ function RoxyScene:init(background)
   self.tilemaps = {}
   self.sequences = {}
 
+  -- Sensible defaults used by Scene draw filtering
+  self.isVisible = true
+  self.blocksLowerDraw = false
+
   self.backgroundColor = nil
   self.backgroundImage = nil
-  self.backgroundDrawFn = function(x, y, width, height) end
+  self.backgroundDrawFn = NO_OP_BG_DRAW -- Use shared no-op (avoid per-instance closure)
 
   self:setBackground(background)
 end
@@ -103,7 +117,12 @@ function RoxyScene:enter()
 end
 
 -- ! Update
-function RoxyScene:update()
+function RoxyScene:update(dt)
+  -- noop by default
+end
+
+-- ! Draw
+function RoxyScene:draw(dt)
   -- noop by default
 end
 
@@ -114,16 +133,18 @@ function RoxyScene:pause()
   self.isPaused = true
 
   -- Disable sprites from updating or colliding
-  for i = #self.sprites, 1, -1 do
-    local sprite = self.sprites[i]
+  local sprites = self.sprites
+  for i = #sprites, 1, -1 do
+    local sprite = sprites[i]
     sprite:pause()
     sprite:setUpdatesEnabled(false)
     sprite:setCollisionsEnabled(false)
   end
 
-  -- Disable sequence from updating
-  for i = #self.sequences, 1, -1 do
-    local sequence = self.sequences[i]
+  -- Disable sequences from updating
+  local sequences = self.sequences
+  for i = #sequences, 1, -1 do
+    local sequence = sequences[i]
     sequence:pause()
   end
 
@@ -137,16 +158,18 @@ function RoxyScene:resume()
   self.isPaused = false
 
   -- Enable sprites for updating and colliding
-  for i = #self.sprites, 1, -1 do
-    local sprite = self.sprites[i]
+  local sprites = self.sprites
+  for i = #sprites, 1, -1 do
+    local sprite = sprites[i]
     sprite:setUpdatesEnabled(true)
     sprite:setCollisionsEnabled(true)
     sprite:play()
   end
 
   -- Enable sequences for updating
-  for i = #self.sequences, 1, -1 do
-    local sequence = self.sequences[i]
+  local sequences = self.sequences
+  for i = #sequences, 1, -1 do
+    local sequence = sequences[i]
     sequence:play()
   end
 
@@ -183,8 +206,6 @@ function RoxyScene:cleanup()
   self.frozenBackground = nil -- Clean up screenshot from transitions
 end
 
--- TODO: Add sprite management methods etc. HERE
-
 --------------------------------------------------------------------------------
 -- Background Drawing
 --------------------------------------------------------------------------------
@@ -194,19 +215,31 @@ function RoxyScene:setBackground(background)
   -- Solid color
   if background == nil or type(background) == "number" then
     local color = background or CLEAR_COLOR
-    Log.debug("[RoxyScene:setBackground] Setting background color to " .. color)
+    local colorFn = _getColorCallback(color) -- Avoid double lookup/construction
+
+    -- Early-out if unchanged color and no image
+    if self.backgroundImage == nil and self.backgroundColor == color and self.backgroundDrawFn == colorFn then
+      return
+    end
+
+    Log.debug("[RoxyScene:setBackground] Setting background color to " .. color) --#DEBUG
     setBackgroundColor(color)
     self.backgroundColor = color
     self.backgroundImage = nil
-    self.backgroundDrawFn = _getColorCallback(color)
+    self.backgroundDrawFn = colorFn
     redrawBackground()
     return
   end
 
   -- Background image
   if type(background) == "userdata" then
-    Log.debug("[RoxyScene:setBackground] Setting background image")
     local img = background
+    -- Early-out if unchanged image
+    if self.backgroundImage == img then
+      return
+    end
+
+    Log.debug("[RoxyScene:setBackground] Setting background image") --#DEBUG
     self.backgroundColor = nil
     self.backgroundImage = img
     self.backgroundDrawFn = _getImageCallback(img)
@@ -214,12 +247,13 @@ function RoxyScene:setBackground(background)
     return
   end
 
-  Log.debug("[RoxyScene:setBackground] Falling back to background color: " .. CLEAR_COLOR)
   -- Fallback
+  Log.debug("[RoxyScene:setBackground] Falling back to background color: " .. CLEAR_COLOR) --#DEBUG
+  local colorFn = _getColorCallback(CLEAR_COLOR) -- Avoid double lookup/construction
   setBackgroundColor(CLEAR_COLOR)
   self.backgroundColor = CLEAR_COLOR
   self.backgroundImage = nil
-  self.backgroundDrawFn = _getColorCallback(CLEAR_COLOR)
+  self.backgroundDrawFn = colorFn
   redrawBackground()
 end
 
@@ -231,14 +265,15 @@ end
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
 
-  -- Give the sprite a back‑pointer so it can self‑remove later
-  sprite.scene = self
-
+  -- Avoid duplicates
   for i = 1, #self.sprites do
     if self.sprites[i] == sprite then
       return
     end
   end
+
+  -- Give the sprite a back-pointer so it can self-remove later
+  sprite.scene = self
 
   tableInsert(self.sprites, sprite)
   sprite:add()
@@ -250,7 +285,7 @@ function RoxyScene:removeSprite(sprite)
 
   for i = #self.sprites, 1, -1 do
     if self.sprites[i] == sprite then
-      sprite.scene = nil -- Clear back‑pointer
+      sprite.scene = nil -- Clear back-pointer
       sprite:remove()
       tableRemove(self.sprites, i)
       return
@@ -260,8 +295,11 @@ end
 
 -- ! Remove All Sprites
 function RoxyScene:removeAllSprites()
-  for i = #self.sprites, 1, -1 do
-    self.sprites[i]:remove()
+  local sprites = self.sprites
+  for i = #sprites, 1, -1 do
+    local sprite = sprites[i]
+    sprite.scene = nil -- Clear back-pointer
+    sprite:remove()
   end
   self.sprites = {}
 end
@@ -287,7 +325,7 @@ function RoxyScene:addTilemap(tilemap)
 
   tableInsert(self.tilemaps, tilemap)
 
-  -- Give the tilemap a back‑pointer so it can self‑remove later
+  -- Give the tilemap a back-pointer so it can self-remove later
   tilemap.scene = self
 end
 
@@ -296,7 +334,7 @@ function RoxyScene:removeTilemap(tilemap)
   if not tilemap then return end
   for i = #self.tilemaps, 1, -1 do
     if self.tilemaps[i] == tilemap then
-      tilemap.scene = nil -- Clear back‑pointer
+      tilemap.scene = nil -- Clear back-pointer
       tilemap:destroy()
       tableRemove(self.tilemaps, i)
       return
@@ -306,8 +344,11 @@ end
 
 -- ! Remove All Tilemaps
 function RoxyScene:removeAllTilemaps()
-  for i = #self.tilemaps, 1, -1 do
-    self.tilemaps[i]:destroy()
+  local tilemaps = self.tilemaps
+  for i = #tilemaps, 1, -1 do
+    local tilemap = tilemaps[i]
+    tilemap.scene = nil -- Clear back-pointer
+    tilemap:destroy()
   end
   self.tilemaps = {}
 end
@@ -333,7 +374,7 @@ function RoxyScene:addSequence(sequence)
 
   tableInsert(self.sequences, sequence)
 
-  -- Give the sequence a back‑pointer so it can self‑remove later
+  -- Give the sequence a back-pointer so it can self-remove later
   sequence.scene = self
 
   sequence:play()
@@ -344,7 +385,7 @@ function RoxyScene:removeSequence(sequence)
   if not sequence then return end
   for i = #self.sequences, 1, -1 do
     if self.sequences[i] == sequence then
-      sequence.scene = nil -- Clear back‑pointer
+      sequence.scene = nil -- Clear back-pointer
       sequence:clear(true)
       tableRemove(self.sequences, i)
       return
@@ -354,8 +395,11 @@ end
 
 -- ! Remove All Sequences
 function RoxyScene:removeAllSequences()
-  for i = #self.sequences, 1, -1 do
-    self.sequences[i]:clear(true)
+  local sequences = self.sequences
+  for i = #sequences, 1, -1 do
+    local sequence = sequences[i]
+    sequence.scene = nil -- Clear back-pointer
+    sequence:clear(true)
   end
   self.sequences = {}
 end
@@ -371,8 +415,9 @@ end
 
 -- ! Set Input Handler
 function RoxyScene:addHandler()
-  if self.inputHandler and (type(self.inputHandler) == "table" or type(self.inputHandler) == "function") then
-    addHandler(self, self.inputHandler, 0)
+  local inputHandler = self.inputHandler
+  if inputHandler and (type(inputHandler) == "table" or type(inputHandler) == "function") then
+    addHandler(self, inputHandler, 0)
   end
 end
 

--- a/roxy.lua
+++ b/roxy.lua
@@ -251,16 +251,22 @@ function pd.update()
   handleInput()
   updateSequences(dt)
 
+  -- Cache list once and length once.
   local updateList = getUpdateList()
-  for i = 1, #updateList do
+  local updateCount = #updateList
+  for i = 1, updateCount do
     updateList[i]:update(dt)
   end
+
   local bgList = getBackgroundList()
-  for i = 1, #bgList do
+  local bgCount = #bgList
+  for i = 1, bgCount do
     bgList[i]:updateBackground(dt)
   end
 
-  if Transition.isTransitioning then
+  local isTransitioning = Transition.isTransitioning
+
+  if isTransitioning then
     local currentTransition = Transition.currentTransition
     if currentTransition then
       prepareTransitionScreenshot() -- Push offscreen context here (pre-render)
@@ -270,12 +276,13 @@ function pd.update()
   spriteUpdate()
 
   local list = getDrawList()
-  for i = 1, #list do
+  local drawCount = #list
+  for i = 1, drawCount do
     list[i]:draw(dt)
   end
 
   -- Now render the transition overlay
-  if Transition.isTransitioning then
+  if isTransitioning then
     executeTransitionDrawing() -- This will pop the offscreen context
   end
 

--- a/roxy.lua
+++ b/roxy.lua
@@ -261,6 +261,11 @@ function pd.update()
 
   spriteUpdate()
 
+  local list = Scene.getDrawList()
+  for i = 1, #list do
+    list[i]:draw(r.deltaTime)
+  end
+
   if Transition.isTransitioning then
     local currentTransition = Transition.currentTransition
     if currentTransition.captureScreenshotsDuringTransition then

--- a/roxy.lua
+++ b/roxy.lua
@@ -98,6 +98,7 @@ local executeTransitionDrawing    <const> = Transition.executeTransitionDrawing
 local replaceScene      <const> = Scene.replaceScene
 local getUpdateList     <const> = Scene.getUpdateList
 local getBackgroundList <const> = Scene.getBackgroundList
+local getDrawList       <const> = Scene.getDrawList
 
 local updateDebug <const> = Debug.update --#DEBUG
 local drawFPS     <const> = pd.drawFPS --#DEBUG
@@ -242,8 +243,8 @@ function pd.update()
   r.deltaTime = dt
 
   --#DEBUG START
-  if r.deltaTime > 0.05 then
-    Log.debug("Long frame: " .. r.deltaTime)
+  if dt > 0.05 then
+    Log.debug("Long frame: " .. dt)
   end
   --#DEBUG END
 
@@ -259,19 +260,23 @@ function pd.update()
     bgList[i]:updateBackground(dt)
   end
 
-  spriteUpdate()
-
-  local list = Scene.getDrawList()
-  for i = 1, #list do
-    list[i]:draw(r.deltaTime)
-  end
-
   if Transition.isTransitioning then
     local currentTransition = Transition.currentTransition
-    if currentTransition.captureScreenshotsDuringTransition then
-      prepareTransitionScreenshot()
+    if currentTransition then
+      prepareTransitionScreenshot() -- Push offscreen context here (pre-render)
     end
-    executeTransitionDrawing()
+  end
+
+  spriteUpdate()
+
+  local list = getDrawList()
+  for i = 1, #list do
+    list[i]:draw(dt)
+  end
+
+  -- Now render the transition overlay
+  if Transition.isTransitioning then
+    executeTransitionDrawing() -- This will pop the offscreen context
   end
 
   drawCrankIndicator()


### PR DESCRIPTION
### Overview
This release enhances the scene system with post-sprite draw capabilities, enabling developers to render elements after all sprites have been drawn. It also introduces new APIs for manual scene list rebuilding, optimizes the update loop for better frame performance, and improves transition screenshot handling with reduced allocations and added customization.

### Key Changes
- **Scene System**
  - Added `RoxyScene:draw(dt)` and `Scene.getDrawList()` for rendering after sprite updates
  - Scene stacking now respects `blocksLowerDraw` and `isVisible` flags when building the draw list
  - Added `Scene.invalidateLists()` to allow external triggers for rebuilding update, background, and draw lists
  - Updated `pd.update` to call `draw()` for eligible scenes after `spriteUpdate`

- **Transitions**
  - Optimized screenshot capture by reusing a preallocated image
  - Added `Transition.clearTransitionScreenshot(color)` to fill screenshot with a solid color (default white)
  - Renamed `captureScreenshotsDuringTransition` to `captureScreenshot` for clarity
  - Simplified draw mode handling in `executeTransitionDrawing`

- **Core Update Loop**
  - Moved `prepareTransitionScreenshot` before sprite and scene drawing
  - Transition overlay rendering now occurs after scene drawing for proper layering
  - Cached list lengths for update, background, and draw lists to reduce table lookups
  - Cached `Transition.isTransitioning` state to avoid repeated global lookups

### Challenges/Notes
- Post-sprite draw support required carefully restructuring the update loop to ensure proper rendering order without breaking existing scene stacking behavior
- Transition screenshot optimization reduces per-frame allocations during effects, improving memory stability during rapid scene changes