### PR TITLE
[0.14.0] - Projection-Specific Tilemaps, New Scene Start Phase, and Input Pause/Resume

### DIFF
--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -299,6 +299,7 @@ function Camera.reset()
   Camera._deadZoneWidth   = 0
   Camera._deadZoneHeight  = 0
   Camera.friction         = FRICTION_DEFAULT
+  Camera._updateFunc      = Camera.updateStatic
 
   -- Immediate screen‑space reset
   setDrawOffset(0, 0)

--- a/core/modules/Input.lua
+++ b/core/modules/Input.lua
@@ -24,6 +24,7 @@ local CRANK_DIRECTION_DEFAULT    <const> = 1
 
 -- Pre-defined array for efficient iteration instead of pairs()
 local BUTTON_NAMES <const> = { "A", "B", "up", "down", "left", "right" }
+local BUTTON_COUNT <const> = #BUTTON_NAMES
 
 -- Input event keys - kept in sync with handler merging system
 local INPUT_KEYS <const> = {
@@ -35,6 +36,7 @@ local INPUT_KEYS <const> = {
   "upButtonDown", "upButtonUp", "upButtonHold",
   "cranked", "crankDocked", "crankUndocked"
 }
+local INPUT_KEY_COUNT <const> = #INPUT_KEYS
 
 -- Button name to callback key mapping
 local BUTTON_KEYS <const> = {
@@ -63,7 +65,6 @@ local persistentMergedHandler = {} -- Reused table to avoid allocation
 local cachedHoldCallbacks = {}
 
 -- Configuration state
-local buttonHoldBufferAmount = BUTTON_HOLD_BUFFER_DEFAULT
 local cachedBufferAmount = BUTTON_HOLD_BUFFER_DEFAULT
 
 -- Combined crank indicator state into single object
@@ -80,6 +81,7 @@ local pendingRegistryDirty = false
 Input.crankDirection = CRANK_DIRECTION_DEFAULT
 Input.isEnabled = true
 Input._blocked = false -- Blocks input until all buttons released
+Input._paused = false  -- Pauses all input callbacks until resumed
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -94,7 +96,7 @@ end
 -- ! Reset Button Flags
 -- Fast reset using array iteration instead of pairs()
 local function resetButtonFlags()
-  for i = 1, #BUTTON_NAMES do
+  for i = 1, BUTTON_COUNT do
     local name = BUTTON_NAMES[i]
     held[name] = false
     heldFrames[name] = 0
@@ -105,17 +107,23 @@ end
 -- Cache hold callbacks when handler changes to avoid lookups in handleInput
 local function cacheHoldCallbacks(handler)
   if not handler then
-    for i = 1, #BUTTON_NAMES do
+    for i = 1, BUTTON_COUNT do
       cachedHoldCallbacks[BUTTON_NAMES[i]] = nil
     end
     return
   end
 
-  for i = 1, #BUTTON_NAMES do
+  for i = 1, BUTTON_COUNT do
     local name = BUTTON_NAMES[i]
     local keys = BUTTON_KEYS[name]
     cachedHoldCallbacks[name] = handler[keys.hold]
   end
+end
+
+-- ! Should Process Input
+-- Centralized check for whether callbacks should run
+local function shouldProcessInput()
+  return Input.isEnabled and (not Input._paused) and (not Input._blocked)
 end
 
 -- ! Merge Handlers
@@ -127,12 +135,12 @@ local function mergeHandlers()
   local merged = persistentMergedHandler
 
   -- Clear only known keys instead of using pairs() which creates garbage
-  for i = 1, #INPUT_KEYS do
+  for i = 1, INPUT_KEY_COUNT do
     merged[INPUT_KEYS[i]] = nil
   end
 
   -- Find the highest priority handler for each input event
-  for i = 1, #INPUT_KEYS do
+  for i = 1, INPUT_KEY_COUNT do
     local key = INPUT_KEYS[i]
     for j = 1, #handlerRegistry do
       local handler = handlerRegistry[j]
@@ -154,20 +162,27 @@ local function wrapMergedHandler(userHandler)
 
   -- Copy handler to avoid mutating the pooled table
   local wrappedHandler = {}
-  for i = 1, #INPUT_KEYS do
+  for i = 1, INPUT_KEY_COUNT do
     local key = INPUT_KEYS[i]
-    wrappedHandler[key] = userHandler[key]
+    local original = userHandler[key]
+    if original then
+      -- Gate every callback behind shouldProcessInput()
+      wrappedHandler[key] = function(...)
+        if shouldProcessInput() then original(...) end
+      end
+    end
   end
 
   -- Wrap Down/Up events to track hold state (only if handlers exist)
-  for i = 1, #BUTTON_NAMES do
+  for i = 1, BUTTON_COUNT do
     local name = BUTTON_NAMES[i]
     local keys = BUTTON_KEYS[name]
-    local origDown, origUp = wrappedHandler[keys.down], wrappedHandler[keys.up]
+    local origDown, origUp = userHandler[keys.down], userHandler[keys.up]
 
     -- Only create wrapper functions if original handlers exist or we need state tracking
     if origDown or userHandler[keys.up] or userHandler[keys.hold] then
       wrappedHandler[keys.down] = function(...)
+        if not shouldProcessInput() then return end
         held[name] = true
         heldFrames[name] = 0
         if origDown then origDown(...) end
@@ -176,6 +191,7 @@ local function wrapMergedHandler(userHandler)
 
     if origUp or userHandler[keys.down] or userHandler[keys.hold] then
       wrappedHandler[keys.up] = function(...)
+        if not shouldProcessInput() then return end
         held[name] = false
         heldFrames[name] = 0
         if origUp then origUp(...) end
@@ -202,6 +218,7 @@ function Input.init()
   crankIndicator.forced = false
   Input.isEnabled = true
   Input._blocked = false
+  Input._paused = false
 
   handlerRegistry = {}
   activeMergedHandler = nil
@@ -331,7 +348,7 @@ end
 -- Create a modal handler that blocks all inputs not explicitly handled
 function Input.makeModalHandler(handler)
   handler = handler or {}
-  for i = 1, #INPUT_KEYS do
+  for i = 1, INPUT_KEY_COUNT do
     local key = INPUT_KEYS[i]
     if handler[key] == nil then
       handler[key] = function() end -- Inert callback
@@ -377,19 +394,51 @@ function Input.setButtonHoldBufferAmount(frames)
 end
 
 --------------------------------------------------------------------------------
+-- Pause / Resume Controls
+--------------------------------------------------------------------------------
+
+-- ! Pause
+-- Pause all input handling immediately (no callbacks will fire)
+function Input.pause()
+  Input._paused = true
+  -- Flush any queued events so they do not leak through after resume
+  Input.flushButtonQueue()
+  resetButtonFlags()
+  Log.debug("[Input.pause] Input paused") --#DEBUG
+end
+
+-- ! Resume
+-- Resume input handling. Optionally block until buttons are clear.
+function Input.resume(blockUntilClear)
+  Input._paused = false
+  if blockUntilClear then
+    Input.blockUntilClear()
+  else
+    Input.flushButtonQueue()
+    resetButtonFlags()
+  end
+  Log.debug("[Input.resume] Input resumed (blockUntilClear=" .. tostring(blockUntilClear) .. ")") --#DEBUG
+end
+
+-- ! Is Paused
+-- Query paused state
+function Input.isPaused()
+  return Input._paused
+end
+
+--------------------------------------------------------------------------------
 -- Crank Controls
 --------------------------------------------------------------------------------
 
 -- ! Set Crank Indicator
 -- Single function to configure crank indicator
-function Input.setCrankIndicator(config)
+function Input.setCrankIndicator(config, forced)
   if type(config) == "table" then
     crankIndicator.active = config.active or false
     crankIndicator.forced = config.forced or false
   else
-    -- Legacy support: setCrankIndicator(active, forced)
     crankIndicator.active = config == true
-    crankIndicator.forced = arguments and arguments[2] == true
+    crankIndicator.forced = forced == true
   end
   Log.debug("[Input.setCrankIndicator] active=" .. tostring(crankIndicator.active) .. ", forced=" .. tostring(crankIndicator.forced)) --#DEBUG
 end
@@ -441,7 +490,7 @@ end
 -- ! Crank Docked
 -- Trigger crank docked callback through merged handler
 function Input.crankDocked()
-  if Input.isEnabled and activeMergedHandler and activeMergedHandler.crankDocked then
+  if shouldProcessInput() and activeMergedHandler and activeMergedHandler.crankDocked then
     activeMergedHandler.crankDocked()
   end
 end
@@ -449,7 +498,7 @@ end
 -- ! Crank Undocked
 -- Trigger crank undocked callback through merged handler
 function Input.crankUndocked()
-  if Input.isEnabled and activeMergedHandler and activeMergedHandler.crankUndocked then
+  if shouldProcessInput() and activeMergedHandler and activeMergedHandler.crankUndocked then
     activeMergedHandler.crankUndocked()
   end
 end
@@ -461,11 +510,11 @@ end
 -- ! Handle Input
 -- Main per-frame input processing with minimal overhead
 function Input.handleInput()
-  if not Input.isEnabled or not activeMergedHandler then return end
-
-  -- Handle input blocking during scene transitions
-  if Input._blocked then
-    if getButtonState() == 0 then -- No buttons pressed
+  if not activeMergedHandler then return end
+  if not shouldProcessInput() then
+    -- Handle input blocking during scene transitions
+    -- Avoid double getButtonState() call if not blocked
+    if Input._blocked and getButtonState() == 0 then
       Log.debug("[Input.handleInput] Unblocking input") --#DEBUG
       Input._blocked = false
       getButtonState() -- Flush button state
@@ -477,12 +526,11 @@ function Input.handleInput()
   local buf = cachedBufferAmount
 
   -- Use cached callbacks and array iteration for maximum performance
-  for i = 1, #BUTTON_NAMES do
+  for i = 1, BUTTON_COUNT do
     local name = BUTTON_NAMES[i]
     if held[name] then
       local frames = heldFrames[name] + 1
       heldFrames[name] = frames
-
       if frames >= buf then
         local callback = cachedHoldCallbacks[name]
         if callback then callback() end

--- a/core/modules/Scene.lua
+++ b/core/modules/Scene.lua
@@ -134,6 +134,7 @@ local function activateScene(scene)
     local backgroundDrawFn = scene.backgroundDrawFn or NO_OP_BG_DRAW
     setBackgroundDrawing(backgroundDrawFn)
     redrawBackground()
+    scene:start()
   end
 end
 

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -22,13 +22,15 @@ local mergeImmutable <const> = r.Table.mergeImmutable
 local getConfig           <const> = Config.get
 local getTransitionConfig <const> = Config.getTransitionConfig
 
-local pushContext <const> = Graphics.pushContext
-local popContext  <const> = Graphics.popContext
-local setColor    <const> = Graphics.setColor
-local fillRect    <const> = Graphics.fillRect
-local newImage    <const> = Graphics.image.new
-local getDrawMode <const> = Graphics.getImageDrawMode
-local setDrawMode <const> = Graphics.setImageDrawMode
+local getDrawOffset <const> = Graphics.getDrawOffset
+local setDrawOffset <const> = Graphics.setDrawOffset
+local pushContext   <const> = Graphics.pushContext
+local popContext    <const> = Graphics.popContext
+local setColor      <const> = Graphics.setColor
+local fillRect      <const> = Graphics.fillRect
+local newImage      <const> = Graphics.image.new
+local getDrawMode   <const> = Graphics.getImageDrawMode
+local setDrawMode   <const> = Graphics.setImageDrawMode
 
 local EMPTY_TABLE   <const> = {}
 
@@ -265,12 +267,22 @@ function Transition.executeTransitionDrawing()
   end
 
   local drawMode = transition.drawMode or DRAW_MODE_COPY
-  local prev = getDrawMode()
-  if prev ~= drawMode then
+  local prevMode = getDrawMode()
+  if prevMode ~= drawMode then
     setDrawMode(drawMode)
   end
+
+  -- Draw transitions in screen space (ignore camera)
+  local offsetX, offsetY = getDrawOffset()
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(0, 0)
+  end
   transition:draw()
-  if drawMode ~= prev then
-    setDrawMode(prev)
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(offsetX, offsetY)
+  end
+
+  if drawMode ~= prevMode then
+    setDrawMode(prevMode)
   end
 end

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -73,12 +73,11 @@ local function _getImageCallback(img)
 end
 
 --------------------------------------------------------------------------------
--- Class Definition & Init
+-- ! Class Definition and Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyScene").extends(Object)
 
---! Initialize
 function RoxyScene:init(background)
   self.name = self.className or "RoxyScene"
   Log.debug("[RoxyScene:init] Initializing Scene: " .. self.name) --#DEBUG
@@ -92,6 +91,9 @@ function RoxyScene:init(background)
   self.sprites = {}
   self.tilemaps = {}
   self.sequences = {}
+
+  self._spriteAutoAddQueue = {}
+  self._sequenceAutoStartQueue = {}
 
   -- Sensible defaults used by Scene draw filtering
   self.isVisible = true
@@ -114,6 +116,20 @@ function RoxyScene:enter()
   self._didEnter = true
   Log.debug("[RoxyScene:enter] Entering Scene: " .. self.name) --#DEBUG
   self:addHandler()
+
+  -- Flush any queued sprite auto-adds
+  local spriteQueue = self._spriteAutoAddQueue
+  for i = 1, #spriteQueue do
+    spriteQueue[i]:add()
+  end
+  self._spriteAutoAddQueue = {}
+
+  -- Flush any queued sequence auto-starts
+  local sequenceQueue = self._sequenceAutoStartQueue
+  for i = 1, #sequenceQueue do
+    sequenceQueue[i]:play()
+  end
+  self._sequenceAutoStartQueue = {}
 end
 
 -- ! Update
@@ -200,6 +216,10 @@ function RoxyScene:cleanup()
 
   resetCamera()
 
+  self._spriteAutoAddQueue = {}
+  self._sequenceAutoStartQueue = {}
+  self._tilemapActivateQueue = {}
+
   self.backgroundColor = nil
   self.backgroundImage = nil
   self.backgroundDrawFn = nil
@@ -267,16 +287,21 @@ function RoxyScene:addSprite(sprite)
 
   -- Avoid duplicates
   for i = 1, #self.sprites do
-    if self.sprites[i] == sprite then
-      return
-    end
+    if self.sprites[i] == sprite then return end
   end
 
   -- Give the sprite a back-pointer so it can self-remove later
   sprite.scene = self
 
   tableInsert(self.sprites, sprite)
-  sprite:add()
+
+  if self._didEnter then
+    -- Scene is active -- attach immediately
+    sprite:add()
+  else
+    -- Scene isn't active yet -- queue for enter()
+    tableInsert(self._spriteAutoAddQueue, sprite)
+  end
 end
 
 -- ! Remove Sprite
@@ -318,9 +343,7 @@ function RoxyScene:addTilemap(tilemap)
   if not tilemap then return end
 
   for i = 1, #self.tilemaps do
-    if self.tilemaps[i] == tilemap then
-      return
-    end
+    if self.tilemaps[i] == tilemap then return end
   end
 
   tableInsert(self.tilemaps, tilemap)
@@ -367,9 +390,7 @@ function RoxyScene:addSequence(sequence)
   if not sequence then return end
 
   for i = 1, #self.sequences do
-    if self.sequences[i] == sequence then
-      return
-    end
+    if self.sequences[i] == sequence then return end
   end
 
   tableInsert(self.sequences, sequence)
@@ -377,7 +398,13 @@ function RoxyScene:addSequence(sequence)
   -- Give the sequence a back-pointer so it can self-remove later
   sequence.scene = self
 
-  sequence:play()
+  if self._didEnter then
+    -- Scene is active -- start now
+    sequence:play()
+  else
+    -- Scene isn't active yet -- queue for enter()
+    tableInsert(self._sequenceAutoStartQueue, sequence)
+  end
 end
 
 -- ! Remove Sequence

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -6,6 +6,7 @@ local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
 local r       <const> = roxy
+local Input   <const> = r.Input
 local Camera  <const> = r.Camera
 
 local tableInsert <const> = table.insert
@@ -21,8 +22,10 @@ local clearClipRect       <const> = Graphics.clearClipRect
 
 local redrawBackground <const> = Sprite.redrawBackground
 
-local addHandler    <const> = r.Input.addHandler
-local removeHandler <const> = r.Input.removeHandler
+local addHandler    <const> = Input.addHandler
+local pauseHandler  <const> = Input.pause
+local resumeHandler <const> = Input.resume
+local removeHandler <const> = Input.removeHandler
 
 local resetCamera <const> = Camera.reset
 
@@ -84,6 +87,7 @@ function RoxyScene:init(background)
 
   self.isPaused = false
   self._didEnter = false
+  self._didStart = false
   self._didExit = false
   self._didCleanup = false
 
@@ -113,9 +117,8 @@ end
 -- ! Enter
 function RoxyScene:enter()
   if self._didEnter then return end
-  self._didEnter = true
   Log.debug("[RoxyScene:enter] Entering Scene: " .. self.name) --#DEBUG
-  self:addHandler()
+  self._didEnter = true
 
   -- Flush any queued sprite auto-adds
   local spriteQueue = self._spriteAutoAddQueue
@@ -130,6 +133,15 @@ function RoxyScene:enter()
     sequenceQueue[i]:play()
   end
   self._sequenceAutoStartQueue = {}
+end
+
+-- ! Start
+function RoxyScene:start()
+  if self._didStart then return end
+  Log.debug("[RoxyScene:start] Starting Scene: " .. self.name) --#DEBUG
+  self._didStart = true
+
+  self:addHandler()
 end
 
 -- ! Update
@@ -195,18 +207,19 @@ end
 -- ! Exit
 function RoxyScene:exit()
   if self._didExit then return end
+  Log.debug("[RoxyScene:exit] Exiting Scene: " .. self.name) --#DEBUG
   self._didExit = true
 
-  Log.debug("[RoxyScene:exit] Exiting Scene: " .. self.name) --#DEBUG
+  pauseHandler()
 end
 
 -- ! Cleanup
 function RoxyScene:cleanup()
   if self._didCleanup then return end
+  Log.debug("[RoxyScene:cleanup] Cleaning Up Scene: " .. self.name) --#DEBUG
   self._didCleanup = true
 
-  Log.debug("[RoxyScene:cleanup] Cleaning Up Scene: " .. self.name) --#DEBUG
-
+  resumeHandler(true)
   removeHandler(self)
 
   self:removeAllSprites()

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -355,7 +355,7 @@ end
 
 -- ! Spawn Tilemap
 function RoxyScene:spawnTilemap(path, tilemapOpts)
-  return RoxyTilemap(path, tilemapOpts, self)
+  return RoxyOrthoTilemap(path, tilemapOpts, self)
 end
 
 --------------------------------------------------------------------------------

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -1,0 +1,264 @@
+-- core/tilemaps/RoxyIsoTilemap.lua
+
+local pd        <const> = playdate
+local Graphics  <const> = pd.graphics
+
+local r       <const> = roxy
+local Camera  <const> = r.Camera
+
+local floor <const> = math.floor
+local min   <const> = math.min
+local ceil  <const> = math.ceil
+local max   <const> = math.max
+local round <const> = r.Math.round
+
+local tableInsert <const> = table.insert
+local tableSort   <const> = table.sort
+
+local getCameraPosition <const> = Camera.getPosition
+
+local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
+local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Isometric Draw Offset
+-- Per-tile draw offsets so diamonds align with Tiled
+local function _isoDrawOffsets(tileWidth, tileHeight, img)
+  -- Tiled’s isometric origin expects images taller than the logical tile.
+  -- Offset X by half the extra width; offset Y by the full extra height.
+  local imgWidth, imgHeight = img:getSize()
+  local offsetX = (tileWidth  - imgWidth)  * 0.5
+  local offsetY = (tileHeight - imgHeight)
+  return offsetX, offsetY
+end
+
+--------------------------------------------------------------------------------
+-- ! Class Definition
+--------------------------------------------------------------------------------
+
+class("RoxyIsoTilemap").extends(RoxyTilemap)
+
+function RoxyIsoTilemap:init(jsonPath, opts, scene)
+  opts = opts or {}
+  -- Disable sprite wrapping to avoid orthographic renderer.
+  opts.wrapInSprites = false
+  RoxyIsoTilemap.super.init(self, jsonPath, opts, scene)
+
+  -- Fix world height for staggered‑Y: rows advance by half tile height.
+  if self.mapOrientation == "staggered" and self.staggerAxis == "y" then
+    local halfHeight = (self.mapTileHeight or 0) * 0.5
+    -- Total height = first row’s full height + (rows-1) * halfHeight --> halfHeight * (rows + 1)
+    self.worldHeight = halfHeight * (self.mapHeight + 1)
+    -- Width is usually fine as columns * tileWidth; keep as-is unless you need the extra half tile on the right.
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Projection Methods
+--------------------------------------------------------------------------------
+
+-- Isometric projection uses half tile width/height for diamond mapping.
+--     screenX = originX + (worldX - worldY) * (tileWidth  * 0.5)
+--     screenY = originY + (worldX + worldY) * (tileHeight * 0.5)
+--     Then apply camera/parallax and round.
+
+-- ! World to Screen
+function RoxyIsoTilemap:worldToScreen(worldX, worldY, layer)
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local halfWidth = tileWidth * 0.5
+  local halfHeight = tileHeight * 0.5
+
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local cameraX, cameraY = getCameraPosition()
+
+  -- Staggered-Y support
+  if self.mapOrientation == "staggered" and self.staggerAxis == "y" then
+    -- Parity: odd rows shift, based on 0-based worldY.
+    local isOddRow = (worldY % 2) == 1
+    local applyShift = (self.staggerIndex == "odd"  and isOddRow) or (self.staggerIndex == "even" and not isOddRow)
+    local shiftX = applyShift and halfWidth or 0
+  
+    local screenX = originX + worldX * tileWidth + shiftX
+    local screenY = originY + worldY * halfHeight
+    return round(screenX - cameraX * parallaxX), round(screenY - cameraY * parallaxY)
+  end
+
+  -- Default diamond (classic isometric)
+  local isoX = originX + (worldX - worldY) * halfWidth
+  local isoY = originY + (worldX + worldY) * halfHeight
+  return round(isoX - cameraX * parallaxX), round(isoY - cameraY * parallaxY)
+end
+
+-- ! Screen to World
+-- Inverse of the above:
+--   dx = (screenX + cameraX*px - originX)
+--   dy = (screenY + cameraY*py - originY)
+--   worldX = (dx/halfWidth + dy/halfHeight) * 0.5
+--   worldY = (dy/halfHeight - dx/halfWidth) * 0.5
+function RoxyIsoTilemap:screenToWorld(screenX, screenY, layer)
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local halfWidth = tileWidth * 0.5
+  local halfHeight = tileHeight * 0.5
+
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local cameraX, cameraY = getCameraPosition()
+
+  local dx = (screenX + cameraX * parallaxX) - originX
+  local dy = (screenY + cameraY * parallaxY) - originY
+
+  -- Staggered-Y inverse mapping
+  if self.mapOrientation == "staggered" and self.staggerAxis == "y" then
+    local worldY = dy / halfHeight
+    local row = math.floor(worldY + 1e-6)
+    local isOddRow  = (row % 2) == 1
+    local applyShift = (self.staggerIndex == "odd"  and isOddRow) or (self.staggerIndex == "even" and not isOddRow)
+    local shiftX = applyShift and halfWidth or 0
+  
+    local worldX = (dx - shiftX) / tileWidth
+    return worldX, worldY
+  end
+
+  -- Default diamond (classic isometric inverse)
+  local worldX = (dx / halfWidth + dy / halfHeight) * 0.5
+  local worldY = (dy / halfHeight - dx / halfWidth) * 0.5
+  return worldX, worldY
+end
+
+--------------------------------------------------------------------------------
+-- Public API Preserved From Original Class
+--------------------------------------------------------------------------------
+
+-- ! Set Tile At
+-- Sets the tile at the given tile coordinates (x, y) on the specified layer.
+-- Note: Coordinates are in tile units, not pixels.
+function RoxyIsoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
+  local layer = self.layers[name]
+  if not layer then return end
+
+  layer.tilemap:setTileAtPosition(x, y, tileIndex)
+
+  -- Invalidate just the changed tile’s diamond bounds
+  if updateSprite and layer.imageTable then
+    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
+    -- Draw positions assume top-left of the tile image at screenX/screenY
+    Graphics.sprite.addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Drawing
+--------------------------------------------------------------------------------
+
+-- ! Draw
+-- Draw a single tile layer (isometric, direct draw)
+function RoxyIsoTilemap:draw(name)
+  local layer = self.layers and self.layers[name]
+  if not layer or not layer.tilemap or layer.visible == false then return end
+  local imageTable = layer.imageTable
+  if not imageTable then return end
+
+  local tilemap = layer.tilemap
+  local mapWidthTiles, mapHeightTiles = tilemap:getSize()
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+
+  -- Basic camera-space culling (coarse). We skip tiles unlikely to be visible.
+  -- Convert screen rect corners back to approximate world tile coords, clamp, and draw.
+  local leftWorld,  topWorld  = self:screenToWorld(0, 0, layer)
+  local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+
+  -- Expand a bit to avoid edge gaps from rounding
+  local minWorldX = floor(min(leftWorld, rightWorld)) - 2
+  local maxWorldX = ceil (max(leftWorld, rightWorld)) + 2
+  local minWorldY = floor(min(topWorld, bottomWorld)) - 2
+  local maxWorldY = ceil (max(topWorld, bottomWorld)) + 2
+
+  -- Clamp to map bounds (tile coordinates are 1..width/height in tilemap API)
+  local minX = max(1, minWorldX + 1)
+  local maxX = min(mapWidthTiles, maxWorldX + 1)
+  local minY = max(1, minWorldY + 1)
+  local maxY = min(mapHeightTiles, maxWorldY + 1)
+
+  for tileY = minY, maxY do
+    for tileX = minX, maxX do
+      local idx = tilemap:getTileAtPosition(tileX, tileY)
+      if idx and idx ~= 0 then
+        local screenX, screenY = self:worldToScreen(tileX - 1, tileY - 1, layer)
+
+        -- Tight screen cull for the tile’s image rect
+        if not (screenX > DISPLAY_WIDTH or screenY > DISPLAY_HEIGHT or screenX + tileWidth < 0 or screenY + tileHeight < 0) then
+          local img = imageTable:getImage(idx)
+          if img then
+            local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+            img:draw(screenX + offsetX, screenY + offsetY)
+          end
+        end
+      end
+    end
+  end
+end
+
+-- ! Draw Visible
+-- Draw all visible tile layers by z-index
+function RoxyIsoTilemap:drawVisible()
+  if not self.layers then return end
+
+  -- Collect visible layers
+  local list = {}
+  for _, layer in pairs(self.layers) do
+    if layer.tilemap and layer.visible ~= false then
+      tableInsert(list, layer)
+    end
+  end
+
+  -- Sort by zIndex to match sprite render order
+  tableSort(list, function(a, b)
+    return (a.zIndex or 0) < (b.zIndex or 0)
+  end)
+
+  -- Draw in order
+  for i = 1, #list do
+    local layer = list[i]
+    local imageTable = layer.imageTable
+    if imageTable then
+      local tilemap = layer.tilemap
+      local mapWidthTiles, mapHeightTiles = tilemap:getSize()
+      local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  
+      -- Coarse camera culling once per layer.
+      local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
+      local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+  
+      local minWorldX = floor(min(leftWorld, rightWorld)) - 2
+      local maxWorldX = ceil(max(leftWorld, rightWorld)) + 2
+      local minWorldY = floor(min(topWorld, bottomWorld)) - 2
+      local maxWorldY = ceil(max(topWorld, bottomWorld)) + 2
+  
+      local minX = max(1, minWorldX + 1)
+      local maxX = min(mapWidthTiles,  maxWorldX + 1)
+      local minY = max(1, minWorldY + 1)
+      local maxY = min(mapHeightTiles, maxWorldY + 1)
+  
+      for tileY = minY, maxY do
+        for tileX = minX, maxX do
+          local idx = tilemap:getTileAtPosition(tileX, tileY)
+          if idx and idx ~= 0 then
+            local screenX, screenY = self:worldToScreen(tileX - 1, tileY - 1, layer)
+            if not (screenX > DISPLAY_WIDTH or screenY > DISPLAY_HEIGHT or screenX + tileWidth < 0 or screenY + tileHeight < 0) then
+              local img = imageTable:getImage(idx)
+              if img then
+                local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+                img:draw(screenX + offsetX, screenY + offsetY)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -30,7 +30,7 @@ local function _isoDrawOffsets(tileWidth, tileHeight, img)
   -- Tiled’s isometric origin expects images taller than the logical tile.
   -- Offset X by half the extra width; offset Y by the full extra height.
   local imgWidth, imgHeight = img:getSize()
-  local offsetX = (tileWidth  - imgWidth)  * 0.5
+  local offsetX = (tileWidth - imgWidth) * 0.5
   local offsetY = (tileHeight - imgHeight)
   return offsetX, offsetY
 end
@@ -43,16 +43,24 @@ class("RoxyIsoTilemap").extends(RoxyTilemap)
 
 function RoxyIsoTilemap:init(jsonPath, opts, scene)
   opts = opts or {}
-  -- Disable sprite wrapping to avoid orthographic renderer.
+  
+  -- Disable sprite wrapping to avoid orthographic renderer
   opts.wrapInSprites = false
   RoxyIsoTilemap.super.init(self, jsonPath, opts, scene)
 
-  -- Fix world height for staggered‑Y: rows advance by half tile height.
+  -- World height for staggered‑Y: rows advance by half tile height
   if self.mapOrientation == "staggered" and self.staggerAxis == "y" then
     local halfHeight = (self.mapTileHeight or 0) * 0.5
-    -- Total height = first row’s full height + (rows-1) * halfHeight --> halfHeight * (rows + 1)
-    self.worldHeight = halfHeight * (self.mapHeight + 1)
-    -- Width is usually fine as columns * tileWidth; keep as-is unless you need the extra half tile on the right.
+    self.worldHeight = halfHeight * (self.mapHeight + 1) -- First row full + (rows-1) half steps
+
+    -- World width when the last row is shifted to the right
+    local halfWidth = (self.mapTileWidth or 0) * 0.5
+    local lastRowIsShifted =
+      (self.staggerIndex == "odd"  and (self.mapHeight % 2 == 1)) or -- H odd --> last row is odd --> shifted
+      (self.staggerIndex == "even" and (self.mapHeight % 2 == 0)) -- H even --> last row is even --> shifted
+    if lastRowIsShifted then
+      self.worldWidth += halfWidth -- Add the extra overhang on the right edge
+    end
   end
 end
 

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -7,6 +7,8 @@ local Sprite    <const> = Graphics.sprite
 local r       <const> = roxy
 local Camera  <const> = r.Camera
 
+local min   <const> = math.min
+local max   <const> = math.max
 local round <const> = r.Math.round
 
 local tableInsert <const> = table.insert
@@ -26,19 +28,25 @@ local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 -- Compute draw parameters for orthographic projection.
 -- Returns: screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled
 local function _computeDrawParams(layer)
-  -- (Moved from the old base helper; logic unchanged except local names.)
   local cameraX, cameraY = getCameraPosition()
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local originX, originY = layer.originX or 0, layer.originY or 0
   local mapPixelWidth, mapPixelHeight = layer.mapPixelWidth or 0, layer.mapPixelHeight or 0
 
+  -- Respect parallax origin
+  local parallaxOriginX = layer.parallaxoriginx or 0
+  local parallaxOriginY = layer.parallaxoriginy or 0
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
   local screenX, screenY
   if layer.anchor == "topLeft" then
-    screenX = round(originX - cameraX * parallaxX)
-    screenY = round(originY - cameraY * parallaxY)
+    -- Include pivot adjust so sprites vs direct draw match.
+    screenX = round(originX + pivotAdjustX - cameraX * parallaxX)
+    screenY = round(originY + pivotAdjustY - cameraY * parallaxY)
   else
-    screenX = round(originX - (mapPixelWidth  * 0.5) - cameraX * parallaxX)
-    screenY = round(originY - (mapPixelHeight * 0.5) - cameraY * parallaxY)
+    screenX = round(originX - (mapPixelWidth  * 0.5) + pivotAdjustX - cameraX * parallaxX)
+    screenY = round(originY - (mapPixelHeight * 0.5) + pivotAdjustY - cameraY * parallaxY)
   end
 
   local sourceX, sourceY = 0, 0
@@ -47,10 +55,10 @@ local function _computeDrawParams(layer)
   if screenX < 0 then sourceX = -screenX end
   if screenY < 0 then sourceY = -screenY end
 
-  local maxW = DISPLAY_WIDTH - math.max(0, screenX)
-  local maxH = DISPLAY_HEIGHT - math.max(0, screenY)
-  sourceWidth  = math.min(sourceWidth - sourceX, math.max(0, maxW))
-  sourceHeight = math.min(sourceHeight - sourceY, math.max(0, maxH))
+  local maxW = DISPLAY_WIDTH - max(0, screenX)
+  local maxH = DISPLAY_HEIGHT - max(0, screenY)
+  sourceWidth  = min(sourceWidth - sourceX, max(0, maxW))
+  sourceHeight = min(sourceHeight - sourceY, max(0, maxH))
 
   if sourceWidth <= 0 or sourceHeight <= 0 then
     return screenX, screenY, nil, true
@@ -60,10 +68,15 @@ local function _computeDrawParams(layer)
 end
 
 --------------------------------------------------------------------------------
--- ! Class Definition
+-- ! Class Definition and Initialization
 --------------------------------------------------------------------------------
 
 class("RoxyOrthoTilemap").extends(RoxyTilemap)
+
+function RoxyOrthoTilemap:init(jsonPath, opts, scene)
+  RoxyOrthoTilemap.super.init(self, jsonPath, opts, scene)
+  self._projection = "orthogonal"
+end
 
 --------------------------------------------------------------------------------
 -- Projection methods
@@ -76,9 +89,18 @@ function RoxyOrthoTilemap:worldToScreen(worldX, worldY, layer)
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
+  -- Parallax-origin pivot to match sprite behavior (like other tilemap classes)
+  local parallaxOriginX = layer.parallaxoriginx or 0
+  local parallaxOriginY = layer.parallaxoriginy or 0
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
   local orthoX = originX + worldX * tileWidth
   local orthoY = originY + worldY * tileHeight
-  return round(orthoX - cameraX * parallaxX), round(orthoY - cameraY * parallaxY)
+
+  -- Include pivotAdjust* before subtracting camera (consistent with other classes)
+  return round(orthoX + pivotAdjustX - cameraX * parallaxX),
+         round(orthoY + pivotAdjustY - cameraY * parallaxY)
 end
 
 -- ! Screen to World (orthogonal)
@@ -88,8 +110,18 @@ function RoxyOrthoTilemap:screenToWorld(screenX, screenY, layer)
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  local worldX = ((screenX + cameraX * parallaxX) - originX) / tileWidth
-  local worldY = ((screenY + cameraY * parallaxY) - originY) / tileHeight
+  -- Parallax-origin pivot to match sprite behavior
+  local parallaxOriginX = layer.parallaxoriginx or 0
+  local parallaxOriginY = layer.parallaxoriginy or 0
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
+  -- Undo camera and pivot before converting to world
+  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
+  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+
+  local worldX = dx / tileWidth
+  local worldY = dy / tileHeight
   return worldX, worldY
 end
 
@@ -101,16 +133,23 @@ end
 -- Sets the tile at the given tile coordinates (x, y) on the specified layer.
 -- Note: Coordinates are in tile units, not pixels.
 function RoxyOrthoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
-  local layer = self.layers[name]
+  local layer = self.layers and self.layers[name]
   if not layer then return end
 
   layer.tilemap:setTileAtPosition(x, y, tileIndex)
 
-  if updateSprite and layer.sprite then
+  if updateSprite then
     local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-    -- Top-left of tile in pixels
+    -- Use consistent world-to-screen conversion
     local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
-    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+
+    -- Support both sprite-based and direct drawing approaches
+    if layer.sprite then
+      addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+    else
+      -- For direct drawing, mark the area as needing refresh
+      addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+    end
   end
 end
 
@@ -167,4 +206,66 @@ function RoxyOrthoTilemap:drawVisible()
       end
     end
   end
+end
+
+-- ! Draw Layer Region (for consistency with other tilemap classes)
+function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+  local layer = self.layers and self.layers[layerName]
+  if not layer or not layer.tilemap or layer.visible == false then return end
+
+  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+
+  -- Clamp bounds
+  minTileX = max(1, minTileX)
+  maxTileX = min(mapWidthTiles, maxTileX)
+  minTileY = max(1, minTileY)
+  maxTileY = min(mapHeightTiles, maxTileY)
+
+  if minTileX > maxTileX or minTileY > maxTileY then return end
+
+  -- Calculate screen rectangle for the tile region
+  local topLeftX, topLeftY = self:worldToScreen(minTileX - 1, minTileY - 1, layer)
+  local regionWidth = (maxTileX - minTileX + 1) * tileWidth
+  local regionHeight = (maxTileY - minTileY + 1) * tileHeight
+
+  -- Convert to source rectangle (pixels within the tilemap image)
+  local sourceX = (minTileX - 1) * tileWidth
+  local sourceY = (minTileY - 1) * tileHeight
+
+  -- Clamp to screen bounds
+  local screenX, screenY = max(0, topLeftX), max(0, topLeftY)
+  local sourceOffsetX = screenX - topLeftX
+  local sourceOffsetY = screenY - topLeftY
+
+  local visibleWidth = min(regionWidth - sourceOffsetX, DISPLAY_WIDTH - screenX)
+  local visibleHeight = min(regionHeight - sourceOffsetY, DISPLAY_HEIGHT - screenY)
+
+  if visibleWidth > 0 and visibleHeight > 0 then
+    layer.tilemap:drawIgnoringOffset(
+      screenX, screenY,
+      sourceX + sourceOffsetX, sourceY + sourceOffsetY,
+      visibleWidth, visibleHeight
+    )
+  end
+end
+
+-- ! Draw with Region-Based Culling (optional alternative to current draw method)
+function RoxyOrthoTilemap:drawWithTileCulling(name)
+  local layer = self.layers and self.layers[name]
+  if not layer or not layer.tilemap or layer.visible == false then return end
+
+  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+
+  -- Calculate visible tile bounds
+  local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
+  local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+
+  local minTileX = max(1, math.floor(topLeftX) + 1)
+  local maxTileX = min(mapWidthTiles, math.ceil(bottomRightX) + 1)
+  local minTileY = max(1, math.floor(topLeftY) + 1)
+  local maxTileY = min(mapHeightTiles, math.ceil(bottomRightY) + 1)
+
+  self:drawLayerRegion(name, minTileX, maxTileX, minTileY, maxTileY)
 end

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -1,0 +1,170 @@
+-- core/tilemaps/RoxyOrthoTilemap.lua
+
+local pd        <const> = playdate
+local Graphics  <const> = pd.graphics
+local Sprite    <const> = Graphics.sprite
+
+local r       <const> = roxy
+local Camera  <const> = r.Camera
+
+local round <const> = r.Math.round
+
+local tableInsert <const> = table.insert
+local tableSort   <const> = table.sort
+
+local getCameraPosition <const> = Camera.getPosition
+local addDirtyRect      <const> = Sprite.addDirtyRect
+
+local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
+local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Compute Draw Parameters
+-- Compute draw parameters for orthographic projection.
+-- Returns: screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled
+local function _computeDrawParams(layer)
+  -- (Moved from the old base helper; logic unchanged except local names.)
+  local cameraX, cameraY = getCameraPosition()
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  local mapPixelWidth, mapPixelHeight = layer.mapPixelWidth or 0, layer.mapPixelHeight or 0
+
+  local screenX, screenY
+  if layer.anchor == "topLeft" then
+    screenX = round(originX - cameraX * parallaxX)
+    screenY = round(originY - cameraY * parallaxY)
+  else
+    screenX = round(originX - (mapPixelWidth  * 0.5) - cameraX * parallaxX)
+    screenY = round(originY - (mapPixelHeight * 0.5) - cameraY * parallaxY)
+  end
+
+  local sourceX, sourceY = 0, 0
+  local sourceWidth, sourceHeight = mapPixelWidth, mapPixelHeight
+
+  if screenX < 0 then sourceX = -screenX end
+  if screenY < 0 then sourceY = -screenY end
+
+  local maxW = DISPLAY_WIDTH - math.max(0, screenX)
+  local maxH = DISPLAY_HEIGHT - math.max(0, screenY)
+  sourceWidth  = math.min(sourceWidth - sourceX, math.max(0, maxW))
+  sourceHeight = math.min(sourceHeight - sourceY, math.max(0, maxH))
+
+  if sourceWidth <= 0 or sourceHeight <= 0 then
+    return screenX, screenY, nil, true
+  end
+
+  return screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, false
+end
+
+--------------------------------------------------------------------------------
+-- ! Class Definition
+--------------------------------------------------------------------------------
+
+class("RoxyOrthoTilemap").extends(RoxyTilemap)
+
+--------------------------------------------------------------------------------
+-- Projection methods
+--------------------------------------------------------------------------------
+
+-- ! World to Screen (orthogonal)
+function RoxyOrthoTilemap:worldToScreen(worldX, worldY, layer)
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local cameraX, cameraY = getCameraPosition()
+
+  local orthoX = originX + worldX * tileWidth
+  local orthoY = originY + worldY * tileHeight
+  return round(orthoX - cameraX * parallaxX), round(orthoY - cameraY * parallaxY)
+end
+
+-- ! Screen to World (orthogonal)
+function RoxyOrthoTilemap:screenToWorld(screenX, screenY, layer)
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local cameraX, cameraY = getCameraPosition()
+
+  local worldX = ((screenX + cameraX * parallaxX) - originX) / tileWidth
+  local worldY = ((screenY + cameraY * parallaxY) - originY) / tileHeight
+  return worldX, worldY
+end
+
+--------------------------------------------------------------------------------
+-- Public API preserved from original class
+--------------------------------------------------------------------------------
+
+-- ! Set Tile At
+-- Sets the tile at the given tile coordinates (x, y) on the specified layer.
+-- Note: Coordinates are in tile units, not pixels.
+function RoxyOrthoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
+  local layer = self.layers[name]
+  if not layer then return end
+
+  layer.tilemap:setTileAtPosition(x, y, tileIndex)
+
+  if updateSprite and layer.sprite then
+    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+    -- Top-left of tile in pixels
+    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
+    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Drawing
+--------------------------------------------------------------------------------
+
+-- ! Draw
+-- Draw a single tile layer directly (no sprite required)
+function RoxyOrthoTilemap:draw(name)
+  local layer = self.layers and self.layers[name]
+  if not layer or not layer.tilemap or layer.visible == false then return end
+
+  local screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled = _computeDrawParams(layer)
+  if culled then return end
+
+  -- Use drawIgnoringOffset because we already applied camera/offset logic
+  local drawIgnoring = layer.tilemap.drawIgnoringOffset
+  if sourceX then
+    drawIgnoring(layer.tilemap, screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight)
+  else
+    drawIgnoring(layer.tilemap, screenX, screenY)
+  end
+end
+
+-- ! Draw Visible
+-- Draw all visible tile layers by zIndex (ascending)
+function RoxyOrthoTilemap:drawVisible()
+  if not self.layers then return end
+
+  -- Collect visible layers
+  local list = {}
+  for name, layer in pairs(self.layers) do
+    if layer.tilemap and layer.visible ~= false then
+      tableInsert(list, layer)
+    end
+  end
+
+  -- Sort by zIndex to match sprite render order
+  tableSort(list, function(a, b)
+    return (a.zIndex or 0) < (b.zIndex or 0)
+  end)
+
+  -- Draw in order
+  for i = 1, #list do
+    local layer = list[i]
+    local screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled = _computeDrawParams(layer)
+    if not culled then
+      local drawIgnoring = layer.tilemap.drawIgnoringOffset
+      if sourceX then
+        drawIgnoring(layer.tilemap, screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight)
+      else
+        drawIgnoring(layer.tilemap, screenX, screenY)
+      end
+    end
+  end
+end

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -1,5 +1,7 @@
--- core/tilemaps/RoxyIsoTilemap.lua
--- Classic diamond isometric tilemaps for Roxy (no stagger logic).
+-- core/tilemaps/RoxyStagTilemap.lua
+-- Staggered-Y isometric tilemaps that match Tiled:
+-- Only rows whose parity matches Tiled's staggerindex are shifted.
+-- Direction is configurable via self.staggerDirection = "left" | "right" (default "right").
 
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
@@ -32,8 +34,30 @@ local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 -- Helpers
 --------------------------------------------------------------------------------
 
+-- ! Row Shift X for Row 0
+-- Return the horizontal row shift (in pixels) for a given 0-based row index.
+-- Matches Tiled: shift ONLY rows whose parity equals self.staggerIndex.
+local function _rowShiftX_for_row0(self, row0, halfWidth)
+  if self.staggerAxis ~= "y" then return 0 end
+
+  local rowIsOdd = (row0 % 2) == 1
+  local shouldShift
+  if self.staggerIndex == "odd" then
+    shouldShift = rowIsOdd
+  elseif self.staggerIndex == "even" then
+    shouldShift = not rowIsOdd
+  else
+    shouldShift = false
+  end
+  if not shouldShift then return 0 end
+
+  local direction = self.staggerDirection or "right"
+  return (direction == "right") and (halfWidth) or (-halfWidth)
+end
+
+-- ! Get Max Image Height
 -- Helper to compute and cache max image height for the layer
-local function _getMaxImgH(layer)
+local function _getMaxImgHeight(layer)
   if layer._maxImgH then return layer._maxImgH end
   local imagetable = layer.imageTable
   local imagetableLength = imagetable and imagetable:getLength() or 0
@@ -55,26 +79,33 @@ end
 -- ! Class Definition and Initialize
 --------------------------------------------------------------------------------
 
-class("RoxyIsoTilemap").extends(RoxyTilemap)
+class("RoxyStagTilemap").extends(RoxyTilemap)
 
-function RoxyIsoTilemap:init(jsonPath, opts, scene)
+function RoxyStagTilemap:init(jsonPath, opts, scene)
   opts = opts or {}
   opts.wrapInSprites = false
   opts.anchor = "topLeft"
-  RoxyIsoTilemap.super.init(self, jsonPath, opts, scene)
+  RoxyStagTilemap.super.init(self, jsonPath, opts, scene)
 
-  -- Mark the projection for clarity/debugging
-  self._projection = "iso"
+  self._projection = "staggered-y"
+
+  -- Tiled fields read in base class:
+  --   self.staggerAxis  -> expected "y"
+  --   self.staggerIndex -> "odd" | "even"
+  -- Direction knob: which way the shifted rows move horizontally in pixels
+  self.staggerDirection = self.staggerDirection or "right" -- "left" | "right"
 end
 
 --------------------------------------------------------------------------------
--- Projection (classic diamond isometric)
--- screenX = originX + (worldX - worldY) * (tileWidth  * 0.5)
--- screenY = originY + (worldX + worldY) * (tileHeight * 0.5)
+-- Projection (Staggered-Y)
+-- Row spacing = halfHeight; Column step = tileWidth.
+-- Shift rule (Tiled):
+--   If row parity matches staggerIndex -> shift by ±halfWidth (dir knob)
+--   Otherwise -> no shift
 --------------------------------------------------------------------------------
 
 -- ! World to Screen
-function RoxyIsoTilemap:worldToScreen(worldX, worldY, layer)
+function RoxyStagTilemap:worldToScreen(worldX, worldY, layer)
   local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
   local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
 
@@ -82,22 +113,25 @@ function RoxyIsoTilemap:worldToScreen(worldX, worldY, layer)
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot so direct math matches sprite path
+  local row0 = floor(worldY + 1e-6)
+  local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
+
+  -- Parallax-origin pivot to mirror sprite behavior
   local parallaxOriginX = layer.parallaxoriginx or 0
   local parallaxOriginY = layer.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-  local isoX = originX + (worldX - worldY) * halfWidth
-  local isoY = originY + (worldX + worldY) * halfHeight
+  local screenX = originX + worldX * tileWidth + shiftX
+  local screenY = originY + worldY * halfHeight
 
-  -- Include pivotAdjust* before subtracting camera
-  return round(isoX + pivotAdjustX - cameraX * parallaxX),
-         round(isoY + pivotAdjustY - cameraY * parallaxY)
+  -- Apply pivotAdjust* before subtracting camera
+  return round(screenX + pivotAdjustX - cameraX * parallaxX),
+         round(screenY + pivotAdjustY - cameraY * parallaxY)
 end
 
 -- ! Screen to World
-function RoxyIsoTilemap:screenToWorld(screenX, screenY, layer)
+function RoxyStagTilemap:screenToWorld(screenX, screenY, layer)
   local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
   local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
 
@@ -105,7 +139,7 @@ function RoxyIsoTilemap:screenToWorld(screenX, screenY, layer)
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot so direct math matches sprite path
+  -- Parallax-origin pivot to mirror sprite behavior
   local parallaxOriginX = layer.parallaxoriginx or 0
   local parallaxOriginY = layer.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
@@ -115,8 +149,11 @@ function RoxyIsoTilemap:screenToWorld(screenX, screenY, layer)
   local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
   local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldX = (dx / halfWidth + dy / halfHeight) * 0.5
-  local worldY = (dy / halfHeight - dx / halfWidth) * 0.5
+  local worldY = dy / halfHeight
+  local row0 = floor(worldY + 1e-6)
+  local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
+
+  local worldX = (dx - shiftX) / tileWidth
   return worldX, worldY
 end
 
@@ -125,7 +162,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Set Tile At
-function RoxyIsoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
+function RoxyStagTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
   local layer = self.layers and self.layers[name]
   if not layer then return end
 
@@ -143,44 +180,40 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
--- Draw a single tile layer with conservative vertical culling.
-function RoxyIsoTilemap:draw(name)
+function RoxyStagTilemap:draw(name)
   local layer = self.layers and self.layers[name]
   if not layer or not layer.tilemap or layer.visible == false then return end
 
   local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-
-  -- Get world coordinates of screen corners
-  local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
-  local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
-  local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
-  local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-
-  -- Find the bounds of visible tiles with margin for image height
-  local maxImgH = _getMaxImgH(layer)
+  local tileHeight = layer.tileHeight or 0
   local halfHeight = tileHeight * 0.5
+  
+  -- Get screen corners in world space
+  local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
+  local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+  
+  -- Calculate margin based on tallest image (like RoxyIsoTilemap)
+  local maxImgH = _getMaxImgHeight(layer)
   local overdraw = max(0, maxImgH - tileHeight)
   local margin = ceil(overdraw / max(1, halfHeight)) + 1
-
-  -- Calculate conservative bounds
-  local minWorldX = min(topLeftX, topRightX, bottomLeftX, bottomRightX) - margin
-  local maxWorldX = max(topLeftX, topRightX, bottomLeftX, bottomRightX) + margin
-  local minWorldY = min(topLeftY, topRightY, bottomLeftY, bottomRightY) - margin
-  local maxWorldY = max(topLeftY, topRightY, bottomLeftY, bottomRightY) + margin
-
+  
+  -- Calculate bounds with proper margin
+  local minWorldX = min(leftWorld, rightWorld) - margin
+  local maxWorldX = max(leftWorld, rightWorld) + margin
+  local minWorldY = min(topWorld, bottomWorld) - margin
+  local maxWorldY = max(topWorld, bottomWorld) + margin
+  
   -- Convert to tile coordinates (1-based)
   local minTileX = max(1, floor(minWorldX) + 1)
   local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
   local minTileY = max(1, floor(minWorldY) + 1)
   local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
 
-  self:drawLayerRegion(name, minTileX, maxTileX, minTileY, maxTileY)
+  self:drawLayerRows(name, minTileY, maxTileY, minTileX, maxTileX)
 end
 
 -- ! Draw Visible
--- Draw all visible tile layers sorted by z-index.
-function RoxyIsoTilemap:drawVisible()
+function RoxyStagTilemap:drawVisible()
   if not self.layers then return end
 
   local list = {}
@@ -194,38 +227,36 @@ function RoxyIsoTilemap:drawVisible()
   for i = 1, #list do
     local layer = list[i]
     local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-
-    -- Get world coordinates of screen corners
-    local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
-    local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
-    local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
-    local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-
-    -- Find the bounds of visible tiles with margin for image height
-    local maxImgH = _getMaxImgH(layer)
+    local tileHeight = layer.tileHeight or 0
     local halfHeight = tileHeight * 0.5
+    
+    -- Get screen corners in world space
+    local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
+    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+    
+    -- Calculate margin based on tallest image
+    local maxImgH = _getMaxImgHeight(layer)
     local overdraw = max(0, maxImgH - tileHeight)
     local margin = ceil(overdraw / max(1, halfHeight)) + 1
-
-    -- Calculate conservative bounds
-    local minWorldX = min(topLeftX, topRightX, bottomLeftX, bottomRightX) - margin
-    local maxWorldX = max(topLeftX, topRightX, bottomLeftX, bottomRightX) + margin
-    local minWorldY = min(topLeftY, topRightY, bottomLeftY, bottomRightY) - margin
-    local maxWorldY = max(topLeftY, topRightY, bottomLeftY, bottomRightY) + margin
-
+    
+    -- Calculate bounds with proper margin
+    local minWorldX = min(leftWorld, rightWorld) - margin
+    local maxWorldX = max(leftWorld, rightWorld) + margin
+    local minWorldY = min(topWorld, bottomWorld) - margin
+    local maxWorldY = max(topWorld, bottomWorld) + margin
+    
     -- Convert to tile coordinates (1-based)
     local minTileX = max(1, floor(minWorldX) + 1)
     local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
     local minTileY = max(1, floor(minWorldY) + 1)
     local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
 
-    self:drawLayerRegion(layer.name, minTileX, maxTileX, minTileY, maxTileY)
+    self:drawLayerRows(layer.name, minTileY, maxTileY, minTileX, maxTileX)
   end
 end
 
--- ! Draw Layer Region
-function RoxyIsoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+-- ! Draw Layer Rows
+function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minCol, maxCol)
   local restoreX, restoreY = _beginManualDraw()
 
   local layer = self.layers and self.layers[layerName]
@@ -245,88 +276,88 @@ function RoxyIsoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY,
   local mapWidthTiles, mapHeightTiles = tilemap:getSize()
   local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
 
-  -- Clamp bounds
-  minTileX = max(1, minTileX)
-  maxTileX = min(mapWidthTiles, maxTileX)
-  minTileY = max(1, minTileY)
-  maxTileY = min(mapHeightTiles, maxTileY)
+  local rowStart = max(1, minRow or 1)
+  local rowEnd   = min(mapHeightTiles, maxRow or mapHeightTiles)
+  if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
 
-  if minTileX > maxTileX or minTileY > maxTileY then
-    _endManualDraw(restoreX, restoreY); return
+  -- Use passed column bounds if provided, otherwise calculate them
+  local minX, maxX
+  if minCol and maxCol then
+    minX = max(1, minCol)
+    maxX = min(mapWidthTiles, maxCol)
+  else
+    -- Fallback to old calculation for backwards compatibility
+    local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
+    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+    local minWorldX = floor(min(leftWorld, rightWorld)) - 2
+    local maxWorldX = ceil (max(leftWorld, rightWorld)) + 2
+    minX = max(1, minWorldX + 1)
+    maxX = min(mapWidthTiles, maxWorldX + 1)
   end
+
+  if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
   local tiles, widthFromTileMap = tilemap:getTiles()
   local stride = widthFromTileMap or mapWidthTiles
 
-  -- Camera and parallax calculations
+  -- Use the same pivot adjust as worldToScreen/sprite path (like RoxyIsoTilemap)
   local originX, originY = layer.originX or 0, layer.originY or 0
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local parallaxOriginX = layer.parallaxoriginx or 0
   local parallaxOriginY = layer.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
-
+  
   local cameraX, cameraY = getCameraPosition()
   local halfHeight, halfWidth = tileHeight * 0.5, tileWidth * 0.5
 
-  -- Draw tiles in the specified region
-  for tileY = minTileY, maxTileY do
-    for tileX = minTileX, maxTileX do
-      local i = (tileY - 1) * stride + tileX
-      local idx = tiles and tiles[i] or 0
+  for tileY = rowStart, rowEnd do
+    local row0 = tileY - 1
+    local rowShiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
+    -- Apply pivot adjustments consistently
+    local baseScreenX = round(originX + rowShiftX + pivotAdjustX - cameraX * parallaxX)
+    local baseScreenY = round(originY + row0 * halfHeight + pivotAdjustY - cameraY * parallaxY)
+
+    local currentX = baseScreenX + (minX - 1) * tileWidth
+    local currentY = baseScreenY
+
+    local i = row0 * stride + minX
+    for tileX = minX, maxX do
+      local idx = tiles and tiles[i] or 0
       if idx and idx ~= 0 then
         local img = cache[idx]
         if not img then img = imageTable:getImage(idx); cache[idx] = img end
-
         if img then
-          -- Convert tile coordinates to screen position
-          local worldX, worldY = tileX - 1, tileY - 1
-          local screenX = originX + (worldX - worldY) * halfWidth
-          local screenY = originY + (worldX + worldY) * halfHeight
-
-          local finalScreenX = round(screenX + pivotAdjustX - cameraX * parallaxX)
-          local finalScreenY = round(screenY + pivotAdjustY - cameraY * parallaxY)
-
           local offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-          local drawX, drawY = finalScreenX + offX, finalScreenY + offY
-
-          -- Final screen bounds check (optional optimization)
-          local imgW, imgH = img:getSize()
+          local drawX, drawY = currentX + offX, currentY + offY
+          local imgWidth, imgHeight = img:getSize()
           if not (drawX > DISPLAY_WIDTH or drawY > DISPLAY_HEIGHT or
-                  drawX + imgW < 0 or drawY + imgH < 0) then
+                  drawX + imgWidth < 0 or drawY + imgHeight < 0) then
             img:draw(drawX, drawY)
           end
         end
       end
+
+      currentX = currentX + tileWidth
+      i += 1
     end
   end
 
   _endManualDraw(restoreX, restoreY)
 end
 
--- ! Get Rows From Screen
--- Convert a screen pixel to a 1-based row (tileY).
-function RoxyIsoTilemap:getRowFromScreen(screenX, screenY, layerName)
+-- ! Get Row From Screen
+function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
-    -- Fall back to any layer if needed
-    for _, layer in pairs(self.layers or {}) do
-      if layer.tilemap then
-        targetLayer = layer
-        break
-      end
-    end
+    for _, layer in pairs(self.layers or {}) do if layer.tilemap then targetLayer = layer; break end end
     if not targetLayer then return 1 end
   end
 
   local _, mapHeightTiles = targetLayer.tilemap:getSize()
   local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
   local row = floor(worldY + 1)
-  if row < 1 then
-    row = 1
-  elseif row > mapHeightTiles then
-    row = mapHeightTiles
-  end
+  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
   return row
 end

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -976,6 +976,60 @@ function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesW
 end
 
 --------------------------------------------------------------------------------
+-- Origin helpers
+--------------------------------------------------------------------------------
+
+-- ! Set Layer Origin
+-- Updates the origin for a single layer and keeps any display sprite in sync.
+function RoxyTilemap:setLayerOrigin(name, originX, originY)
+  local layer = self.layers and self.layers[name]
+  if not layer then return false end
+
+  -- Update stored origin used by both sprite and direct draw
+  layer.originX = originX or 0
+  layer.originY = originY or 0
+
+  -- Keep an existing sprite in sync
+  local sprite = layer.sprite
+  if sprite then
+    local parallaxX = layer.parallaxx or 1
+    local parallaxY = layer.parallaxy or 1
+    local pox = layer.parallaxoriginx or 0
+    local poy = layer.parallaxoriginy or 0
+
+    -- If this layer was using a parallax update closure, rebuild it with the new origin.
+    if sprite.update and sprite.setUpdatesEnabled then
+      -- Recreate the cached updater using the shared helper
+      local pivotAdjustX = pox * (1 - parallaxX)
+      local pivotAdjustY = poy * (1 - parallaxY)
+      sprite.update = createParallaxUpdate(
+        layer.originX, layer.originY,
+        pivotAdjustX, pivotAdjustY,
+        parallaxX, parallaxY,
+        round, getCameraPosition
+      )
+      -- Ensure we do not double-apply draw offset
+      sprite:setIgnoresDrawOffset(true)
+      sprite:setUpdatesEnabled(true)
+    else
+      -- No parallax updater; just move the sprite to the new origin
+      sprite:moveTo(layer.originX, layer.originY)
+    end
+  end
+
+  return true
+end
+
+-- ! Set Origin For All Layers
+-- Convenience to apply the same origin to every tile layer.
+function RoxyTilemap:setOriginForAllLayers(originX, originY)
+  if not self.layers then return end
+  for name, _ in pairs(self.layers) do
+    self:setLayerOrigin(name, originX, originY)
+  end
+end
+
+--------------------------------------------------------------------------------
 -- Drawing
 --------------------------------------------------------------------------------
 

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -11,6 +11,8 @@ local Camera  <const> = r.Camera
 
 local min   <const> = math.min
 local max   <const> = math.max
+local floor <const> = math.floor
+local ceil  <const> = math.ceil
 local round <const> = r.Math.round
 
 local createTable <const> = table.create
@@ -211,9 +213,9 @@ local function createDefaultObjectSprite(obj, layerOpts)
     Log.warn("[createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
   end
 
-  -- Create parallax sprite if needed and RoxyParallaxSprite is available
+  -- Create parallax sprite if needed
   local sprite
-  if hasParallax and r.RoxyParallaxSprite then
+  if hasParallax then
     local spriteOpts = {
       view = image,
       worldX = obj.x or 0,
@@ -225,11 +227,8 @@ local function createDefaultObjectSprite(obj, layerOpts)
     }
     sprite = r.RoxyParallaxSprite(spriteOpts)
   else
-    -- Create regular sprite
     sprite = newSprite()
-    if image then
-      sprite:setImage(image)
-    end
+    if image then sprite:setImage(image) end
   end
 
   -- Fallback image creation for regular sprites
@@ -339,11 +338,17 @@ end
 -- Hoist and Cache sprite:update - Move parallax update function outside per-sprite loop
 -- Define the parallax update function once, outside the sprite creation loop
 -- This avoids creating new function instances for each sprite
-local function createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, parallaxX, parallaxY, rnd, camGetter)
+local function createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, rnd, camGetter, anchor, mapPixelWidth, mapPixelHeight)
   return function(self)
     local cameraX, cameraY = camGetter()
+
+    -- Apply parallax origin pivot (consistent with projection classes)
+    local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+    local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
     local screenX = rnd(worldX + pivotAdjustX - cameraX * parallaxX)
     local screenY = rnd(worldY + pivotAdjustY - cameraY * parallaxY)
+
     local currentX, currentY = self:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
       self:moveTo(screenX, screenY)
@@ -352,10 +357,51 @@ local function createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, 
 end
 
 --------------------------------------------------------------------------------
--- ! Class Definition & Init
+-- ! Class Definition
 --------------------------------------------------------------------------------
 
 class("RoxyTilemap").extends(Object)
+
+--------------------------------------------------------------------------------
+-- Isometric helpers (shared by iso/staggered leaves)
+--------------------------------------------------------------------------------
+
+-- ! Isometric Draw Offsets
+-- Per-tile draw offsets so diamonds align with Tiled.
+function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, img)
+  local imgWidth, imgHeight = img:getSize()
+  local offsetX = (tileWidth - imgWidth) * 0.5
+  local offsetY = (tileHeight - imgHeight)
+  return offsetX, offsetY
+end
+
+-- ! Begin Manual Draw
+-- Temporarily zero draw offset when doing manual placement.
+function RoxyTilemap._beginManualDraw()
+  local offsetX, offsetY = playdate.graphics.getDrawOffset()
+  if offsetX ~= 0 or offsetY ~= 0 then playdate.graphics.setDrawOffset(0, 0) end
+  return offsetX, offsetY
+end
+
+-- ! End Manual Draw
+-- Restore draw offset after manual placement.
+function RoxyTilemap._endManualDraw(offsetX, offsetY)
+  if offsetX ~= 0 or offsetY ~= 0 then playdate.graphics.setDrawOffset(offsetX, offsetY) end
+end
+
+-- ! Get Valid Layer
+function RoxyTilemap._getValidLayer(layerName)
+  if not layerName or not self.layers then return nil end
+  local layer = self.layers[layerName]
+  if not layer or not layer.tilemap or layer.visible == false then
+    return nil
+  end
+  return layer
+end
+
+--------------------------------------------------------------------------------
+-- ! Initialize
+--------------------------------------------------------------------------------
 
 --[[
   jsonPath: string - Path to Tiled JSON map
@@ -364,6 +410,8 @@ class("RoxyTilemap").extends(Object)
 ]]
 function RoxyTilemap:init(jsonPath, opts, scene)
   opts = validateOptions(opts)
+
+  self.scene = scene
 
   self._retainedPaths = {}
 
@@ -515,7 +563,9 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         end
         tilemap:setTiles(indices, layer.width)
 
-        local tileWidth, tileHeight = tilemap:getTileSize()
+        -- Use logical map tile size (e.g., 64x32) for iso math/culling
+        -- Actual image size (e.g., 64x64) is handled via per-image offsets
+        local tileWidth, tileHeight = self.mapTileWidth, self.mapTileHeight
 
         -- Precompute map pixel size for direct draw
         local width, height = tilemap:getSize()
@@ -523,6 +573,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         local mapPixelHeight = height * tileHeight
 
         local layerData = {
+          name = layer.name,
           tilemap = tilemap,
           anchor = opts.anchor,
           tileWidth = tileWidth,
@@ -575,11 +626,18 @@ function RoxyTilemap:init(jsonPath, opts, scene)
             sprite:setIgnoresDrawOffset(true)
             sprite:setUpdatesEnabled(true)
 
+            -- Use consistent pivot calculation like projection classes
             local pivotAdjustX = pox * (1 - parallaxX)
             local pivotAdjustY = poy * (1 - parallaxY)
             local worldX, worldY = originX, originY
 
-            sprite.update = createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, parallaxX, parallaxY, rnd, camGetter)
+            sprite.update = createParallaxUpdate(
+              worldX, worldY,
+              parallaxX, parallaxY,
+              pox, poy,
+              rnd, camGetter,
+              opts.anchor, mapPixelWidth, mapPixelHeight
+            )
           else
             sprite:moveTo(originX, originY)
           end
@@ -652,7 +710,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 end
 
 --------------------------------------------------------------------------------
--- ! Public Methods
+-- Public Methods
 --------------------------------------------------------------------------------
 
 -- ! Get Tilemap
@@ -811,11 +869,10 @@ function RoxyTilemap:removeLayer(name)
   if layer.sprite then
     local sprite = layer.sprite
     if self.scene and self.scene.removeSprite then
-      self.scene:removeSprite(sprite) -- Removes from scene.sprites and display list
+      self.scene:removeSprite(sprite)
     else
       sprite:remove()
     end
-    -- Also prune our own bookkeeping list
     if self.sprites then
       for i = #self.sprites, 1, -1 do
         if self.sprites[i] == sprite then tableRemove(self.sprites, i) break end
@@ -832,8 +889,11 @@ function RoxyTilemap:removeLayer(name)
     layer.collisionSprites = nil
   end
 
+  -- Clear heavy references
   layer.tilemap = nil
   layer.imageTable = nil
+  layer._imgCache = nil
+
   self.layers[name] = nil
 end
 
@@ -904,6 +964,7 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
   -- Swap imagetable
   layer.tilemap:setImageTable(newTable)
   layer.imageTable = newTable
+  layer._imgCache = {}
 
   -- Update asset retention (if a path swap)
   if newPath then
@@ -976,6 +1037,25 @@ function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesW
 end
 
 --------------------------------------------------------------------------------
+-- Projection methods
+--------------------------------------------------------------------------------
+
+-- ! World to Screen (abstract method)
+function RoxyTilemap:worldToScreen(worldX, worldY, layer)
+  Log.error("[RoxyTilemap:worldToScreen] Abstract method - must be implemented by projection subclass")
+end
+
+-- ! Screen to World (abstract method)
+function RoxyTilemap:screenToWorld(screenX, screenY, layer)
+  Log.error("[RoxyTilemap:screenToWorld] Abstract method - must be implemented by projection subclass")
+end
+
+-- ! Set Tile At (abstract method)
+function RoxyTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
+  Log.error("[RoxyTilemap:setTileAt] Abstract method - must be implemented by projection subclass")
+end
+
+--------------------------------------------------------------------------------
 -- Origin helpers
 --------------------------------------------------------------------------------
 
@@ -999,14 +1079,13 @@ function RoxyTilemap:setLayerOrigin(name, originX, originY)
 
     -- If this layer was using a parallax update closure, rebuild it with the new origin.
     if sprite.update and sprite.setUpdatesEnabled then
-      -- Recreate the cached updater using the shared helper
-      local pivotAdjustX = pox * (1 - parallaxX)
-      local pivotAdjustY = poy * (1 - parallaxY)
+      -- Recreate the cached updater using the helper
       sprite.update = createParallaxUpdate(
         layer.originX, layer.originY,
-        pivotAdjustX, pivotAdjustY,
         parallaxX, parallaxY,
-        round, getCameraPosition
+        pox, poy, -- Pass origins separately for consistency
+        round, getCameraPosition,
+        layer.anchor, layer.mapPixelWidth, layer.mapPixelHeight
       )
       -- Ensure we do not double-apply draw offset
       sprite:setIgnoresDrawOffset(true)
@@ -1027,6 +1106,77 @@ function RoxyTilemap:setOriginForAllLayers(originX, originY)
   for name, _ in pairs(self.layers) do
     self:setLayerOrigin(name, originX, originY)
   end
+end
+
+--------------------------------------------------------------------------------
+-- Culling Utilities
+--------------------------------------------------------------------------------
+
+-- ! Get Screen Bounds In World Space
+-- Returns the world coordinates of screen corners for a given layer
+function RoxyTilemap:getScreenBoundsInWorld(layer)
+  if not layer then return 0, 0, 0, 0 end
+
+  local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
+  local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
+  local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
+  local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+
+  local minX = min(topLeftX, topRightX, bottomLeftX, bottomRightX)
+  local maxX = max(topLeftX, topRightX, bottomLeftX, bottomRightX)
+  local minY = min(topLeftY, topRightY, bottomLeftY, bottomRightY)
+  local maxY = max(topLeftY, topRightY, bottomLeftY, bottomRightY)
+
+  return minX, minY, maxX, maxY
+end
+
+-- ! Get Visible Tile Bounds
+-- Calculate which tiles are potentially visible with proper margin
+function RoxyTilemap:getVisibleTileBounds(layer, extraMargin)
+  if not layer then return 1, 1, 1, 1 end
+
+  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
+
+  -- Get world bounds of screen
+  local minWorldX, minWorldY, maxWorldX, maxWorldY = self:getScreenBoundsInWorld(layer)
+
+  -- Calculate margin based on image heights (if needed)
+  local margin = extraMargin or 0
+  if not extraMargin and layer.imageTable then
+    -- Calculate proper margin like the projection classes do
+    local tileHeight = layer.tileHeight or 0
+    local halfHeight = tileHeight * 0.5
+
+    -- Find max image height (similar to _getMaxImgH in projection classes)
+    local maxImgH = 0
+    local imageTable = layer.imageTable
+    local imageTableLength = imageTable and imageTable:getLength() or 0
+    for i = 1, imageTableLength do
+      local img = imageTable:getImage(i)
+      if img then
+        local _, height = img:getSize()
+        if height and height > maxImgH then
+          maxImgH = height
+        end
+      end
+    end
+
+    local overdraw = max(0, maxImgH - tileHeight)
+    margin = ceil(overdraw / max(1, halfHeight)) + 1
+  end
+
+  -- Apply margin and convert to tile coordinates
+  minWorldX = minWorldX - margin
+  maxWorldX = maxWorldX + margin
+  minWorldY = minWorldY - margin
+  maxWorldY = maxWorldY + margin
+
+  local minTileX = max(1, floor(minWorldX) + 1)
+  local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
+  local minTileY = max(1, floor(minWorldY) + 1)
+  local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
+
+  return minTileX, minTileY, maxTileX, maxTileY
 end
 
 --------------------------------------------------------------------------------
@@ -1063,12 +1213,15 @@ function RoxyTilemap:destroy()
     end
     if layer.collisionSprites then
       for _, sprite in ipairs(layer.collisionSprites) do
-        -- Collision sprites were not tracked by scene.sprites, so display remove is enough
         sprite:remove()
       end
       layer.collisionSprites = nil
     end
+
+    -- Clear heavy references
     layer.tilemap = nil
+    layer.imageTable = nil
+    layer._imgCache = nil
   end
 
   -- Remove object sprites (tracked by scene if added that way)
@@ -1106,9 +1259,55 @@ function RoxyTilemap:destroy()
   -- Detach from scene and let it drop us from its tilemaps list
   if self.scene then
     local scene = self.scene
-    self.scene = nil -- Break the back‑pointer to avoid recursive destroy loops
+    self.scene = nil
     if scene.removeTilemap then
-      scene:removeTilemap(self) -- RoxyScene will remove us from its tilemaps list
+      scene:removeTilemap(self)
     end
   end
 end
+
+--#DEBUG START
+--------------------------------------------------------------------------------
+-- Debugging
+-- Useful for troubleshooting the projection classes
+--------------------------------------------------------------------------------
+
+-- ! Debug Layer Info
+function RoxyTilemap:debugLayerInfo(layerName)
+  local layer = self.layers and self.layers[layerName]
+  if not layer then
+    Log.debug("Layer '" .. tostring(layerName) .. "' not found")
+    return
+  end
+
+  Log.debug("**Layer: " .. layerName .. "**")
+  Log.debug("Projection: " .. tostring(self._projection))
+  Log.debug("Origin: " .. tostring(layer.originX) .. ", " .. tostring(layer.originY))
+  Log.debug("Parallax: " .. tostring(layer.parallaxx) .. ", " .. tostring(layer.parallaxy))
+  Log.debug("Parallax Origin: " .. tostring(layer.parallaxoriginx) .. ", " .. tostring(layer.parallaxoriginy))
+  Log.debug("Tile Size: " .. tostring(layer.tileWidth) .. "x" .. tostring(layer.tileHeight))
+  Log.debug("Map Size: " .. tostring(layer.mapPixelWidth) .. "x" .. tostring(layer.mapPixelHeight))
+  Log.debug("Visible: " .. tostring(layer.visible))
+  Log.debug("Has Sprite: " .. tostring(layer.sprite ~= nil))
+  Log.debug("Has Collisions: " .. tostring(layer.collisionSprites ~= nil))
+end
+
+-- ! Debug Visible Bounds
+function RoxyTilemap:debugVisibleBounds(layerName)
+  local layer = self.layers and self.layers[layerName]
+  if not layer then
+    log.debug("Layer '" .. tostring(layerName) .. "' not found")
+    return
+  end
+
+  local minWorldX, minWorldY, maxWorldX, maxWorldY = self:getScreenBoundsInWorld(layer)
+  local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layer)
+
+  log.debug("**Visible Bounds for " .. layerName .. "**")
+  log.debug("World bounds: (" .. minWorldX .. ", " .. minWorldY .. ") to (" .. maxWorldX .. ", " .. maxWorldY .. ")")
+  log.debug("Tile bounds: (" .. minTileX .. ", " .. minTileY .. ") to (" .. maxTileX .. ", " .. maxTileY .. ")")
+
+  local cameraX, cameraY = getCameraPosition()
+  log.debug("Camera: (" .. cameraX .. ", " .. cameraY .. ")")
+end
+--#DEBUG END

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -20,9 +20,13 @@ local tableSort   <const> = table.sort
 
 local loadJSON <const> = r.JSON.loadJson
 
+local pushContext     <const> = Graphics.pushContext
+local popContext      <const> = Graphics.popContext
+local setColor        <const> = Graphics.setColor
 local newImage        <const> = Graphics.image.new
 local newImagetable   <const> = Graphics.imagetable.new
 local newTilemap      <const> = Graphics.tilemap.new
+local fillRect        <const> = Graphics.fillRect
 local addWallSprites  <const> = Graphics.sprite.addWallSprites
 local newSprite       <const> = Graphics.sprite.new
 
@@ -37,6 +41,10 @@ local setCameraBounds   <const> = Camera.setBounds
 local getCameraPosition <const> = Camera.getPosition
 
 local IMAGE_PATH_PREFIX <const> = "assets/images/"
+
+local SPRITE_DEFAULT_DIMS <const> = 16
+
+local COLOR_BLACK <const> = Graphics.kColorBlack
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
@@ -79,7 +87,7 @@ local function normalizeImgPath(tiledImgPath)
     return nil
   end
   local filename = tiledImgPath:match("([^/]+)$") or ""
-  local base     = filename:gsub("%-table%-%d+%-%d+%.png$", "")
+  local base = filename:gsub("%-table%-%d+%-%d+%.png$", "")
   if base == filename then
     Log.warn("[normalizeImgPath] Unexpected image path pattern: " .. tostring(tiledImgPath)) --#DEBUG
     return IMAGE_PATH_PREFIX .. filename
@@ -87,10 +95,10 @@ local function normalizeImgPath(tiledImgPath)
   return IMAGE_PATH_PREFIX .. base
 end
 
--- ! Get Image Table
-local function getImageTable(path)
+-- ! Get Imagetable
+local function getImagetable(path)
   if type(path) ~= "string" or path == "" then
-    Log.warn("[getImageTable] Invalid or missing path: " .. tostring(path))
+    Log.warn("[getImagetable] Invalid or missing path: " .. tostring(path))
     return nil
   end
   local cached = getCachedAsset(path)
@@ -104,7 +112,7 @@ local function getImageTable(path)
   if loaded then
     cacheAsset(path, function() return loaded end)
   else --#DEBUG
-    Log.warn("[getImageTable] Failed to load imagetable at path: " .. path) --#DEBUG
+    Log.warn("[getImagetable] Failed to load imagetable at path: " .. path) --#DEBUG
   end
 
   return loaded
@@ -152,63 +160,18 @@ local function validateOptions(opts)
   return opts
 end
 
--- ! Compute Draw Parameters
--- Compute screen position and sourceRect for direct drawing
-local function _computeDrawParams(layer)
-  local camX, camY = getCameraPosition()
-  local px, py = layer.parallaxx or 1, layer.parallaxy or 1
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local mapPixelWidth, mapPixelHeight = layer.mapPixelWidth or 0, layer.mapPixelHeight or 0
-
-  -- Compute where the tilemap’s top-left should appear on screen
-  local round = round
-  local screenX, screenY
-  if layer.anchor == "topLeft" then
-    screenX = round(originX - camX * px)
-    screenY = round(originY - camY * py)
-  else
-    -- Centered: origin is the map center; shift to top-left
-    screenX = round(originX - (mapPixelWidth * 0.5)  - camX * px)
-    screenY = round(originY - (mapPixelHeight * 0.5) - camY * py)
-  end
-
-  -- Build a sourceRect (in map local pixels) to avoid drawing offscreen areas
-  local srcX = 0
-  local srcY = 0
-  local srcWidth = mapPixelWidth
-  local srcHeight = mapPixelHeight
-
-  -- Clip against the screen: if the map is shifted left/up, start inside the map
-  if screenX < 0 then srcX = -screenX end
-  if screenY < 0 then srcY = -screenY end
-
-  -- Visible width/height on screen (do not exceed map bounds)
-  local maxW = DISPLAY_WIDTH  - max(0, screenX)
-  local maxH = DISPLAY_HEIGHT - max(0, screenY)
-  srcWidth = min(srcWidth - srcX, max(0, maxW))
-  srcHeight = min(srcHeight - srcY, max(0, maxH))
-
-  -- Nothing visible?
-  if srcWidth <= 0 or srcHeight <= 0 then
-    return screenX, screenY, nil, true
-  end
-
-  -- sourceRect is relative to the map (x,y,width,height)
-  return screenX, screenY, srcX, srcY, srcWidth, srcHeight, false
-end
-
 -- ! Create default Object Sprite
 local function createDefaultObjectSprite(obj, layerOpts)
   -- Check if object has parallax properties
   local hasParallax = false
   local parallaxX, parallaxY = 1, 1
   local parallaxOriginX, parallaxOriginY = 0, 0
-  local objectProperties = {}
+  local objectProps = {}
 
   -- Parse object properties
   if obj.properties then
     for _, prop in ipairs(obj.properties) do
-      objectProperties[prop.name] = prop.value
+      objectProps[prop.name] = prop.value
 
       -- Check for parallax properties
       if prop.name == "parallaxX" or prop.name == "parallaxx" then
@@ -229,8 +192,8 @@ local function createDefaultObjectSprite(obj, layerOpts)
   local imagePath = nil
 
   -- Check for image in object properties (common Tiled pattern)
-  if objectProperties.image or objectProperties.sprite then
-    imagePath = IMAGE_PATH_PREFIX .. (objectProperties.image or objectProperties.sprite)
+  if objectProps.image or objectProps.sprite then
+    imagePath = IMAGE_PATH_PREFIX .. (objectProps.image or objectProps.sprite)
   end
 
   -- Fallback to type-based or name-based image loading
@@ -248,9 +211,8 @@ local function createDefaultObjectSprite(obj, layerOpts)
     Log.warn("[createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
   end
 
-  local sprite
-
   -- Create parallax sprite if needed and RoxyParallaxSprite is available
+  local sprite
   if hasParallax and r.RoxyParallaxSprite then
     local spriteOpts = {
       view = image,
@@ -273,18 +235,18 @@ local function createDefaultObjectSprite(obj, layerOpts)
   -- Fallback image creation for regular sprites
   if not image and not hasParallax then
     -- Create a simple rectangle sprite as fallback
-    local width = obj.width or 16
-    local height = obj.height or 16
-    local fallbackImage = Graphics.image.new(width, height)
-    Graphics.pushContext(fallbackImage)
-    Graphics.setColor(Graphics.kColorBlack)
-    Graphics.drawRect(0, 0, width, height)
-    Graphics.popContext()
+    local width = obj.width or SPRITE_DEFAULT_DIMS
+    local height = obj.height or SPRITE_DEFAULT_DIMS
+    local fallbackImage = newImage(width, height)
+    pushContext(fallbackImage)
+      setColor(COLOR_BLACK)
+      fillRect(0, 0, width, height)
+    popContext()
     sprite:setImage(fallbackImage)
   end
 
   -- Store all object properties on the sprite for reference
-  sprite.objectProperties = objectProperties
+  sprite.objectProps = objectProps
 
   return sprite
 end
@@ -317,16 +279,16 @@ local function processObjectLayer(self, layer, opts, layerOpts, autoAdd, scene, 
         y = y + (obj.height or 0) * 0.5
       end
 
-      -- Compute final screen coordinates (sx, sy)
-      local sx, sy = x, y
+      -- Compute final screen coordinates (screenX, screenY)
+      local screenX, screenY = x, y
 
       -- Position the sprite
       if sprite.setWorldPosition then
         -- Parallax‐aware sprite
-        sprite:setWorldPosition(sx, sy)
+        sprite:setWorldPosition(screenX, screenY)
       else
         -- Normal screen‐positioned sprite
-        sprite:moveTo(sx, sy)
+        sprite:moveTo(screenX, screenY)
       end
 
       -- Set z-index if specified
@@ -377,11 +339,11 @@ end
 -- Hoist and Cache sprite:update - Move parallax update function outside per-sprite loop
 -- Define the parallax update function once, outside the sprite creation loop
 -- This avoids creating new function instances for each sprite
-local function createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, px, py, rnd, camGetter)
+local function createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, parallaxX, parallaxY, rnd, camGetter)
   return function(self)
     local cameraX, cameraY = camGetter()
-    local screenX = rnd(worldX + pivotAdjustX - cameraX * px)
-    local screenY = rnd(worldY + pivotAdjustY - cameraY * py)
+    local screenX = rnd(worldX + pivotAdjustX - cameraX * parallaxX)
+    local screenY = rnd(worldY + pivotAdjustY - cameraY * parallaxY)
     local currentX, currentY = self:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
       self:moveTo(screenX, screenY)
@@ -424,12 +386,27 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     return
   end
 
+  -- Keep raw map/grid metadata for projection leaves
+  self.mapWidth = mapData.width or 0
+  self.mapHeight = mapData.height or 0
+  self.mapTileWidth = mapData.tilewidth or 0
+  self.mapTileHeight = mapData.tileheight or 0
+
+  -- Store Tiled map orientation metadata for projection leaves
+  self.mapOrientation = mapData.orientation -- "isometric" | "staggered" | "orthogonal" | ...
+  self.staggerAxis = mapData.staggeraxis -- "x" | "y" | nil
+  self.staggerIndex = mapData.staggerindex -- "odd" | "even" | nil
+
+  -- Your original world size (orthographic assumption)
+  self.worldWidth = (mapData.width or 0) * (mapData.tilewidth or 0)
+  self.worldHeight = (mapData.height or 0) * (mapData.tileheight or 0)
+
   -- Build GID ranges for tileset auto-detection
   local gidRanges = {}
   for _, tileset in ipairs(mapData.tilesets or {}) do
     gidRanges[#gidRanges + 1] = {
-      first   = tileset.firstgid,
-      last    = tileset.firstgid + (tileset.tilecount or 0) - 1,
+      first = tileset.firstgid,
+      last = tileset.firstgid + (tileset.tilecount or 0) - 1,
       tileset = tileset
     }
   end
@@ -446,9 +423,6 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     end
     return nil
   end
-
-  self.worldWidth  = (mapData.width  or 0) * (mapData.tilewidth  or 0)
-  self.worldHeight = (mapData.height or 0) * (mapData.tileheight or 0)
 
   -- Apply camera bounds if requested
   if opts.cameraBounds then
@@ -473,7 +447,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     end
 
     tileset.imagePath = normPath -- Store normalized path
-    tileset.imageTable = getImageTable(normPath)
+    tileset.imageTable = getImagetable(normPath)
     retain(normPath, tileset.imageTable)
     tilesets[tileset.name] = tileset
 
@@ -574,12 +548,12 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         layerData.originX = originX
         layerData.originY = originY
 
-        local px = tonumber(layer.parallaxx) or 1
-        local py = tonumber(layer.parallaxy) or 1
+        local parallaxX = tonumber(layer.parallaxx) or 1
+        local parallaxY = tonumber(layer.parallaxy) or 1
         local pox = opts.parallaxOriginX or mapPox
         local poy = opts.parallaxOriginY or mapPoy
-        layerData.parallaxx = px
-        layerData.parallaxy = py
+        layerData.parallaxx = parallaxX
+        layerData.parallaxy = parallaxY
         layerData.parallaxoriginx = pox
         layerData.parallaxoriginy = poy
 
@@ -597,15 +571,15 @@ function RoxyTilemap:init(jsonPath, opts, scene)
           local camGetter = getCameraPosition
           local rnd = round
           local useParallax = (layerOptions.parallax ~= false)
-          if useParallax and (px ~= 1 or py ~= 1 or offsetX ~= 0 or offsetY ~= 0) then
+          if useParallax and (parallaxX ~= 1 or parallaxY ~= 1 or offsetX ~= 0 or offsetY ~= 0) then
             sprite:setIgnoresDrawOffset(true)
             sprite:setUpdatesEnabled(true)
 
-            local pivotAdjustX = pox * (1 - px)
-            local pivotAdjustY = poy * (1 - py)
+            local pivotAdjustX = pox * (1 - parallaxX)
+            local pivotAdjustY = poy * (1 - parallaxY)
             local worldX, worldY = originX, originY
 
-            sprite.update = createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, px, py, rnd, camGetter)
+            sprite.update = createParallaxUpdate(worldX, worldY, pivotAdjustX, pivotAdjustY, parallaxX, parallaxY, rnd, camGetter)
           else
             sprite:moveTo(originX, originY)
           end
@@ -634,7 +608,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
             sprite:setTag(1)
             sprite:setCollideRect(0, 0, sprite:getSize())
             if wallGroup then
-              sprite:setGroups(type(wallGroup) == "table" and wallGroup or {wallGroup})
+              sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
             end
             if layerCollidesWithGroups and type(layerCollidesWithGroups) == "table" and #layerCollidesWithGroups > 0 then
               sprite:setCollidesWithGroups(layerCollidesWithGroups)
@@ -772,23 +746,6 @@ function RoxyTilemap:getTileAt(name, x, y)
   return tilemap and tilemap:getTileAtPosition(x, y) or nil
 end
 
--- ! Set Tile At
--- Sets the tile at the given tile coordinates (x, y) on the specified layer.
--- Note: Coordinates are in tile units, not pixels.
-function RoxyTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
-  local layer = self.layers[name]
-  if not layer then return end
-
-  layer.tilemap:setTileAtPosition(x, y, tileIndex)
-
-  if updateSprite and layer.sprite then
-    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-    -- Top-left of tile in pixels
-    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
-    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
-  end
-end
-
 -- ! For Each Tile
 -- Iterates over each tile on the specified layer, calling the provided function.
 -- Note: Coordinates passed to the function are in tile units.
@@ -809,32 +766,6 @@ end
 -- This is cached at init-time and available even if cameraBounds is false.
 function RoxyTilemap:getWorldSize()
   return self.worldWidth, self.worldHeight
-end
-
--- ! World to Screen
--- Convert tile/world coords to screen coords with parallax (orthogonal only)
-function RoxyTilemap:worldToScreen(worldX, worldY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local px, py = layer.parallaxx or 1, layer.parallaxy or 1
-  local camX, camY = getCameraPosition()
-
-  local orthoX = originX + worldX * tileWidth
-  local orthoY = originY + worldY * tileHeight
-  return round(orthoX - camX * px), round(orthoY - camY * py)
-end
-
--- ! Screen to World
--- Convert screen coordinates back to world coordinates (orthogonal only)
-function RoxyTilemap:screenToWorld(screenX, screenY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local px, py = layer.parallaxx or 1, layer.parallaxy or 1
-  local camX, camY = getCameraPosition()
-
-  local worldX = ((screenX + camX * px) - originX) / tileWidth
-  local worldY = ((screenY + camY * py) - originY) / tileHeight
-  return worldX, worldY
 end
 
 -- ! Hide Layer
@@ -928,7 +859,7 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
   if type(newImageTableOrPath) == "string" then
     -- Normalize path like tileset loader does
     newPath = normalizeImgPath(newImageTableOrPath) or newImageTableOrPath
-    newTable = getImageTable(newPath)
+    newTable = getImagetable(newPath)
     if not newTable then
       Log.warn("[RoxyTilemap:setLayerImageTable] Failed to load imagetable: " .. tostring(newPath)) --#DEBUG
       return false
@@ -996,16 +927,16 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
   local mapPixelWidth  = mapWidthTiles  * tileWidth
   local mapPixelHeight = mapHeightTiles * tileHeight
 
-  local px, py = layer.parallaxx or 1, layer.parallaxy or 1
-  local camX, camY = getCameraPosition()
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local cameraX, cameraY = getCameraPosition()
   local originX, originY = layer.originX or 0, layer.originY or 0
   local centerX = (layer.anchor == "topLeft") and 0 or 0.5
   local centerY = (layer.anchor == "topLeft") and 0 or 0.5
 
-  local screenX = round(originX - mapPixelWidth * centerX  - camX * px)
-  local screenY = round(originY - mapPixelHeight * centerY - camY * py)
+  local screenX = round(originX - mapPixelWidth * centerX  - cameraX * parallaxX)
+  local screenY = round(originY - mapPixelHeight * centerY - cameraY * parallaxY)
 
-  addDirtyRect(screenX, screenY, mapPixelWidth, mapPixelHeight) -- ADDED
+  addDirtyRect(screenX, screenY, mapPixelWidth, mapPixelHeight)
 
   return true
 end
@@ -1049,53 +980,15 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
--- Draw a single tile layer directly (no sprite required)
 function RoxyTilemap:draw(name)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap or layer.visible == false then return end
-
-  local screenX, screenY, srcX, srcY, srcWidth, srcHeight, culled = _computeDrawParams(layer)
-  if culled then return end
-
-  -- Use drawIgnoringOffset because we already applied camera/offset logic
-  if srcX then
-    layer.tilemap:drawIgnoringOffset(screenX, screenY, srcX, srcY, srcWidth, srcHeight)
-  else
-    layer.tilemap:drawIgnoringOffset(screenX, screenY)
-  end
+  -- Subclasses should implement their own drawing.
+  Log.warn("[RoxyTilemap:draw] Abstract. Implement in a projection leaf.") --#DEBUG
 end
 
 -- ! Draw Visible
--- Draw all visible tile layers by zIndex (ascending)
 function RoxyTilemap:drawVisible()
-  if not self.layers then return end
-
-  -- Collect visible layers
-  local list = {}
-  for name, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      tableInsert(list, layer)
-    end
-  end
-
-  -- Sort by zIndex to match sprite render order
-  tableSort(list, function(a, b)
-    return (a.zIndex or 0) < (b.zIndex or 0)
-  end)
-
-  -- Draw in order
-  for i = 1, #list do
-    local layer = list[i]
-    local screenX, screenY, srcX, srcY, srcWidth, srcHeight, culled = _computeDrawParams(layer)
-    if not culled then
-      local drawIgnoring = layer.tilemap.drawIgnoringOffset
-      if srcX then
-        drawIgnoring(layer.tilemap, screenX, screenY, srcX, srcY, srcWidth, srcHeight)
-      else
-        drawIgnoring(layer.tilemap, screenX, screenY)
-      end
-    end
-  end
+  -- Subclasses should implement their own drawing.
+  Log.warn("[RoxyTilemap:drawVisible] Abstract. Implement in a projection leaf.") --#DEBUG
 end
 
 --------------------------------------------------------------------------------

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -23,11 +23,6 @@ local pushRaw     <const> = Scene.pushRaw
 local popRaw      <const> = Scene.popRaw
 local replaceRaw  <const> = Scene.replaceRaw
 
--- Expose stack-op constants so children don’t need to re-require them
-local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
-local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
-local STACK_OP_POP     <const> = Transition.STACK_OP_POP
-
 -- Bit-flags that track where we are in the life-cycle
 local STATE_MIDPOINT_REACHED <const> = 1
 local STATE_HOLD_ELAPSED     <const> = 2
@@ -44,7 +39,7 @@ function RoxyTransition:init(opts)
   -- Basic properties
   self.name = opts.name or "UnnamedTransition"
   self.type = opts.type or "Base"
-  self.stackOp  = opts.stackOp or STACK_OP_REPLACE
+  self.stackOp  = opts.stackOp or Transition.STACK_OP_REPLACE
 
   -- bookkeeping
   self.state = 0
@@ -66,7 +61,7 @@ end
 function RoxyTransition:_onStart()
   Log.debug("Transition '" .. self.name .. "' started") --#DEBUG
 
-  if self.stackOp == STACK_OP_REPLACE and self._currentScene then
+  if self.stackOp == Transition.STACK_OP_REPLACE and self._currentScene then
     self._currentScene:exit()
   end
 end
@@ -83,9 +78,9 @@ function RoxyTransition:_onMidpoint()
   local oldScene = self._currentScene
 
   -- Perform stack operation
-  if stackOp == STACK_OP_PUSH then
+  if stackOp == Transition.STACK_OP_PUSH then
     pushRaw(newScene)
-  elseif stackOp == STACK_OP_POP then
+  elseif stackOp == Transition.STACK_OP_POP then
     popRaw()
     newScene = Scene.currentScene
   else -- Replace
@@ -93,14 +88,14 @@ function RoxyTransition:_onMidpoint()
   end
 
   -- Handle scene lifecycle
-  if stackOp == STACK_OP_POP then
+  if stackOp == Transition.STACK_OP_POP then
     if oldScene then
       oldScene:cleanup()
     end
     if newScene then
       newScene:resume()
     end
-  elseif stackOp == STACK_OP_PUSH then
+  elseif stackOp == Transition.STACK_OP_PUSH then
     if oldScene then
       oldScene:pause()
     end
@@ -143,6 +138,13 @@ end
 
 -- ! On Complete
 function RoxyTransition:_onComplete()
+  local scene = self._newScene
+
+  if scene and scene.start then
+    print("running scene start")
+    scene:start()
+  end
+
   Transition.isTransitioning = false
   Transition.currentTransition = nil
   self:cleanup()
@@ -174,9 +176,9 @@ function RoxyTransition:cleanup()
   self._capturedScreenshot   = nil
 end
 
--- Re-export constants so children can reference them via RoxyTransition.*
+-- Re-export constants so children can reference them via RoxyTransition
 RoxyTransition.STATE_MIDPOINT_REACHED = STATE_MIDPOINT_REACHED
 RoxyTransition.STATE_HOLD_ELAPSED     = STATE_HOLD_ELAPSED
-RoxyTransition.STACK_OP_REPLACE       = STACK_OP_REPLACE
-RoxyTransition.STACK_OP_PUSH          = STACK_OP_PUSH
-RoxyTransition.STACK_OP_POP           = STACK_OP_POP
+RoxyTransition.STACK_OP_REPLACE       = Transition.STACK_OP_REPLACE
+RoxyTransition.STACK_OP_PUSH          = Transition.STACK_OP_PUSH
+RoxyTransition.STACK_OP_POP           = Transition.STACK_OP_POP

--- a/roxy.lua
+++ b/roxy.lua
@@ -51,6 +51,8 @@ import "libraries/roxy/core/sprites/RoxyParticles"
 import "libraries/roxy/core/physics/RoxyPhysicsBody"
 import "libraries/roxy/core/animations/RoxyAnimation"
 import "libraries/roxy/core/tilemaps/RoxyTilemap"
+import "libraries/roxy/core/tilemaps/RoxyOrthoTilemap"
+import "libraries/roxy/core/tilemaps/RoxyIsoTilemap"
 import "libraries/roxy/core/scenes/RoxyScene"
 
 -- Create global Roxy table if it does not already exist

--- a/roxy.lua
+++ b/roxy.lua
@@ -53,6 +53,7 @@ import "libraries/roxy/core/animations/RoxyAnimation"
 import "libraries/roxy/core/tilemaps/RoxyTilemap"
 import "libraries/roxy/core/tilemaps/RoxyOrthoTilemap"
 import "libraries/roxy/core/tilemaps/RoxyIsoTilemap"
+import "libraries/roxy/core/tilemaps/RoxyStagTilemap"
 import "libraries/roxy/core/scenes/RoxyScene"
 
 -- Create global Roxy table if it does not already exist


### PR DESCRIPTION
### Overview
This major release restructures tilemaps into projection-specific classes, adds a post-transition `Scene:start()` lifecycle phase, and introduces input pause/resume control. The tilemap overhaul brings dedicated orthogonal, diamond isometric, and staggered-Y isometric implementations with new culling and region-draw utilities. Scene and transition behavior is refined for cleaner handoffs, while camera, input, and rendering paths receive stability and performance improvements.

### Key Changes
- **Tilemaps (Architecture)**
  - Split `RoxyTilemap` into abstract base + projection subclasses: `RoxyOrthoTilemap`, `RoxyIsoTilemap`, and new `RoxyStagTilemap`
  - Core imports added for all projections (including `RoxyStagTilemap`)
  - Scene now spawns `RoxyOrthoTilemap` by default (`RoxyScene:spawnTilemap`)
  - Base tilemap gains projection hooks, culling helpers, isometric offsets, manual draw helpers, and debug utilities
  - Orthogonal tilemap adds parallax pivot support and region-based drawing
  - Isometric split: diamond iso handled by `RoxyIsoTilemap`; staggered-Y handled by `RoxyStagTilemap`
  - Fixed world width on staggered-Y isometric maps (right-edge overhang)
  - New origin helpers: `setLayerOrigin(name, x, y)` and `setOriginForAllLayers(x, y)`

- **Scene & Transitions**
  - New `RoxyScene:start()` lifecycle method (runs after transitions finish)
  - Sprites/sequences queued until `enter()` to prevent pre-transition activation
  - Transitions render in **screen space** (ignore camera draw offset)
  - Transition constants now referenced via `Transition.STACK_OP_*`

- **Input**
  - Added `Input.pause()` / `Input.resume([blockUntilClear])` to temporarily disable callbacks
  - Minor performance tuning by caching lengths and reducing iteration overhead

- **Camera & Core**
  - Camera reset now returns to static mode (prevents follow target errors)
  - Transition rendering saves/restores draw offset and draw mode
  - Manual tilemap draws zero and restore global draw offset for correctness

### Breaking Changes ⚠️
- **Tilemap API & Classes**
  - `RoxyTilemap` is now an **abstract base**; instantiate a projection:
    - `RoxyOrthoTilemap` (orthogonal), `RoxyIsoTilemap` (diamond iso), `RoxyStagTilemap` (staggered-Y iso)
  - Projection math updated across classes with a **parallax-origin pivot**; remove custom alignment hacks and use each class’s `worldToScreen` / `screenToWorld`
  - Parallax object sprites now **require** `RoxyParallaxSprite`

- **Scene Lifecycle**
  - New `Scene:start()` runs **after** transitions; move post-transition setup (e.g., enable input, start gameplay) from `enter()` → `start()`
  - `addSprite` / `addSequence` early calls are **queued** until `enter()`; if you relied on pre-enter activation, adjust flow or move to `start()`

- **Transitions**
  - Transition drawing is now **screen-space**; effects that depended on ambient camera offsets must compute offsets explicitly
  - Use `Transition.STACK_OP_*` constants (relying on local copies may break)

- **Manual Draw Behavior**
  - Tilemap direct draws temporarily zero global draw offset; apply camera via projection conversions, not global offset

- **Cleanup Semantics**
  - Layer removal/destroy clears heavy references; avoid retaining pointers into layer internals

### Challenges/Notes
- The projection split isolates math per tilemap type and simplifies future projection additions
- Queuing of sprites/sequences plus `Scene:start()` ensures clean visual handoff during transitions without early input or animation
- Culling and region-draw utilities are tuned for large maps to minimize overdraw and memory churn