### PR TITLE
[0.14.1] - Tilemap Chunk Rendering and Native Renderer Integration (Breaking Changes)

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -263,7 +263,7 @@ function RoxyAnimation:stepFrame(direction)
   local startFrame = currentAnimation.startFrame
   local endFrame = currentAnimation.endFrame
   -- Guard against zero-length animations
-  -- (Shouldn’t happen under normal addAnimation, but protects against division by zero)
+  -- (Shouldn't happen under normal addAnimation, but protects against division by zero)
   local range = endFrame - startFrame + 1
   if range <= 0 then return self end
 

--- a/core/animations/roxy_animation.c
+++ b/core/animations/roxy_animation.c
@@ -71,7 +71,7 @@ int roxy_animation_update_l(lua_State* L) {
     accumulator = 0.0f;
     isFirstCycle = 0;
   } else {
-    // Calculate how much progress we’ve made in terms of frames.
+    // Calculate how much progress we've made in terms of frames.
     // (dt * speed) gives the time-adjusted speed,
     // Dividing by frameDuration converts that into "frame units".
     float frameDelta = (dt * speed) / frameDuration;

--- a/core/modules/Cache.lua
+++ b/core/modules/Cache.lua
@@ -8,13 +8,13 @@ local getConfig <const> = roxy.Config.get
 
 local MAX_CACHE_SIZE_DEFAULT <const> = 50
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Internal Functions
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! New Entry
 -- Creates a new cache entry for the given key and asset.
-local function newEntry(key, asset)
+local function _newEntry(key, asset)
   return {
     key = key,
     asset = asset,
@@ -25,7 +25,7 @@ end
 
 -- ! Move to Head
 -- Moves an entry to the head, marking it as most recently used.
-local function moveToHead(bucket, entry)
+local function _moveToHead(bucket, entry)
   if bucket.head == entry then return end
 
   if entry.prev then
@@ -53,7 +53,7 @@ end
 
 -- ! Add to Head
 -- Adds a new entry to the head of the linked list.
-local function addToHead(bucket, entry)
+local function _addToHead(bucket, entry)
   entry.next = bucket.head
   entry.prev = nil
   if bucket.head then
@@ -69,7 +69,7 @@ end
 
 -- ! Remove Tail
 -- Removes the least recently used entry from the tail.
-local function removeTail(bucket)
+local function _removeTail(bucket)
   local tail = bucket.tail
   if not tail then return end -- Nothing to remove
   bucket.cache[tail.key] = nil
@@ -83,9 +83,9 @@ local function removeTail(bucket)
   bucket.currentSize -= 1
 end
 
--- ----------------------------------
--- ! Bucket Constructor
--- ----------------------------------
+--------------------------------------------------------------------------------
+-- Bucket Constructor
+--------------------------------------------------------------------------------
 
 -- ! New Bucket
 -- Creates a new cache bucket with specified max size.
@@ -111,9 +111,9 @@ local function resolveBucket(firstArg, ...)
   return defaultBucket, firstArg, ...
 end
 
--- ----------------------------------
+--------------------------------------------------------------------------------
 -- Public API
--- ----------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Initialize Cache module
 function Cache.init()
@@ -146,7 +146,7 @@ function Cache.setMaxCacheSize(bucketOrSize, maybeSize)
     bucket.currentSize = 0
   else
     while bucket.currentSize > bucket.maxCacheSize do
-      removeTail(bucket)
+      _removeTail(bucket)
     end
   end
 
@@ -180,12 +180,12 @@ function Cache.cacheAsset(bucketOrKey, keyOrLoader, maybeLoader)
     return false
   end
 
-  local entry = newEntry(key, asset)
+  local entry = _newEntry(key, asset)
   bucket.cache[key] = entry
-  addToHead(bucket, entry)
+  _addToHead(bucket, entry)
 
   if bucket.currentSize > bucket.maxCacheSize then
-    removeTail(bucket)
+    _removeTail(bucket)
   end
 
   return true
@@ -205,12 +205,19 @@ function Cache.getCachedAsset(bucketOrKey, maybeKey)
 
   local entry = bucket.cache[key]
   if not entry then
-    Log.warn("[Cache.getCachedAsset] Asset with key '" .. tostring(key) .. "' not cached.") --#DEBUG
+    -- Log.debug("[Cache.getCachedAsset] Asset with key '" .. tostring(key) .. "' not cached.") --#DEBUG
     return nil
   end
 
-  moveToHead(bucket, entry)
+  _moveToHead(bucket, entry)
   return entry.asset
+end
+
+-- ! Get Is Asset Cached
+-- Checks if an asset is cached for the given key.
+function Cache.getIsAssetCached(bucketOrKey, maybeKey)
+  local bucket, key = resolveBucket(bucketOrKey, maybeKey)
+  return bucket.cache[key] ~= nil
 end
 
 -- ! Get or Load Asset
@@ -227,7 +234,7 @@ function Cache.getOrLoadAsset(bucketOrKey, keyOrLoader, maybeLoader)
 
   local entry = bucket.cache[key]
   if entry then
-    moveToHead(bucket, entry)
+    _moveToHead(bucket, entry)
     return entry.asset
   else
     if type(loaderFn) ~= "function" then
@@ -240,22 +247,47 @@ function Cache.getOrLoadAsset(bucketOrKey, keyOrLoader, maybeLoader)
       return nil
     end
 
-    local entry = newEntry(key, asset)
+    local entry = _newEntry(key, asset)
     bucket.cache[key] = entry
-    addToHead(bucket, entry)
+    _addToHead(bucket, entry)
     if bucket.currentSize > bucket.maxCacheSize then
-      removeTail(bucket)
+      _removeTail(bucket)
     end
 
     return asset
   end
 end
 
--- ! Get Is Asset Cached
--- Checks if an asset is cached for the given key.
-function Cache.getIsAssetCached(bucketOrKey, maybeKey)
-  local bucket, key = resolveBucket(bucketOrKey, maybeKey)
-  return bucket.cache[key] ~= nil
+-- ! Put Asset
+-- Inserts or replaces an asset for a key and marks it MRU.
+function Cache.putAsset(bucketOrKey, keyOrAsset, maybeAsset)
+  local bucket, key, asset = resolveBucket(bucketOrKey, keyOrAsset, maybeAsset)
+
+  --#DEBUG START
+  if (type(key) ~= "string" and type(key) ~= "number") then
+    Log.warn("[Cache.putAsset] Expected string/number for key, got " .. type(key))
+    return false
+  end
+  if asset == nil then
+    Log.warn("[Cache.putAsset] Nil asset for key '" .. tostring(key) .. "'.")
+    return false
+  end
+  --#DEBUG END
+
+  local entry = bucket.cache[key]
+  if entry then
+    -- Replace the asset and bump to MRU
+    entry.asset = asset
+    _moveToHead(bucket, entry)
+  else
+    entry = _newEntry(key, asset)
+    bucket.cache[key] = entry
+    _addToHead(bucket, entry)
+    if bucket.currentSize > bucket.maxCacheSize then
+      _removeTail(bucket)
+    end
+  end
+  return true
 end
 
 -- ! Evict Asset

--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -60,7 +60,7 @@ Camera._deadZoneHeight  = 0     -- Dead zone height (pixels, 0 = disabled)
 Camera.friction         = FRICTION_DEFAULT
 
 -- Indicates whether the camera needs an update this frame.
--- Remains true while there’s an active target, any velocity, or an ongoing shake.
+-- Remains true while there's an active target, any velocity, or an ongoing shake.
 Camera._isActive = true -- Ensure initial update
 
 -- Default to static mode (must be set after all Camera functions exist!)

--- a/core/modules/Sounds.lua
+++ b/core/modules/Sounds.lua
@@ -64,7 +64,7 @@ local function getPlayer(name)
   end
 
   -- If we get here, either the player is missing or its cache record
-  -- was evicted by the LRU. Clear the stale pointer so we don’t use it.
+  -- was evicted by the LRU. Clear the stale pointer so we don't use it.
   players[name] = nil
 
   -- Slow path: load (or re‑load) from disk

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -22,15 +22,16 @@ local mergeImmutable <const> = r.Table.mergeImmutable
 local getConfig           <const> = Config.get
 local getTransitionConfig <const> = Config.getTransitionConfig
 
-local getDrawOffset <const> = Graphics.getDrawOffset
-local setDrawOffset <const> = Graphics.setDrawOffset
-local pushContext   <const> = Graphics.pushContext
-local popContext    <const> = Graphics.popContext
-local setColor      <const> = Graphics.setColor
-local fillRect      <const> = Graphics.fillRect
-local newImage      <const> = Graphics.image.new
-local getDrawMode   <const> = Graphics.getImageDrawMode
-local setDrawMode   <const> = Graphics.setImageDrawMode
+local getDrawOffset     <const> = Graphics.getDrawOffset
+local setDrawOffset     <const> = Graphics.setDrawOffset
+local pushContext       <const> = Graphics.pushContext
+local popContext        <const> = Graphics.popContext
+local setColor          <const> = Graphics.setColor
+local fillRect          <const> = Graphics.fillRect
+local newImage          <const> = Graphics.image.new
+local getDrawMode       <const> = Graphics.getImageDrawMode
+local setDrawMode       <const> = Graphics.setImageDrawMode
+local redrawBackground  <const> = Graphics.sprite.redrawBackground
 
 local EMPTY_TABLE   <const> = {}
 
@@ -66,9 +67,30 @@ Transition.STACK_OP_POP       = STACK_OP_POP
 -- Local
 local transitions = {}
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Helper: Foce Scene Tilemaps Redraw
+-- Nudge all tilemaps in a scene to repaint for a few frames
+local function _forceSceneTilemapsRedraw(scene, frames)
+  if not scene then return end
+  local n = frames or 2
+
+  -- Iterate table-based tilemaps if provided
+  local tilemaps = scene.tilemaps
+  if type(tilemaps) == "table" then
+    for _, tilemap in pairs(tilemaps) do
+      if tilemap and tilemap.forceRedraw then
+        tilemap:forceRedraw(n)
+      end
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
 -- ! Initialize Transition module
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 function Transition.init()
   -- Reset transient state
@@ -95,9 +117,9 @@ function Transition.init()
   Transition.reloadTransitionsWithNewConfig()
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Scene Management
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Load Transitions
 -- Loads a table of transition classes into the transition module.
@@ -214,11 +236,18 @@ function Transition.transitionToScene(newSceneClass, transitionName, opts)
   local transitionInstance = transitionClass(transitionOpts)
   Transition.currentTransition = transitionInstance
   transitionInstance:execute(newScene, scene)
+
+  redrawBackground()
+
+  -- Force 2 frames of redraw on any tilemaps present in the target scene
+  -- For replace/push this is 'newScene'; for pop we fall back to currentScene.
+  local targetScene = newScene or Scene.currentScene
+  _forceSceneTilemapsRedraw(targetScene, 2)
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Rendering
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Prepare Transition Screenshot
 -- Prepares a screenshot for transitions if needed.

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -101,7 +101,7 @@ function Transition.init()
   -- Clear out any previously loaded classes
   transitions = {}
 
-  -- Merge in user’s customTransitions if present
+  -- Merge in user's customTransitions if present
   local config          = getConfig("transitions") or EMPTY_TABLE
   local userTransitions = config.customTransitions
   local allTransitions  = DEFAULT_TRANSITIONS

--- a/core/sprites/RoxyActor.lua
+++ b/core/sprites/RoxyActor.lua
@@ -243,7 +243,7 @@ function RoxyActor:addPhysics(body)
   -- Capture the original update method once
   local originalUpdate = self.update
 
-  -- Override only this instance’s update(dt)
+  -- Override only this instance's update(dt)
   function self:update(dt)
     dt = dt or r.deltaTime or 0
 

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -171,7 +171,7 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
       sprite.animation:draw(x, y, flip)
     end
   elseif type(view) == "userdata" then
-    -- If it’s an ImageTable (has drawImage), treat as a simpleAnim
+    -- If it's an ImageTable (has drawImage), treat as a simpleAnim
     if view.drawImage then
       local length = view:getLength()
       self.simpleAnim = {

--- a/core/sprites/roxy_particles.c
+++ b/core/sprites/roxy_particles.c
@@ -259,7 +259,7 @@ int roxy_particles_setImageTable_l(lua_State* L)
         // frameMode (already validated in Lua)
         ps->frameMode   = (FrameMode)pd->lua->getArgInt(3);
 
-        // staticFrame: convert from Lua’s 1-based to C’s 0-based
+        // staticFrame: convert from Lua's 1-based to C's 0-based
         ps->staticFrame = pd->lua->getArgInt(4) - 1;
 
         // loop flag
@@ -609,7 +609,7 @@ int roxy_particles_draw_l(lua_State* L)
                 pd->graphics->fillEllipse(x - size/2, y - size/2, size, size, 0, 360, (LCDColor)fillColorPtr);
                 break;
             case 1: // Outlined circle
-                // outlines don’t support patterns—always solid
+                // outlines don't support patterns—always solid
                 pd->graphics->drawEllipse(x - size/2, y - size/2, size, size, 1, 0, 360, (LCDColor)(intptr_t)color);
                 break;
             case 2: // Filled square

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -678,8 +678,17 @@ end
 
 -- ! Mark Dirty
 -- Public dirty marker for external animation/parallax/etc
-function RoxyIsoTilemap:markDirty()
+function RoxyIsoTilemap:markDirty(redrawBackground)
   self._frameDirty = true
+
+  if redrawBackground == nil then redrawBackground = true end
+  if redrawBackground then
+    if Sprite.redrawBackground then
+      Sprite.redrawBackground()
+    else
+      addDirtyRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
+    end
+  end
 end
 
 -- ! Set Tile At
@@ -796,7 +805,8 @@ function RoxyIsoTilemap:drawVisible()
   local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
   local hasWarmWork = self:_hasWarmWork()
 
-  if cameraUnchanged and not self._frameDirty and not hasWarmWork then
+  -- Do not early-out if this call was explicitly forced by drawVisibleInRect.
+  if (not self._forceDraw) and cameraUnchanged and not self._frameDirty and not hasWarmWork then
     return -- Nothing to do this frame.
   end
 
@@ -822,7 +832,10 @@ end
 -- ! Draw Visible in Rectangle
 function RoxyIsoTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
+    -- Force this particular draw to paint even if the camera did not move.
+    self._forceDraw = true
     self:drawVisible()
+    self._forceDraw = false
   clearClipRect()
 end
 

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -6,16 +6,22 @@ local Sprite    <const> = Graphics.sprite
 
 local r       <const> = roxy
 local Camera  <const> = r.Camera
-local Cache   <const> = r.Cache
+local Cache   <const> = roxy.Cache
 
 local min   <const> = math.min
 local max   <const> = math.max
 local floor <const> = math.floor
 local ceil  <const> = math.ceil
+local abs   <const> = math.abs
 local round <const> = r.Math.round
 
+local stringRep   <const> = string.rep
+local stringPack  <const> = string.pack
+
 local tableInsert <const> = table.insert
+local tableRemove <const> = table.remove
 local tableSort   <const> = table.sort
+local tableUnpack <const> = table.unpack
 
 local pushContext   <const> = Graphics.pushContext
 local popContext    <const> = Graphics.popContext
@@ -23,29 +29,38 @@ local setClipRect   <const> = Graphics.setClipRect
 local clearClipRect <const> = Graphics.clearClipRect
 local newImage      <const> = Graphics.image.new
 local clear         <const> = Graphics.clear
-local setDrawOffset <const> = Graphics.setDrawOffset
-local getDrawOffset <const> = Graphics.getDrawOffset
 
 local addDirtyRect <const> = Sprite.addDirtyRect
 
-local newCacheBucket  <const> = Cache.newBucket
-local getOrLoadAsset  <const> = Cache.getOrLoadAsset
-local evictAsset      <const> = Cache.evictAsset
-local clearCache      <const> = Cache.clearCache
+local newCacheBucket    <const> = Cache.newBucket
+local getIsAssetCached  <const> = Cache.getIsAssetCached
+local getCachedAsset    <const> = Cache.getCachedAsset
+local putAsset          <const> = Cache.putAsset
+local evictAsset        <const> = Cache.evictAsset
+local clearCache        <const> = Cache.clearCache
 
 local getCameraPosition <const> = Camera.getPosition
+local setCameraBounds   <const> = Camera.setBounds
 
 local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+-- C-side bindings
+local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
+
 -- Default chunk settings
-local DEFAULT_CHUNK_SIZE    <const> = 320
+local DEFAULT_CHUNK_SIZE    <const> = 320 -- Adjusted for iso diamond (e.g., tileWidth * 5)
 local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
 
--- Coarse safety margin (in tiles) for dynamic fallback culling
-local TILE_MARGIN <const> = 1
+-- Cull margins / epsilon
+local TILE_MARGIN          <const> = 1 -- Coarse safety margin for dynamic draw
+local VISIBLE_MARGIN_TILES <const> = 2
+local FLOAT_EPSILON        <const> = 0.000001
+
+local PREFETCH_RINGS  <const> = 1  -- 1 ring beyond visible
+local BUILD_BUDGET    <const> = 2  -- Build at most 2 chunks per frame
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
@@ -57,9 +72,11 @@ local COLOR_CLEAR <const> = Graphics.kColorClear
 --------------------------------------------------------------------------------
 
 -- ! Helper: Visible Layer Rectangle
--- Compute visible layer-space rect for clipping/chunk selection
-local function _visibleLayerRect(self, layerData)
-  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+-- Compute visible layer-space rect
+local function _visibleLayerRect(self, layer)
+  local screenX, screenY = self:worldToScreen(0, 0, layer)
+  -- The screen shows [0..width, 0..height] which corresponds to
+  -- layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
   return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
 end
 
@@ -75,14 +92,90 @@ end
 
 -- ! Helper: Find First Available Layer
 local function _findFirstAvailableLayer(layers)
-  for _, layerData in pairs(layers or {}) do
-    if layerData.tilemap then return layerData end
+  for _, layer in pairs(layers or {}) do
+    if layer.tilemap then return layer end
   end
   return nil
 end
 
+-- ! Helper: Pack Tiles U16
+-- Pack tiles as little-endian uint16 with clamping
+local function _packTilesU16(tiles)
+  if not tiles or #tiles == 0 then return nil end
+  local n = #tiles
+  local format = stringRep("<I2", n)
+  local temp = {}
+  for i = 1, n do
+    local v = tiles[i] or 0
+    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
+    temp[i] = v
+  end
+  return stringPack(format, tableUnpack(temp, 1, n))
+end
+
+-- ! Helper: Sanitize a single tile index
+-- Returns 0 for out-of-range/invalid, else the original index (1..imageCount)
+local function _sanitizeTileIndex(tileIndex, imageCount)
+  if tileIndex == nil or type(tileIndex) ~= "number" then return 0 end
+  if tileIndex == 0 then return 0 end
+  if tileIndex < 1 or (imageCount and tileIndex > imageCount) then return 0 end
+  return tileIndex
+end
+
+-- ! Helper: Sanitize tiles in place
+-- Ensures every tile is 0 or in [1..imageCount]
+local function _sanitizeTilesInPlace(tiles, imageCount)
+  if not tiles then return end
+  for i = 1, #tiles do
+    tiles[i] = _sanitizeTileIndex(tiles[i], imageCount)
+  end
+end
+
+-- ! Helper: Sync Native Tiles
+-- Sync native tiles from current tilesFlat
+local function _syncNativeTiles(layerData)
+  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then return end
+  local blob = _packTilesU16(layerData.tilesFlat)
+  if blob then
+    layerData._nativeRenderer:updateTilesBytes(blob)
+    local selfRef = layerData.ownerTilemap
+    if selfRef then selfRef._frameDirty = true end
+  end
+end
+
+-- ! Helper: Warm Score
+-- Warm queue prioritization helper (closest chunk to visible center)
+local function _warmScore(self, job)
+  local layerConfig = job.layerConfig
+  local size = layerConfig.size
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerConfig.layer)
+  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local centerX = (minX + maxX) * 0.5
+  local centerY = (minY + maxY) * 0.5
+  local dx = abs(job.chunkX - centerX)
+  local dy = abs(job.chunkY - centerY)
+  return dx + dy -- Manhattan distance is cheap and good enough
+end
+
+-- ! Helper: Dequeue Best Warm Job
+local function _dequeueBestWarmJob(self)
+  local queue = self._warmQueue
+  local bestIndex, bestScore
+  for idx = 1, #queue do
+    local score = _warmScore(self, queue[idx])
+    if not bestScore or score < bestScore then
+      bestScore, bestIndex = score, idx
+    end
+  end
+  if not bestIndex then return nil end
+  local job = queue[bestIndex]
+  tableRemove(queue, bestIndex)
+  self._warmSet[job.key] = nil
+  return job
+end
+
 --------------------------------------------------------------------------------
--- ! Class Definition and Initialize
+-- Class Definition / Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyIsoTilemap").extends(RoxyTilemap)
@@ -93,19 +186,102 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
   opts.anchor = "topLeft"
   RoxyIsoTilemap.super.init(self, jsonPath, opts, scene)
 
+  -- Override world size for isometric projection
+  local mapWidthTiles   = self.mapWidth  or 0
+  local mapHeightTiles  = self.mapHeight or 0
+  local tileWidth       = self.mapTileWidth or 0
+  local tileHeight      = self.mapTileHeight or 0
+
+  local halfWidthPx   = tileWidth * 0.5
+  local halfHeightPx  = tileHeight * 0.5
+
+  -- Horizontal/vertical span: sum of widths/heights in diamond
+  self.worldWidth = (mapWidthTiles + mapHeightTiles) * halfWidthPx
+
+  -- Vertical span: sum of heights in diamond
+  local worldHeightBase = (mapWidthTiles + mapHeightTiles) * halfHeightPx
+
+  -- Adjust for any tall tiles (maxImageHeight across layers)
+  local maxOverdrawPx = 0
+  for _, layer in pairs(self.layers or {}) do
+    if layer.tilemap then
+      local maxImageHeight = layer.maxImageHeight or 0
+      if maxImageHeight > tileHeight then
+        local over = max(0, (maxImageHeight - tileHeight) * 0.5)
+        if over > maxOverdrawPx then maxOverdrawPx = over end
+      end
+    end
+  end
+  self.worldHeight = worldHeightBase + maxOverdrawPx
+
+  -- Refresh camera bounds if requested
+  if opts and opts.cameraBounds then
+    local x2 = max(0, self.worldWidth - DISPLAY_WIDTH)
+    local y2 = max(0, self.worldHeight - DISPLAY_HEIGHT)
+
+    if type(self.setCameraBounds) == "function" then
+      pcall(function() self:setCameraBounds(0, 0, x2, y2) end)
+    elseif Camera and type(setCameraBounds) == "function" then
+      pcall(function() setCameraBounds({ x1 = 0, y1 = 0, x2 = x2, y2 = y2 }) end)
+    end
+  end
+
   self._projection = "iso"
 
   -- Static / chunk config and ordered layers
   self._staticChunkLayers = {}
   self._orderedLayers = {}
 
+  self._warmQueue = {}  -- Queue of { layerConfig, chunkX, chunkY, key }
+  self._warmSet   = {}  -- Tracks keys already queued
+
+  self._didPrimeVisible = false -- One-time prime flag
+  self._frameDirty = true -- Assume dirty until first frame settles
+  self._lastCameraX, self._lastCameraY = nil, nil -- Camera stamp
+
   -- Map-scoped cache key namespace
   self._mapCacheId = jsonPath or tostring(self)
 
   self:_initializeStaticLayers(opts)
+
   for _, layerData in pairs(self.layers) do
     if layerData.tilemap then
       self:_preloadLayerCaches(layerData)
+
+      -- Create native renderer instance for this layer
+      if layerData.imageTable and newTileRenderer_C then
+        -- Sanitize tiles once on load so the native blob never sees out-of-range values
+        _sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+
+        local isIsometric = 1
+        local staggerIndexOdd = 0
+        local staggerDirectionRight = 0
+
+        --#DEBUG START
+        if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
+           or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
+          Log.error("[RoxyIsoTilemap] Invalid tile metrics; width/height/halves must be > 0")
+        end
+        --#DEBUG END
+
+        layerData._nativeRenderer = newTileRenderer_C(
+          isIsometric,
+          staggerIndexOdd,
+          staggerDirectionRight,
+          layerData.mapWidth,       -- Tiles
+          layerData.mapHeight,      -- Tiles
+          layerData.tileWidth,      -- px
+          layerData.tileHeight,     -- px
+          layerData.halfWidth,      -- px
+          layerData.halfHeight,     -- px
+          layerData.maxImageHeight, -- Tall art overdraw
+          layerData.imageTable,     -- LCDBitmapTable
+          layerData.imageCount,     -- Frames in table
+          nil                       -- Optional tiles blob
+        )
+        layerData.ownerTilemap = self
+        _syncNativeTiles(layerData)
+      end
     end
   end
 
@@ -113,96 +289,203 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
 end
 
 --------------------------------------------------------------------------------
--- Static Layer Configuration
+-- Internal API
 --------------------------------------------------------------------------------
 
--- ! Utility: Initialize Static Layers
+--
+-- Static Layer Configuration
+--
+
+-- ! Initialize Static Layers
+-- Build chunk/static configuration per layer
 function RoxyIsoTilemap:_initializeStaticLayers(opts)
   local layerOptions = (opts and opts.layerOptions) or {}
   local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
 
-  -- One shared bucket for all chunk images on this map
   self._globalChunkBucket = newCacheBucket(totalChunkCache)
 
-  for layerName, layerData in pairs(self.layers) do
-    local lopts = layerOptions[layerName] or {}
-    if lopts.preRenderChunked then
+  for layerName, layer in pairs(self.layers) do
+    local layerOpts = layerOptions[layerName] or {}
+    if layerOpts.preRenderChunked then
+      local halfWidth = layer.halfWidth or floor((layer.tileWidth or DEFAULT_TILE_WIDTH) * 0.5)
+
+      local tallOverdraw = 0
+      if layer.maxImageHeight and layer.tileHeight then
+        tallOverdraw = max(0, ceil((layer.maxImageHeight - layer.tileHeight) * 0.5))
+      end
+
+      local overlap = layerOpts.overlapPx or max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+
       self._staticChunkLayers[layerName] = {
         name      = layerName,
-        layer     = layerData,
-        size      = max(1, lopts.chunkSizePx or DEFAULT_CHUNK_SIZE),
-        overlap   = lopts.overlapPx or DEFAULT_CHUNK_OVERLAP,
-        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
-                    tostring(layerData.tiledId or layerName) .. ":",
+        layer     = layer,
+        size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
+        overlap   = overlap,
+        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
+        _dirty    = true, -- Per-layer dirty bit
       }
     end
   end
 end
 
--- ! Utility: Rebuild Ordered Layers (z-sorted)
+-- ! Prime Visible Chunks
+-- Build currently visible chunks once to avoid first-frame misses
+function RoxyIsoTilemap:_primeVisibleChunks()
+  if self._didPrimeVisible then return end
+  for _, layerConfig in pairs(self._staticChunkLayers) do
+    local layer = layerConfig.layer
+    local size, overlap = layerConfig.size, layerConfig.overlap
+
+    local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+    visibleX -= overlap; visibleY -= overlap; visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
+
+    local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    for chunkY = minY, maxY do
+      for chunkX = minX, maxX do
+        local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+        if not getIsAssetCached(self._globalChunkBucket, key) then
+          self:_enqueueWarm(layerConfig, chunkX, chunkY)
+        end
+      end
+    end
+  end
+  self._didPrimeVisible = true
+  self._frameDirty = true
+end
+
+-- ! Rebuild Ordered Layers
+-- Build a stable, z-sorted draw list (rarely changes)
 function RoxyIsoTilemap:_rebuildOrderedLayers()
   local items = {}
-  for name, layerData in pairs(self.layers) do
-    if layerData.tilemap and layerData.visible ~= false then
+  for name, layer in pairs(self.layers) do
+    if layer.tilemap and layer.visible ~= false then
       local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
-      tableInsert(items, { layer = layerData, name = name, type = renderType, z = layerData.zIndex or 0 })
+      tableInsert(items, { layer = layer, name = name, type = renderType, z = layer.zIndex or 0 })
     end
   end
   tableSort(items, function(a, b) return a.z < b.z end)
   self._orderedLayers = items
 end
 
--- ! Utility: Preload Layer Caches
+-- ! Preload Layer Caches
 function RoxyIsoTilemap:_preloadLayerCaches(layerData)
-  if not layerData.imageTable or not layerData.tileWidth or not layerData.tileHeight then return end
+  layerData._imageCache  = layerData._imageCache  or {}
+  layerData._offsetCache = layerData._offsetCache or {}
+end
 
-  local n = layerData.imageCount
-  layerData._imageCache = {} -- Overwrite if exists to ensure fresh
-  layerData._offsetCache = {}
+--
+-- Chunk building & warming
+--
 
-  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+-- ! Enqueue Warm
+function RoxyIsoTilemap:_enqueueWarm(layerConfig, chunkX, chunkY)
+  local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+  if self._warmSet[key] then return end
+  self._warmSet[key] = true
+  self._warmQueue[#self._warmQueue + 1] = {
+    layerConfig = layerConfig,
+    chunkX = chunkX,
+    chunkY = chunkY,
+    key = key
+  }
+end
 
-  for i = 1, n do
-    local img = layerData.imageTable:getImage(i)
-    if img then
-      layerData._imageCache[i] = img
-      local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
-      layerData._offsetCache[i] = offsetX
-      layerData._offsetCache[i + 0.5] = offsetY
+-- ! Warm Some Chunks
+-- Amortize chunk builds across frames
+function RoxyIsoTilemap:_warmSomeChunks()
+  local built = 0
+  while built < BUILD_BUDGET and #self._warmQueue > 0 do
+    local job = _dequeueBestWarmJob(self) -- Pick closest
+    if not job then break end
+    if not getIsAssetCached(self._globalChunkBucket, job.key) then
+      local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
+      if img then
+        putAsset(self._globalChunkBucket, job.key, img)
+        built += 1
+      end
+    end
+  end
+
+  if built > 0 then
+    self._frameDirty = true
+  end
+end
+
+-- ! Has Warm Work
+-- True when there are chunks waiting to build
+function RoxyIsoTilemap:_hasWarmWork()
+  return self._warmQueue and #self._warmQueue > 0
+end
+
+-- ! Build Chunk
+function RoxyIsoTilemap:_buildChunk(layerConfig, chunkX, chunkY)
+  local size, overlap = layerConfig.size, layerConfig.overlap
+  local width, height = size + 2 * overlap, size + 2 * overlap
+  local img = newImage(width, height)
+  if not img then
+    -- Low-memory guard
+    Log.warn("[RoxyIsoTilemap] Failed to allocate chunk image (%dx%d)", width, height)
+    return nil
+  end
+
+  local pixelX = chunkX * size - overlap
+  local pixelY = chunkY * size - overlap
+
+  pushContext(img)
+    setClipRect(0, 0, width, height)
+    clear(COLOR_CLEAR)
+    self:_renderLayerToBuffer(layerConfig.layer, img, -pixelX, -pixelY, width, height)
+    clearClipRect()
+  popContext()
+  return img
+end
+
+-- ! Enqueue Ring
+function RoxyIsoTilemap:_enqueueRing(layerData, layerConfig)
+  local size, overlap = layerConfig.size, layerConfig.overlap
+
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  visibleX -= (overlap + size * PREFETCH_RINGS)
+  visibleY -= (overlap + size * PREFETCH_RINGS)
+  visibleWidth  += 2 * (overlap + size * PREFETCH_RINGS)
+  visibleHeight += 2 * (overlap + size * PREFETCH_RINGS)
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+
+  -- Skip if ring bounds didn’t change
+  local last = layerConfig._lastRingBounds
+  if last
+    and last.minX == minChunkX and last.maxX == maxChunkX
+    and last.minY == minChunkY and last.maxY == maxChunkY
+  then
+    return
+  end
+  layerConfig._lastRingBounds = { minX = minChunkX, maxX = maxChunkX, minY = minChunkY, maxY = maxChunkY }
+
+  for chunkY = minChunkY, maxChunkY do
+    for chunkX = minChunkX, maxChunkX do
+      local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+      if not getIsAssetCached(self._globalChunkBucket, key) then
+        self:_enqueueWarm(layerConfig, chunkX, chunkY)
+      end
     end
   end
 end
 
---------------------------------------------------------------------------------
--- Chunk building & drawing
---------------------------------------------------------------------------------
+-- ! Render Layer to Buffer
+function RoxyIsoTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
+  local nativeRenderer = layerData._nativeRenderer
 
--- ! Utility: Get or Build Chunk
-function RoxyIsoTilemap:_getOrBuildChunk(layerCfg, chunkX, chunkY)
-  local key = layerCfg.keyPrefix .. chunkX .. ":" .. chunkY
-  return getOrLoadAsset(self._globalChunkBucket, key, function()
-    local size, overlap = layerCfg.size, layerCfg.overlap
-    local width, height = size + 2 * overlap, size + 2 * overlap
-    local img = newImage(width, height)
+  -- Fast path: native renderer to a real LCDBitmap
+  if nativeRenderer and targetImage ~= nil then
+    nativeRenderer:renderToBuffer(targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
+    return
+  end
 
-    -- Convert chunk indices to layer pixel origin for this chunk
-    local pixelX = chunkX * size - overlap
-    local pixelY = chunkY * size - overlap
+  -- Fallback Lua implementation (rare in practice)
+  Log.debug("[_renderLayerToBuffer] Falling back on Lua implementation") --#DEBUG
 
-    pushContext(img)
-      setClipRect(0, 0, width, height)
-      clear(COLOR_CLEAR)
-      self:_renderLayerToBuffer(layerCfg.layer, -pixelX, -pixelY, width, height)
-      clearClipRect()
-    popContext()
-
-    return img
-  end)
-end
-
--- ! Utility: Render Layer to Buffer
--- Render a layer directly to a buffer context (in layer-local coordinates)
-function RoxyIsoTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, bufferWidth, bufferHeight)
   local imageTable = layerData.imageTable
   local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
   if not mapWidth or not mapHeight or not imageTable then return end
@@ -211,15 +494,8 @@ function RoxyIsoTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffer
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  -- Use the canonical field name for tall art margin
   local maxImageHeight = layerData.maxImageHeight or 0
-  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1
-
-  -- Determine the iso rows/cols that can touch this buffer
-  -- Using iso formulas:
-  -- screenX = originX + (worldX - worldY) * halfWidth  (originX cancels due to offset application)
-  -- screenY = originY + (worldX + worldY) * halfHeight
-  -- We step by integer worldX/worldY (tile coords)
+  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1 -- Safety +1
 
   -- Conservative bounds in world space:
   local minWorldX = floor((-offsetX) / halfWidth) - (overdrawRows + 2)
@@ -234,16 +510,14 @@ function RoxyIsoTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffer
   local maxTileX = min(mapWidth  - 1, maxWorldX)
 
   local tiles  = layerData.tilesFlat
-  local stride = layerData.tilesStride or mapWidth
+  local stride = layerData.tilesStride or mapWidth  -- Restore fallback
 
-  -- Per-tile offset cache (avoid repeated _isoDrawOffsets calls)
   local offsetCache = layerData._offsetCache
   if not offsetCache then
     offsetCache = {}
     layerData._offsetCache = offsetCache
   end
 
-  -- Per-tile image cache (avoid imageTable:getImage repeats)
   local imageCache = layerData._imageCache
   if not imageCache then
     imageCache = {}
@@ -287,49 +561,74 @@ function RoxyIsoTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffer
   end
 end
 
--- ! Utility: Draw Static Layer Chunked
+--
+-- Chunked draw (with single-pass fallback)
+--
+
+-- ! Draw Static Layer Chunked
+-- Render a chunked layer using prebuilt chunk images (row-clipped fallback)
 function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
-  local config = self._staticChunkLayers[layerName]
-  if not config then return end
+  local layerConfig = self._staticChunkLayers[layerName]
+  if not layerConfig then return end
 
-  local layerData = config.layer
-  local size    = config.size
-  local overlap = config.overlap
+  local layer         = layerConfig.layer
+  local size, overlap = layerConfig.size, layerConfig.overlap
 
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  -- Visible rect in layer coords, padded by overlap.
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
   visibleX -= overlap; visibleY -= overlap
   visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-  local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local screenX, screenY = self:worldToScreen(0, 0, layer)
 
-  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+  -- First pass — scan for any missing chunks and enqueue builds.
+  local anyMissing = false
+  local toDraw = {} -- {img, dx, dy, imageWidth, imageHeight}
+  local imageWidth, imageHeight = size + 2 * overlap, size + 2 * overlap
 
-  for chunkY = minChunkY, maxChunkY do
-    local rowDestY = chunkY * size - overlap + screenY
-    for chunkX = minChunkX, maxChunkX do
-      local img = self:_getOrBuildChunk(config, chunkX, chunkY)
+  for chunkY = minY, maxY do
+    local rowDeltaY = chunkY * size - overlap + screenY
+    for chunkX = minX, maxX do
+      local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+      local img = getCachedAsset(self._globalChunkBucket, key)
       if img then
-        local destX = chunkX * size - overlap + screenX
-        local destY = rowDestY
-
-        local imageWidth, imageHeight = img:getSize()
-        if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
-             or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
-          img:draw(destX, destY)
+        local dx = chunkX * size - overlap + screenX
+        local dy = rowDeltaY
+        -- Offscreen culling
+        if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
+          toDraw[#toDraw + 1] = { img = img, dx = dx, dy = dy } -- ints already
         end
+      else
+        anyMissing = true
+        self:_enqueueWarm(layerConfig, chunkX, chunkY)
       end
     end
   end
+
+  if anyMissing then
+    -- Single-pass fallback — render the layer once (native rows or Lua), not per-miss.
+    -- Clip to screen to be safe.
+    setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
+      self:drawLayerRows(layerName, nil, nil, nil, nil)
+    clearClipRect()
+    return
+  end
+
+  -- All chunks available — draw them.
+  for index = 1, #toDraw do
+    local element = toDraw[index]
+    -- dx/dy are already integers; removed floor() for tiny win.
+    element.img:draw(element.dx, element.dy)
+  end
 end
 
---------------------------------------------------------------------------------
+--
 -- Projection (classic diamond isometric)
--- screenX = originX + (worldX - worldY) * (tileWidth  * 0.5)
--- screenY = originY + (worldX + worldY) * (tileHeight * 0.5)
---------------------------------------------------------------------------------
+--
 
 -- ! World to Screen
+-- Convert world coordinates to screen coordinates with parallax support
 function RoxyIsoTilemap:worldToScreen(worldX, worldY, layerData)
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
@@ -351,6 +650,7 @@ function RoxyIsoTilemap:worldToScreen(worldX, worldY, layerData)
 end
 
 -- ! Screen to World
+-- Convert screen coordinates to world coordinates with parallax support.
 function RoxyIsoTilemap:screenToWorld(screenX, screenY, layerData)
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
@@ -372,44 +672,61 @@ function RoxyIsoTilemap:screenToWorld(screenX, screenY, layerData)
   return worldX, worldY
 end
 
-
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
 
+-- ! Mark Dirty
+-- Public dirty marker for external animation/parallax/etc
+function RoxyIsoTilemap:markDirty()
+  self._frameDirty = true
+end
+
 -- ! Set Tile At
+-- Override setTileAt to handle static layer updates
 function RoxyIsoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
-  local layerData = self.layers and self.layers[layerName]
-  if not layerData then return end
+  local layer = self.layers and self.layers[layerName]
+  if not layer then return end
 
-  layerData.tilemap:setTileAtPosition(x, y, tileIndex)
+  -- CHANGE: explicit bounds check to avoid native issues
+  local mapWidth, mapHeight = layer.mapWidth or 0, layer.mapHeight or 0
+  if x < 1 or y < 1 or x > mapWidth or y > mapHeight then
+    Log.warn("[RoxyIsoTilemap] setTileAt out of bounds (".. x .. ", ".. y .. ") not in [1..".. mapWidth .. ",1.." .. mapHeight .."]") --#DEBUG
+    return
+  end
 
-  -- Update cached flat data used by dynamic paths
-  local tiles = layerData.tilesFlat
+  local cleanIndex = _sanitizeTileIndex(tileIndex, layer.imageCount)
+
+  layer.tilemap:setTileAtPosition(x, y, cleanIndex)
+
+  local tiles = layer.tilesFlat
   if tiles then
-    local stride = layerData.tilesStride or layerData.mapWidth
+    local stride = layer.tilesStride or layer.mapWidth
     if stride and stride > 0 then
-      local idx = (y - 1) * stride + x
-      if idx >= 1 and idx <= #tiles then
-        tiles[idx] = tileIndex
+      local index = (y - 1) * stride + x
+      if index >= 1 and index <= #tiles then
+        tiles[index] = cleanIndex
       end
     end
   end
 
-  -- Evict any overlapping chunks so they rebuild lazily
+  local nativeRenderer = layer._nativeRenderer
+  if nativeRenderer then
+    nativeRenderer:setTileAt(x, y, cleanIndex)
+  end
+
   if self._staticChunkLayers[layerName] then
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
 
-  if updateSprite and layerData.imageTable then
-    local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
-    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layerData)
+  if updateSprite and layer.imageTable then
+    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
     addDirtyRect(screenX, screenY, tileWidth, tileHeight)
   end
 end
 
 -- ! Get Row From Screen
--- Convert a screen pixel to a 1-based row (tileY)
 function RoxyIsoTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
@@ -430,24 +747,24 @@ function RoxyIsoTilemap:resortLayers()
 end
 
 -- ! Mark Tiles Dirty
--- Evict any chunks overlapped by the edited tile region
+-- Tile edits --> evict overlapping chunks (they will rebuild lazily)
 function RoxyIsoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
-  local cfg = self._staticChunkLayers[layerName]
-  if not cfg then return end
+  local layerConfig = self._staticChunkLayers[layerName]
+  if not layerConfig then return end
 
-  local tileWidth, tileHeight = cfg.layer.tileWidth, cfg.layer.tileHeight
+  self._frameDirty = true
+
+  local tileWidth, tileHeight = layerConfig.layer.tileWidth, layerConfig.layer.tileHeight
   local pixelX = (tileX - 1) * (tileWidth * 0.5) * 2
   local pixelY = (tileY - 1) * (tileHeight * 0.5)
-
-  local pixelWidth  = (tileCountWidth  or 1) * tileWidth
+  local pixelWidth = (tileCountWidth or 1) * tileWidth
   local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, cfg.size)
-
-  for cy = minChunkY, maxChunkY do
-    for cx = minChunkX, maxChunkX do
-      evictAsset(self._globalChunkBucket, cfg.keyPrefix .. cx .. ":" .. cy)
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
+  for chunkY = minChunkY, maxChunkY do
+    for chunkX = minChunkX, maxChunkX do
+      evictAsset(self._globalChunkBucket, layerConfig.keyPrefix .. chunkX .. ":" .. chunkY)
     end
   end
 end
@@ -457,12 +774,13 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
--- Draw a single tile layer with conservative vertical culling
+-- Draw a single layer (chunked or dynamic fallback)
 function RoxyIsoTilemap:draw(layerName)
-  if self._staticChunkLayers and self._staticChunkLayers[layerName] then
+  if self._staticChunkLayers[layerName] then
     self:_drawStaticLayerChunked(layerName); return
   end
 
+  -- Dynamic fallback (rare): draw only visible rows/cols with coarse margin
   local layerData = self.layers and self.layers[layerName]
   if not layerData or not layerData.tilemap or layerData.visible == false then return end
 
@@ -472,37 +790,36 @@ function RoxyIsoTilemap:draw(layerName)
 end
 
 -- ! Draw Visible
--- Draw all visible tile layers sorted by z-index
+-- Draw all visible layers in z-order, with smart skipping
 function RoxyIsoTilemap:drawVisible()
-  -- Keep ordered layers if you have them; otherwise, iterate layers
-  local list = self._orderedLayers
-  if list and #list > 0 then
-    for i = 1, #list do
-      local item = list[i]
-      if item.type == "chunked" then
-        self:_drawStaticLayerChunked(item.name)
-      else
-        local layerData = item.layer
-        if layerData.tilemap and layerData.visible ~= false then
-          local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
-          self:drawLayerRows(item.name, minTileY, maxTileY, minTileX, maxTileX)
-        end
-      end
-    end
-    return
+  local cameraX, cameraY = getCameraPosition()
+  local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
+  local hasWarmWork = self:_hasWarmWork()
+
+  if cameraUnchanged and not self._frameDirty and not hasWarmWork then
+    return -- Nothing to do this frame.
   end
 
-  -- Fallback if ordered list isn't used
-  for name, layerData in pairs(self.layers or {}) do
-    if layerData.tilemap and layerData.visible ~= false then
-      local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
-      self:drawLayerRows(name, minTileY, maxTileY, minTileX, maxTileX)
+  self._lastCameraX, self._lastCameraY = cameraX, cameraY
+  self._frameDirty = false -- We will render now; clear until something changes again
+
+  self:_primeVisibleChunks()
+
+  local ordered = self._orderedLayers
+  for i = 1, #ordered do
+    local item = ordered[i]
+    if item.type == "chunked" then
+      self:_enqueueRing(item.layer, self._staticChunkLayers[item.name])
+      self:_drawStaticLayerChunked(item.name)
+    else
+      self:draw(item.name)
     end
   end
+
+  self:_warmSomeChunks()
 end
 
 -- ! Draw Visible in Rectangle
--- Clip helper for UI overlays, etc.
 function RoxyIsoTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
     self:drawVisible()
@@ -510,6 +827,7 @@ function RoxyIsoTilemap:drawVisibleInRect(x, y, width, height)
 end
 
 -- ! Draw Layer Rows
+-- Dynamic row/column renderer with manual sprite positioning
 function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxColumn)
   local restoreX, restoreY = _beginManualDraw()
 
@@ -517,6 +835,50 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
   if not layerData or not layerData.tilemap or layerData.visible == false then
     _endManualDraw(restoreX, restoreY); return
   end
+
+  -- Fast path: native renderer draws rows directly
+  if RoxyTileRendererC and layerData._nativeRenderer then
+    local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+    local rowStart = max(1, minRow or 1)
+    local rowEnd   = min(mapHeight, maxRow or mapHeight)
+    if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
+
+    local minX, maxX
+    if minColumn and maxColumn then
+      minX = max(1, minColumn)
+      maxX = min(mapWidth, maxColumn)
+    else
+      local x1, _, x2, _ = self:getVisibleTileBounds(layerData)
+      minX, maxX = x1, x2
+    end
+    if minX > maxX then _endManualDraw(restoreX, restoreY); return end
+
+    local originX, originY      = layerData.originX or 0, layerData.originY or 0
+    local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
+    local parallaxOriginX       = layerData.parallaxoriginx or 0
+    local parallaxOriginY       = layerData.parallaxoriginy or 0
+    local cameraX, cameraY      = getCameraPosition()
+
+    local tr = layerData._nativeRenderer
+    if tr then
+      tr:drawRows(
+        rowStart, rowEnd,
+        minX, maxX,
+        originX, originY,
+        parallaxX, parallaxY,
+        parallaxOriginX, parallaxOriginY,
+        cameraX, cameraY
+      )
+      _endManualDraw(restoreX, restoreY)
+      return
+    end
+  end
+
+  --
+  -- Fallback Lua Implementation
+  --
+
+  Log.debug("[drawLayerRows] Falling back on Lua implementation") --#DEBUG
 
   local imageTable = layerData.imageTable
   if not imageTable then
@@ -528,7 +890,7 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
 
   local rowStart = max(1, minRow or 1)
-  local rowEnd   = min(mapHeight, maxRow or mapHeight)
+  local rowEnd = min(mapHeight, maxRow or mapHeight)
   if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
 
   local minX, maxX
@@ -536,17 +898,18 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
     minX = max(1, minColumn)
     maxX = min(mapWidth, maxColumn)
   else
-    -- Ask base class for safe visible bounds
-    -- Only take X since rows are fixed above
-    local visibleX1, visibleY1, visibleX2, visibleY2 = self:getVisibleTileBounds(layerData)
-    minX = visibleX1; maxX = visibleX2
+    local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
+    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
+    local minWorldX = floor(min(leftWorld, rightWorld)) - VISIBLE_MARGIN_TILES
+    local maxWorldX = ceil (max(leftWorld, rightWorld)) + VISIBLE_MARGIN_TILES
+    minX = max(1, minWorldX + 1)
+    maxX = min(mapWidth, maxWorldX + 1)
   end
   if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
-  local tiles  = layerData.tilesFlat
-  local stride = layerData.tilesStride
+  local tiles = layerData.tilesFlat
+  local stride = layerData.tilesStride or mapWidth
 
-  -- Hoisted transforms
   local originX, originY      = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
   local parallaxOriginX       = layerData.parallaxoriginx or 0
@@ -578,19 +941,17 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
           img = imageTable:getImage(tileIndex)
           layerData._imageCache[tileIndex] = img
         end
-
         if img then
-          local offX = layerData._offsetCache[tileIndex]
-          local offY
-          if not offX then
-            offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-            layerData._offsetCache[tileIndex] = offX
-            layerData._offsetCache[tileIndex + 0.5] = offY
+          local offsetX = layerData._offsetCache[tileIndex]
+          local offsetY
+          if not offsetX then
+            offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+            layerData._offsetCache[tileIndex] = offsetX
+            layerData._offsetCache[tileIndex + 0.5] = offsetY
           else
-            offY = layerData._offsetCache[tileIndex + 0.5]
+            offsetY = layerData._offsetCache[tileIndex + 0.5]
           end
-
-          img:draw(currentX + offX, currentY + offY)
+          img:draw(currentX + offsetX, currentY + offsetY)
         end
       end
 
@@ -609,13 +970,23 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Destroy
--- Clear chunk bucket as well as per-layer references
+-- Clean up static layer resources
 function RoxyIsoTilemap:destroy()
+  -- Destroy native renderers first
+  for _, layerData in pairs(self.layers or {}) do
+    if layerData._nativeRenderer then
+      layerData._nativeRenderer:destroy()
+      layerData._nativeRenderer = nil
+    end
+  end
+
   if self._globalChunkBucket then
     clearCache(self._globalChunkBucket)
     self._globalChunkBucket = nil
   end
+
   self._staticChunkLayers = {}
   self._orderedLayers = {}
+
   RoxyIsoTilemap.super.destroy(self)
 end

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -175,7 +175,7 @@ local function _dequeueBestWarmJob(self)
 end
 
 --------------------------------------------------------------------------------
--- Class Definition / Initialize
+-- ! Class Definition / Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyIsoTilemap").extends(RoxyTilemap)
@@ -237,6 +237,7 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
 
   self._didPrimeVisible = false -- One-time prime flag
   self._frameDirty = true -- Assume dirty until first frame settles
+  self._forceDrawFrames = 0 -- Track a small "force draw" window for explicit repaints
   self._lastCameraX, self._lastCameraY = nil, nil -- Camera stamp
 
   -- Map-scoped cache key namespace
@@ -453,7 +454,7 @@ function RoxyIsoTilemap:_enqueueRing(layerData, layerConfig)
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
     _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
 
-  -- Skip if ring bounds didn’t change
+  -- Skip if ring bounds didn't change
   local last = layerConfig._lastRingBounds
   if last
     and last.minX == minChunkX and last.maxX == maxChunkX
@@ -805,13 +806,18 @@ function RoxyIsoTilemap:drawVisible()
   local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
   local hasWarmWork = self:_hasWarmWork()
 
-  -- Do not early-out if this call was explicitly forced by drawVisibleInRect.
-  if (not self._forceDraw) and cameraUnchanged and not self._frameDirty and not hasWarmWork then
+  -- Do not early-out if we are within a forced-draw window
+  if (self._forceDrawFrames or 0) == 0 and cameraUnchanged and not self._frameDirty and not hasWarmWork then
     return -- Nothing to do this frame.
   end
 
   self._lastCameraX, self._lastCameraY = cameraX, cameraY
   self._frameDirty = false -- We will render now; clear until something changes again
+
+  -- Consume one forced frame if active
+  if self._forceDrawFrames and self._forceDrawFrames > 0 then
+    self._forceDrawFrames -= 1
+  end
 
   self:_primeVisibleChunks()
 
@@ -832,11 +838,24 @@ end
 -- ! Draw Visible in Rectangle
 function RoxyIsoTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
-    -- Force this particular draw to paint even if the camera did not move.
-    self._forceDraw = true
+    -- Force this paint to occur at least this frame
+    -- This does not make the renderer "always repaint"
+    -- It is one-shot unless bumped again
+    local n = (self._forceDrawFrames or 0)
+    if n < 1 then self._forceDrawFrames = 1 end
+
     self:drawVisible()
-    self._forceDraw = false
   clearClipRect()
+end
+
+-- ! Force Redraw
+-- Request forced redraws for N frames (e.g., 1–2 frames around transition end)
+function RoxyIsoTilemap:forceRedraw(frames)
+  -- Keep the largest pending window; do not shrink an existing request
+  local n = max(0, frames or 1)
+  if (self._forceDrawFrames or 0) < n then
+    self._forceDrawFrames = n
+  end
 end
 
 -- ! Draw Layer Rows

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -1,11 +1,12 @@
 -- core/tilemaps/RoxyIsoTilemap.lua
--- Classic diamond isometric tilemaps for Roxy (no stagger logic).
 
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
+local Sprite    <const> = Graphics.sprite
 
 local r       <const> = roxy
 local Camera  <const> = r.Camera
+local Cache   <const> = r.Cache
 
 local min   <const> = math.min
 local max   <const> = math.max
@@ -16,8 +17,21 @@ local round <const> = r.Math.round
 local tableInsert <const> = table.insert
 local tableSort   <const> = table.sort
 
+local pushContext   <const> = Graphics.pushContext
+local popContext    <const> = Graphics.popContext
+local setClipRect   <const> = Graphics.setClipRect
+local clearClipRect <const> = Graphics.clearClipRect
+local newImage      <const> = Graphics.image.new
+local clear         <const> = Graphics.clear
 local setDrawOffset <const> = Graphics.setDrawOffset
 local getDrawOffset <const> = Graphics.getDrawOffset
+
+local addDirtyRect <const> = Sprite.addDirtyRect
+
+local newCacheBucket  <const> = Cache.newBucket
+local getOrLoadAsset  <const> = Cache.getOrLoadAsset
+local evictAsset      <const> = Cache.evictAsset
+local clearCache      <const> = Cache.clearCache
 
 local getCameraPosition <const> = Camera.getPosition
 
@@ -25,30 +39,46 @@ local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+-- Default chunk settings
+local DEFAULT_CHUNK_SIZE    <const> = 320
+local DEFAULT_CHUNK_CACHE   <const> = 200
+local DEFAULT_CHUNK_OVERLAP <const> = 32
+
+-- Coarse safety margin (in tiles) for dynamic fallback culling
+local TILE_MARGIN <const> = 1
+
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+
+local COLOR_CLEAR <const> = Graphics.kColorClear
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
--- Helper to compute and cache max image height for the layer
-local function _getMaxImgH(layer)
-  if layer._maxImgH then return layer._maxImgH end
-  local imagetable = layer.imageTable
-  local imagetableLength = imagetable and imagetable:getLength() or 0
-  local maxH = layer.tileHeight or 0
-  for i = 1, imagetableLength do
-    local img = imagetable:getImage(i)
-    if img then
-      local _, height = img:getSize()
-      if height and height > maxH then
-        maxH = height
-      end
-    end
+-- ! Helper: Visible Layer Rectangle
+-- Compute visible layer-space rect for clipping/chunk selection
+local function _visibleLayerRect(self, layerData)
+  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
+end
+
+-- ! Helper: Chunk Indices for Rect
+-- Which chunk indices intersect a pixel rect?
+local function _chunkIndicesForRect(x, y, width, height, size)
+  local minChunkX = floor(x / size)
+  local maxChunkX = floor((x + width  - 1) / size)
+  local minChunkY = floor(y / size)
+  local maxChunkY = floor((y + height - 1) / size)
+  return minChunkX, maxChunkX, minChunkY, maxChunkY
+end
+
+-- ! Helper: Find First Available Layer
+local function _findFirstAvailableLayer(layers)
+  for _, layerData in pairs(layers or {}) do
+    if layerData.tilemap then return layerData end
   end
-  layer._maxImgH = maxH
-  return maxH
+  return nil
 end
 
 --------------------------------------------------------------------------------
@@ -63,8 +93,234 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
   opts.anchor = "topLeft"
   RoxyIsoTilemap.super.init(self, jsonPath, opts, scene)
 
-  -- Mark the projection for clarity/debugging
   self._projection = "iso"
+
+  -- Static / chunk config and ordered layers
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
+
+  -- Map-scoped cache key namespace
+  self._mapCacheId = jsonPath or tostring(self)
+
+  self:_initializeStaticLayers(opts)
+  for _, layerData in pairs(self.layers) do
+    if layerData.tilemap then
+      self:_preloadLayerCaches(layerData)
+    end
+  end
+
+  self:_rebuildOrderedLayers()
+end
+
+--------------------------------------------------------------------------------
+-- Static Layer Configuration
+--------------------------------------------------------------------------------
+
+-- ! Utility: Initialize Static Layers
+function RoxyIsoTilemap:_initializeStaticLayers(opts)
+  local layerOptions = (opts and opts.layerOptions) or {}
+  local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
+
+  -- One shared bucket for all chunk images on this map
+  self._globalChunkBucket = newCacheBucket(totalChunkCache)
+
+  for layerName, layerData in pairs(self.layers) do
+    local lopts = layerOptions[layerName] or {}
+    if lopts.preRenderChunked then
+      self._staticChunkLayers[layerName] = {
+        name      = layerName,
+        layer     = layerData,
+        size      = max(1, lopts.chunkSizePx or DEFAULT_CHUNK_SIZE),
+        overlap   = lopts.overlapPx or DEFAULT_CHUNK_OVERLAP,
+        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
+                    tostring(layerData.tiledId or layerName) .. ":",
+      }
+    end
+  end
+end
+
+-- ! Utility: Rebuild Ordered Layers (z-sorted)
+function RoxyIsoTilemap:_rebuildOrderedLayers()
+  local items = {}
+  for name, layerData in pairs(self.layers) do
+    if layerData.tilemap and layerData.visible ~= false then
+      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
+      tableInsert(items, { layer = layerData, name = name, type = renderType, z = layerData.zIndex or 0 })
+    end
+  end
+  tableSort(items, function(a, b) return a.z < b.z end)
+  self._orderedLayers = items
+end
+
+-- ! Utility: Preload Layer Caches
+function RoxyIsoTilemap:_preloadLayerCaches(layerData)
+  if not layerData.imageTable or not layerData.tileWidth or not layerData.tileHeight then return end
+
+  local n = layerData.imageCount
+  layerData._imageCache = {} -- Overwrite if exists to ensure fresh
+  layerData._offsetCache = {}
+
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+
+  for i = 1, n do
+    local img = layerData.imageTable:getImage(i)
+    if img then
+      layerData._imageCache[i] = img
+      local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+      layerData._offsetCache[i] = offsetX
+      layerData._offsetCache[i + 0.5] = offsetY
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Chunk building & drawing
+--------------------------------------------------------------------------------
+
+-- ! Utility: Get or Build Chunk
+function RoxyIsoTilemap:_getOrBuildChunk(layerCfg, chunkX, chunkY)
+  local key = layerCfg.keyPrefix .. chunkX .. ":" .. chunkY
+  return getOrLoadAsset(self._globalChunkBucket, key, function()
+    local size, overlap = layerCfg.size, layerCfg.overlap
+    local width, height = size + 2 * overlap, size + 2 * overlap
+    local img = newImage(width, height)
+
+    -- Convert chunk indices to layer pixel origin for this chunk
+    local pixelX = chunkX * size - overlap
+    local pixelY = chunkY * size - overlap
+
+    pushContext(img)
+      setClipRect(0, 0, width, height)
+      clear(COLOR_CLEAR)
+      self:_renderLayerToBuffer(layerCfg.layer, -pixelX, -pixelY, width, height)
+      clearClipRect()
+    popContext()
+
+    return img
+  end)
+end
+
+-- ! Utility: Render Layer to Buffer
+-- Render a layer directly to a buffer context (in layer-local coordinates)
+function RoxyIsoTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, bufferWidth, bufferHeight)
+  local imageTable = layerData.imageTable
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  if not mapWidth or not mapHeight or not imageTable then return end
+
+  local n = layerData.imageCount
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
+
+  -- Use the canonical field name for tall art margin
+  local maxImageHeight = layerData.maxImageHeight or 0
+  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1
+
+  -- Determine the iso rows/cols that can touch this buffer
+  -- Using iso formulas:
+  -- screenX = originX + (worldX - worldY) * halfWidth  (originX cancels due to offset application)
+  -- screenY = originY + (worldX + worldY) * halfHeight
+  -- We step by integer worldX/worldY (tile coords)
+
+  -- Conservative bounds in world space:
+  local minWorldX = floor((-offsetX) / halfWidth) - (overdrawRows + 2)
+  local maxWorldX = ceil((bufferWidth  - offsetX) / halfWidth) + (overdrawRows + 2)
+  local minWorldY = floor((-offsetY) / halfHeight) - (overdrawRows + 2)
+  local maxWorldY = ceil((bufferHeight - offsetY) / halfHeight) + (overdrawRows + 2)
+
+  -- Clamp to map
+  local minTileY = max(0, -maxWorldY)
+  local maxTileY = min(mapHeight - 1, maxWorldY)
+  local minTileX = max(0, -maxWorldX)
+  local maxTileX = min(mapWidth  - 1, maxWorldX)
+
+  local tiles  = layerData.tilesFlat
+  local stride = layerData.tilesStride or mapWidth
+
+  -- Per-tile offset cache (avoid repeated _isoDrawOffsets calls)
+  local offsetCache = layerData._offsetCache
+  if not offsetCache then
+    offsetCache = {}
+    layerData._offsetCache = offsetCache
+  end
+
+  -- Per-tile image cache (avoid imageTable:getImage repeats)
+  local imageCache = layerData._imageCache
+  if not imageCache then
+    imageCache = {}
+    layerData._imageCache = imageCache
+  end
+
+  for row0 = minTileY, maxTileY do
+    -- Draw across columns for this row
+    local rowIndex = row0 * stride + (minTileX + 1)
+    for col0 = minTileX, maxTileX do
+      local tileIndex = tiles and tiles[rowIndex] or 0
+      if tileIndex and tileIndex > 0 and tileIndex <= n then
+        local img = imageCache[tileIndex]
+        if not img then
+          img = imageTable:getImage(tileIndex)
+          imageCache[tileIndex] = img
+        end
+        if img then
+          local offX = offsetCache[tileIndex]
+          local offY
+          if not offX then
+            offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
+            offsetCache[tileIndex] = offX
+            offsetCache[tileIndex + 0.5] = offY
+          else
+            offY = offsetCache[tileIndex + 0.5]
+          end
+
+          local worldX, worldY = col0, row0
+          local drawX = (worldX - worldY) * halfWidth + offsetX + offX
+          local drawY = (worldX + worldY) * halfHeight + offsetY + offY
+
+          if drawX < bufferWidth and drawY < bufferHeight
+             and drawX > -tileWidth and drawY > -tileHeight then
+            img:draw(drawX, drawY)
+          end
+        end
+      end
+      rowIndex += 1
+    end
+  end
+end
+
+-- ! Utility: Draw Static Layer Chunked
+function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
+  local config = self._staticChunkLayers[layerName]
+  if not config then return end
+
+  local layerData = config.layer
+  local size    = config.size
+  local overlap = config.overlap
+
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  visibleX -= overlap; visibleY -= overlap
+  visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+
+  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+
+  for chunkY = minChunkY, maxChunkY do
+    local rowDestY = chunkY * size - overlap + screenY
+    for chunkX = minChunkX, maxChunkX do
+      local img = self:_getOrBuildChunk(config, chunkX, chunkY)
+      if img then
+        local destX = chunkX * size - overlap + screenX
+        local destY = rowDestY
+
+        local imageWidth, imageHeight = img:getSize()
+        if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
+             or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
+          img:draw(destX, destY)
+        end
+      end
+    end
+  end
 end
 
 --------------------------------------------------------------------------------
@@ -74,67 +330,125 @@ end
 --------------------------------------------------------------------------------
 
 -- ! World to Screen
-function RoxyIsoTilemap:worldToScreen(worldX, worldY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+function RoxyIsoTilemap:worldToScreen(worldX, worldY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot so direct math matches sprite path
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
   local isoX = originX + (worldX - worldY) * halfWidth
   local isoY = originY + (worldX + worldY) * halfHeight
 
-  -- Include pivotAdjust* before subtracting camera
   return round(isoX + pivotAdjustX - cameraX * parallaxX),
          round(isoY + pivotAdjustY - cameraY * parallaxY)
 end
 
 -- ! Screen to World
-function RoxyIsoTilemap:screenToWorld(screenX, screenY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+function RoxyIsoTilemap:screenToWorld(screenX, screenY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot so direct math matches sprite path
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-  -- Undo camera and pivot before converting to world
-  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
-  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+  local deltaX = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
+  local deltaY = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldX = (dx / halfWidth + dy / halfHeight) * 0.5
-  local worldY = (dy / halfHeight - dx / halfWidth) * 0.5
+  local worldX = (deltaX / halfWidth + deltaY / halfHeight) * 0.5
+  local worldY = (deltaY / halfHeight - deltaX / halfWidth) * 0.5
   return worldX, worldY
 end
+
 
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
 
 -- ! Set Tile At
-function RoxyIsoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
-  local layer = self.layers and self.layers[name]
-  if not layer then return end
+function RoxyIsoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData then return end
 
-  layer.tilemap:setTileAtPosition(x, y, tileIndex)
+  layerData.tilemap:setTileAtPosition(x, y, tileIndex)
 
-  if updateSprite and layer.imageTable then
-    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
-    Graphics.sprite.addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  -- Update cached flat data used by dynamic paths
+  local tiles = layerData.tilesFlat
+  if tiles then
+    local stride = layerData.tilesStride or layerData.mapWidth
+    if stride and stride > 0 then
+      local idx = (y - 1) * stride + x
+      if idx >= 1 and idx <= #tiles then
+        tiles[idx] = tileIndex
+      end
+    end
+  end
+
+  -- Evict any overlapping chunks so they rebuild lazily
+  if self._staticChunkLayers[layerName] then
+    self:markTilesDirty(layerName, x, y, 1, 1)
+  end
+
+  if updateSprite and layerData.imageTable then
+    local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layerData)
+    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  end
+end
+
+-- ! Get Row From Screen
+-- Convert a screen pixel to a 1-based row (tileY)
+function RoxyIsoTilemap:getRowFromScreen(screenX, screenY, layerName)
+  local targetLayer = self.layers and self.layers[layerName]
+  if not targetLayer then
+    targetLayer = _findFirstAvailableLayer(self.layers)
+    if not targetLayer then return 1 end
+  end
+
+  local _, mapHeightTiles = targetLayer.tilemap:getSize()
+  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
+  local row = floor(worldY + 1)
+  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
+  return row
+end
+
+-- ! Resort Layers
+function RoxyIsoTilemap:resortLayers()
+  self:_rebuildOrderedLayers()
+end
+
+-- ! Mark Tiles Dirty
+-- Evict any chunks overlapped by the edited tile region
+function RoxyIsoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
+  local cfg = self._staticChunkLayers[layerName]
+  if not cfg then return end
+
+  local tileWidth, tileHeight = cfg.layer.tileWidth, cfg.layer.tileHeight
+  local pixelX = (tileX - 1) * (tileWidth * 0.5) * 2
+  local pixelY = (tileY - 1) * (tileHeight * 0.5)
+
+  local pixelWidth  = (tileCountWidth  or 1) * tileWidth
+  local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, cfg.size)
+
+  for cy = minChunkY, maxChunkY do
+    for cx = minChunkX, maxChunkX do
+      evictAsset(self._globalChunkBucket, cfg.keyPrefix .. cx .. ":" .. cy)
+    end
   end
 end
 
@@ -143,190 +457,165 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
--- Draw a single tile layer with conservative vertical culling.
-function RoxyIsoTilemap:draw(name)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap or layer.visible == false then return end
+-- Draw a single tile layer with conservative vertical culling
+function RoxyIsoTilemap:draw(layerName)
+  if self._staticChunkLayers and self._staticChunkLayers[layerName] then
+    self:_drawStaticLayerChunked(layerName); return
+  end
 
-  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
 
-  -- Get world coordinates of screen corners
-  local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
-  local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
-  local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
-  local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+  local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
 
-  -- Find the bounds of visible tiles with margin for image height
-  local maxImgH = _getMaxImgH(layer)
-  local halfHeight = tileHeight * 0.5
-  local overdraw = max(0, maxImgH - tileHeight)
-  local margin = ceil(overdraw / max(1, halfHeight)) + 1
-
-  -- Calculate conservative bounds
-  local minWorldX = min(topLeftX, topRightX, bottomLeftX, bottomRightX) - margin
-  local maxWorldX = max(topLeftX, topRightX, bottomLeftX, bottomRightX) + margin
-  local minWorldY = min(topLeftY, topRightY, bottomLeftY, bottomRightY) - margin
-  local maxWorldY = max(topLeftY, topRightY, bottomLeftY, bottomRightY) + margin
-
-  -- Convert to tile coordinates (1-based)
-  local minTileX = max(1, floor(minWorldX) + 1)
-  local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
-  local minTileY = max(1, floor(minWorldY) + 1)
-  local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
-
-  self:drawLayerRegion(name, minTileX, maxTileX, minTileY, maxTileY)
+  self:drawLayerRows(layerName, minTileY, maxTileY, minTileX, maxTileX)
 end
 
 -- ! Draw Visible
--- Draw all visible tile layers sorted by z-index.
+-- Draw all visible tile layers sorted by z-index
 function RoxyIsoTilemap:drawVisible()
-  if not self.layers then return end
-
-  local list = {}
-  for _, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      tableInsert(list, layer)
+  -- Keep ordered layers if you have them; otherwise, iterate layers
+  local list = self._orderedLayers
+  if list and #list > 0 then
+    for i = 1, #list do
+      local item = list[i]
+      if item.type == "chunked" then
+        self:_drawStaticLayerChunked(item.name)
+      else
+        local layerData = item.layer
+        if layerData.tilemap and layerData.visible ~= false then
+          local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+          self:drawLayerRows(item.name, minTileY, maxTileY, minTileX, maxTileX)
+        end
+      end
     end
+    return
   end
-  tableSort(list, function(a, b) return (a.zIndex or 0) < (b.zIndex or 0) end)
 
-  for i = 1, #list do
-    local layer = list[i]
-    local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-
-    -- Get world coordinates of screen corners
-    local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
-    local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
-    local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
-    local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-
-    -- Find the bounds of visible tiles with margin for image height
-    local maxImgH = _getMaxImgH(layer)
-    local halfHeight = tileHeight * 0.5
-    local overdraw = max(0, maxImgH - tileHeight)
-    local margin = ceil(overdraw / max(1, halfHeight)) + 1
-
-    -- Calculate conservative bounds
-    local minWorldX = min(topLeftX, topRightX, bottomLeftX, bottomRightX) - margin
-    local maxWorldX = max(topLeftX, topRightX, bottomLeftX, bottomRightX) + margin
-    local minWorldY = min(topLeftY, topRightY, bottomLeftY, bottomRightY) - margin
-    local maxWorldY = max(topLeftY, topRightY, bottomLeftY, bottomRightY) + margin
-
-    -- Convert to tile coordinates (1-based)
-    local minTileX = max(1, floor(minWorldX) + 1)
-    local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
-    local minTileY = max(1, floor(minWorldY) + 1)
-    local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
-
-    self:drawLayerRegion(layer.name, minTileX, maxTileX, minTileY, maxTileY)
+  -- Fallback if ordered list isn't used
+  for name, layerData in pairs(self.layers or {}) do
+    if layerData.tilemap and layerData.visible ~= false then
+      local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+      self:drawLayerRows(name, minTileY, maxTileY, minTileX, maxTileX)
+    end
   end
 end
 
--- ! Draw Layer Region
-function RoxyIsoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+-- ! Draw Visible in Rectangle
+-- Clip helper for UI overlays, etc.
+function RoxyIsoTilemap:drawVisibleInRect(x, y, width, height)
+  setClipRect(x, y, width, height)
+    self:drawVisible()
+  clearClipRect()
+end
+
+-- ! Draw Layer Rows
+function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxColumn)
   local restoreX, restoreY = _beginManualDraw()
 
-  local layer = self.layers and self.layers[layerName]
-  if not layer or not layer.tilemap or layer.visible == false then
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then
     _endManualDraw(restoreX, restoreY); return
   end
 
-  local imageTable = layer.imageTable
+  local imageTable = layerData.imageTable
   if not imageTable then
     _endManualDraw(restoreX, restoreY); return
   end
 
-  local cache = layer._imgCache
-  if not cache then cache = {}; layer._imgCache = cache end
+  local n = layerData.imageCount
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
 
-  local tilemap = layer.tilemap
-  local mapWidthTiles, mapHeightTiles = tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local rowStart = max(1, minRow or 1)
+  local rowEnd   = min(mapHeight, maxRow or mapHeight)
+  if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
 
-  -- Clamp bounds
-  minTileX = max(1, minTileX)
-  maxTileX = min(mapWidthTiles, maxTileX)
-  minTileY = max(1, minTileY)
-  maxTileY = min(mapHeightTiles, maxTileY)
-
-  if minTileX > maxTileX or minTileY > maxTileY then
-    _endManualDraw(restoreX, restoreY); return
+  local minX, maxX
+  if minColumn and maxColumn then
+    minX = max(1, minColumn)
+    maxX = min(mapWidth, maxColumn)
+  else
+    -- Ask base class for safe visible bounds
+    -- Only take X since rows are fixed above
+    local visibleX1, visibleY1, visibleX2, visibleY2 = self:getVisibleTileBounds(layerData)
+    minX = visibleX1; maxX = visibleX2
   end
+  if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
-  local tiles, widthFromTileMap = tilemap:getTiles()
-  local stride = widthFromTileMap or mapWidthTiles
+  local tiles  = layerData.tilesFlat
+  local stride = layerData.tilesStride
 
-  -- Camera and parallax calculations
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
-  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
-  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+  -- Hoisted transforms
+  local originX, originY      = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
+  local parallaxOriginX       = layerData.parallaxoriginx or 0
+  local parallaxOriginY       = layerData.parallaxoriginy or 0
+  local pivotAdjustX          = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY          = parallaxOriginY * (1 - parallaxY)
+  local cameraX, cameraY      = getCameraPosition()
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local cameraX, cameraY = getCameraPosition()
-  local halfHeight, halfWidth = tileHeight * 0.5, tileWidth * 0.5
+  layerData._imageCache  = layerData._imageCache  or {}
+  layerData._offsetCache = layerData._offsetCache or {}
 
-  -- Draw tiles in the specified region
-  for tileY = minTileY, maxTileY do
-    for tileX = minTileX, maxTileX do
-      local i = (tileY - 1) * stride + tileX
-      local idx = tiles and tiles[i] or 0
+  for tileY = rowStart, rowEnd do
+    local row0 = tileY - 1
 
-      if idx and idx ~= 0 then
-        local img = cache[idx]
-        if not img then img = imageTable:getImage(idx); cache[idx] = img end
+    -- Base isometric screen position for the leftmost column
+    local baseScreenX = round(originX + ((minX - 1) - row0) * halfWidth + pivotAdjustX - cameraX * parallaxX)
+    local baseScreenY = round(originY + ((minX - 1) + row0) * halfHeight + pivotAdjustY - cameraY * parallaxY)
+
+    local currentX = baseScreenX
+    local currentY = baseScreenY
+    local rowIndex = row0 * stride + minX
+
+    for tileX = minX, maxX do
+      local tileIndex = tiles and tiles[rowIndex] or 0
+      if tileIndex and tileIndex > 0 and tileIndex <= n then
+        local img = layerData._imageCache[tileIndex]
+        if not img then
+          img = imageTable:getImage(tileIndex)
+          layerData._imageCache[tileIndex] = img
+        end
 
         if img then
-          -- Convert tile coordinates to screen position
-          local worldX, worldY = tileX - 1, tileY - 1
-          local screenX = originX + (worldX - worldY) * halfWidth
-          local screenY = originY + (worldX + worldY) * halfHeight
-
-          local finalScreenX = round(screenX + pivotAdjustX - cameraX * parallaxX)
-          local finalScreenY = round(screenY + pivotAdjustY - cameraY * parallaxY)
-
-          local offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-          local drawX, drawY = finalScreenX + offX, finalScreenY + offY
-
-          -- Final screen bounds check (optional optimization)
-          local imgW, imgH = img:getSize()
-          if not (drawX > DISPLAY_WIDTH or drawY > DISPLAY_HEIGHT or
-                  drawX + imgW < 0 or drawY + imgH < 0) then
-            img:draw(drawX, drawY)
+          local offX = layerData._offsetCache[tileIndex]
+          local offY
+          if not offX then
+            offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
+            layerData._offsetCache[tileIndex] = offX
+            layerData._offsetCache[tileIndex + 0.5] = offY
+          else
+            offY = layerData._offsetCache[tileIndex + 0.5]
           end
+
+          img:draw(currentX + offX, currentY + offY)
         end
       end
+
+      -- Advance to next iso column (worldX += 1)
+      currentX += halfWidth
+      currentY += halfHeight
+      rowIndex += 1
     end
   end
 
   _endManualDraw(restoreX, restoreY)
 end
 
--- ! Get Rows From Screen
--- Convert a screen pixel to a 1-based row (tileY).
-function RoxyIsoTilemap:getRowFromScreen(screenX, screenY, layerName)
-  local targetLayer = self.layers and self.layers[layerName]
-  if not targetLayer then
-    -- Fall back to any layer if needed
-    for _, layer in pairs(self.layers or {}) do
-      if layer.tilemap then
-        targetLayer = layer
-        break
-      end
-    end
-    if not targetLayer then return 1 end
-  end
+--------------------------------------------------------------------------------
+-- Cleanup
+--------------------------------------------------------------------------------
 
-  local _, mapHeightTiles = targetLayer.tilemap:getSize()
-  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
-  local row = floor(worldY + 1)
-  if row < 1 then
-    row = 1
-  elseif row > mapHeightTiles then
-    row = mapHeightTiles
+-- ! Destroy
+-- Clear chunk bucket as well as per-layer references
+function RoxyIsoTilemap:destroy()
+  if self._globalChunkBucket then
+    clearCache(self._globalChunkBucket)
+    self._globalChunkBucket = nil
   end
-  return row
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
+  RoxyIsoTilemap.super.destroy(self)
 end

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -6,65 +6,93 @@ local Sprite    <const> = Graphics.sprite
 
 local r       <const> = roxy
 local Camera  <const> = r.Camera
+local Cache   <const> = r.Cache
 
 local min   <const> = math.min
 local max   <const> = math.max
+local floor <const> = math.floor
+local ceil  <const> = math.ceil
 local round <const> = r.Math.round
 
 local tableInsert <const> = table.insert
 local tableSort   <const> = table.sort
 
-local getCameraPosition <const> = Camera.getPosition
+local pushContext   <const> = Graphics.pushContext
+local popContext    <const> = Graphics.popContext
+local setClipRect   <const> = Graphics.setClipRect
+local clearClipRect <const> = Graphics.clearClipRect
+local newImage      <const> = Graphics.image.new
+local clear         <const> = Graphics.clear
+
 local addDirtyRect      <const> = Sprite.addDirtyRect
+local getCameraPosition <const> = Camera.getPosition
+
+local newCacheBucket  <const> = Cache.newBucket
+local getOrLoadAsset  <const> = Cache.getOrLoadAsset
+local evictAsset      <const> = Cache.evictAsset
+local clearCache      <const> = Cache.clearCache
+
+-- Default chunk settings
+local DEFAULT_CHUNK_SIZE    <const> = 320
+local DEFAULT_CHUNK_CACHE   <const> = 200
+local DEFAULT_CHUNK_OVERLAP <const> = 32
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+
+local COLOR_CLEAR <const> = Graphics.kColorClear
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
--- ! Compute Draw Parameters
--- Compute draw parameters for orthographic projection.
--- Returns: screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled
-local function _computeDrawParams(layer)
-  local cameraX, cameraY = getCameraPosition()
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local mapPixelWidth, mapPixelHeight = layer.mapPixelWidth or 0, layer.mapPixelHeight or 0
+-- ! Helper: Visible Layer Rectangle
+-- Compute visible layer-space rectangle (pixels), factoring parallax/camera.
+local function _visibleLayerRect(self, layerData)
+  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
+end
 
-  -- Respect parallax origin
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
-  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
-  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+-- ! Helper: Chunk Indices For Rect
+-- Which chunk indices intersect a pixel rect?
+local function _chunkIndicesForRect(x, y, width, height, size)
+  local minChunkX = floor(x / size)
+  local maxChunkX = floor((x + width  - 1) / size)
+  local minChunkY = floor(y / size)
+  local maxChunkY = floor((y + height - 1) / size)
+  return minChunkX, maxChunkX, minChunkY, maxChunkY
+end
 
-  local screenX, screenY
-  if layer.anchor == "topLeft" then
-    -- Include pivot adjust so sprites vs direct draw match.
-    screenX = round(originX + pivotAdjustX - cameraX * parallaxX)
-    screenY = round(originY + pivotAdjustY - cameraY * parallaxY)
-  else
-    screenX = round(originX - (mapPixelWidth  * 0.5) + pivotAdjustX - cameraX * parallaxX)
-    screenY = round(originY - (mapPixelHeight * 0.5) + pivotAdjustY - cameraY * parallaxY)
+-- ! Helper: Find First Available Layer
+local function _findFirstAvailableLayer(layers)
+  for _, layerData in pairs(layers or {}) do
+    if layerData.tilemap then return layerData end
+  end
+  return nil
+end
+
+-- ! Helper: Render Layer Region To Buffer
+-- Render a rectangular region of the layer directly into the given buffer.
+-- For orthographic, we can draw the exact source rect from the tilemap.
+local function _drawLayerRegionToBuffer(layerData, destinationX, destinationY, sourceX, sourceY, width, height)
+  -- Clamp source rect to layer bounds to avoid asking tilemap for out-of-range pixels.
+  local mapPixelWidth, mapPixelHeight = layerData.mapPixelWidth or 0, layerData.mapPixelHeight or 0
+  if sourceX >= mapPixelWidth or sourceY >= mapPixelHeight then return end
+
+  if sourceX < 0 then
+    local delta = -sourceX
+    sourceX += delta; width -= delta; destinationX += delta
+  end
+  if sourceY < 0 then
+    local delta = -sourceY
+    sourceY += delta; height -= delta; destinationY += delta
   end
 
-  local sourceX, sourceY = 0, 0
-  local sourceWidth, sourceHeight = mapPixelWidth, mapPixelHeight
+  width  = min(width,  mapPixelWidth  - sourceX)
+  height = min(height, mapPixelHeight - sourceY)
+  if width <= 0 or height <= 0 then return end
 
-  if screenX < 0 then sourceX = -screenX end
-  if screenY < 0 then sourceY = -screenY end
-
-  local maxW = DISPLAY_WIDTH - max(0, screenX)
-  local maxH = DISPLAY_HEIGHT - max(0, screenY)
-  sourceWidth  = min(sourceWidth - sourceX, max(0, maxW))
-  sourceHeight = min(sourceHeight - sourceY, max(0, maxH))
-
-  if sourceWidth <= 0 or sourceHeight <= 0 then
-    return screenX, screenY, nil, true
-  end
-
-  return screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, false
+  layerData.tilemap:drawIgnoringOffset(destinationX, destinationY, sourceX, sourceY, width, height)
 end
 
 --------------------------------------------------------------------------------
@@ -74,8 +102,128 @@ end
 class("RoxyOrthoTilemap").extends(RoxyTilemap)
 
 function RoxyOrthoTilemap:init(jsonPath, opts, scene)
+  opts = opts or {}
   RoxyOrthoTilemap.super.init(self, jsonPath, opts, scene)
   self._projection = "orthogonal"
+
+  -- Static / chunk config and ordered layers
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
+
+  -- Map-scoped cache key namespace
+  self._mapCacheId = jsonPath or tostring(self)
+
+  self:_initializeStaticLayers(opts)
+  self:_rebuildOrderedLayers()
+end
+
+--------------------------------------------------------------------------------
+-- Static Layer Configuration
+--------------------------------------------------------------------------------
+
+-- ! Utility: Initialize Static Layers
+-- Build chunk/static configuration per layer
+function RoxyOrthoTilemap:_initializeStaticLayers(opts)
+  local layerOptions = (opts and opts.layerOptions) or {}
+  local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
+
+  -- One shared bucket for all chunk images on this map
+  self._globalChunkBucket = newCacheBucket(totalChunkCache)
+
+  for layerName, layerData in pairs(self.layers) do
+    local lopts = layerOptions[layerName] or {}
+    if lopts.preRenderChunked then
+      self._staticChunkLayers[layerName] = {
+        name      = layerName,
+        layer     = layerData,
+        size      = max(1, lopts.chunkSizePx or DEFAULT_CHUNK_SIZE),
+        overlap   = lopts.overlapPx  or DEFAULT_CHUNK_OVERLAP,
+        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
+                    tostring(layerData.tiledId or layerName) .. ":",
+      }
+    end
+  end
+end
+
+-- ! Utility: Rebuild Ordered Layers
+-- Build a stable, z-sorted draw list once (rarely changes)
+function RoxyOrthoTilemap:_rebuildOrderedLayers()
+  local items = {}
+  for name, layerData in pairs(self.layers) do
+    if layerData.tilemap and layerData.visible ~= false then
+      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
+      tableInsert(items, { layer = layerData, name = name, type = renderType, z = layerData.zIndex or 0 })
+    end
+  end
+  tableSort(items, function(a, b) return a.z < b.z end)
+  self._orderedLayers = items
+end
+
+--------------------------------------------------------------------------------
+-- Chunk building & drawing
+--------------------------------------------------------------------------------
+
+-- ! Utility: Get or Build Chunk
+-- Build or fetch a prerendered chunk image from the cache
+function RoxyOrthoTilemap:_getOrBuildChunk(layerCfg, chunkX, chunkY)
+  local key = layerCfg.keyPrefix .. chunkX .. ":" .. chunkY
+  return getOrLoadAsset(self._globalChunkBucket, key, function()
+    local size, overlap = layerCfg.size, layerCfg.overlap
+    local width, height = size + 2 * overlap, size + 2 * overlap
+    local img = newImage(width, height)
+
+    -- Convert chunk indices to layer pixel origin for this chunk
+    local pixelX = chunkX * size - overlap
+    local pixelY = chunkY * size - overlap
+
+    pushContext(img)
+      setClipRect(0, 0, width, height)
+      clear(COLOR_CLEAR)
+      -- Draw the corresponding source rect from the tilemap into the buffer
+      _drawLayerRegionToBuffer(layerCfg.layer, 0, 0, pixelX, pixelY, width, height)
+      clearClipRect()
+    popContext()
+
+    return img
+  end)
+end
+
+-- ! Utility: Draw Static Layer Chunked
+-- Render a chunked layer using prebuilt chunk images
+function RoxyOrthoTilemap:_drawStaticLayerChunked(layerName)
+  local cfg = self._staticChunkLayers[layerName]
+  if not cfg then return end
+
+  local layerData = cfg.layer
+  local size, overlap = cfg.size, cfg.overlap
+
+  -- Visible rect in layer coordinates (inflate by overlap)
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  visibleX -= overlap; visibleY -= overlap
+  visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+
+  -- Top-left screen position of layer pixel (0,0)
+  local screenX, screenY = self:worldToScreen(0, 0, layerData)
+
+  for chunkY = minChunkY, maxChunkY do
+    local rowDestY = chunkY * size - overlap + screenY
+    for chunkX = minChunkX, maxChunkX do
+      local img = self:_getOrBuildChunk(cfg, chunkX, chunkY)
+      if img then
+        local destX = chunkX * size - overlap + screenX
+        local destY = rowDestY
+
+        local imageWidth, imageHeight = img:getSize()
+        if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
+             or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
+          img:draw(destX, destY)
+        end
+      end
+    end
+  end
 end
 
 --------------------------------------------------------------------------------
@@ -83,72 +231,119 @@ end
 --------------------------------------------------------------------------------
 
 -- ! World to Screen (orthogonal)
-function RoxyOrthoTilemap:worldToScreen(worldX, worldY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+function RoxyOrthoTilemap:worldToScreen(worldX, worldY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
   -- Parallax-origin pivot to match sprite behavior (like other tilemap classes)
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
   local orthoX = originX + worldX * tileWidth
   local orthoY = originY + worldY * tileHeight
 
-  -- Include pivotAdjust* before subtracting camera (consistent with other classes)
   return round(orthoX + pivotAdjustX - cameraX * parallaxX),
          round(orthoY + pivotAdjustY - cameraY * parallaxY)
 end
 
 -- ! Screen to World (orthogonal)
-function RoxyOrthoTilemap:screenToWorld(screenX, screenY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+function RoxyOrthoTilemap:screenToWorld(screenX, screenY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot to match sprite behavior
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-  -- Undo camera and pivot before converting to world
-  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
-  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+  local deltaX = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX) -- (CHANGE) Naming for clarity
+  local deltaY = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldX = dx / tileWidth
-  local worldY = dy / tileHeight
+  local worldX = deltaX / tileWidth
+  local worldY = deltaY / tileHeight
   return worldX, worldY
 end
 
 --------------------------------------------------------------------------------
--- Public API preserved from original class
+-- Public API
 --------------------------------------------------------------------------------
 
 -- ! Set Tile At
 -- Sets the tile at the given tile coordinates (x, y) on the specified layer.
--- Note: Coordinates are in tile units, not pixels.
-function RoxyOrthoTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
-  local layer = self.layers and self.layers[name]
-  if not layer then return end
+function RoxyOrthoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData then return end
 
-  layer.tilemap:setTileAtPosition(x, y, tileIndex)
+  layerData.tilemap:setTileAtPosition(x, y, tileIndex)
+
+  -- Keep tilesFlat in sync so dynamic path sees edits immediately
+  local tiles = layerData.tilesFlat
+  if tiles then
+    local stride = layerData.tilesStride or layerData.mapWidth
+    if stride and stride > 0 then
+      local idx = (y - 1) * stride + x
+      if idx >= 1 and idx <= #tiles then
+        tiles[idx] = tileIndex
+      end
+    end
+  end
+
+  -- If chunked, evict overlapping chunks so they rebuild lazily
+  if self._staticChunkLayers[layerName] then
+    self:markTilesDirty(layerName, x, y, 1, 1)
+  end
 
   if updateSprite then
-    local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-    -- Use consistent world-to-screen conversion
-    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
+    local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+    local screenX, screenY = self:worldToScreen(x - 1, y - 1, layerData)
+    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  end
+end
 
-    -- Support both sprite-based and direct drawing approaches
-    if layer.sprite then
-      addDirtyRect(screenX, screenY, tileWidth, tileHeight)
-    else
-      -- For direct drawing, mark the area as needing refresh
-      addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+-- ! Get Row From Screen
+function RoxyOrthoTilemap:getRowFromScreen(screenX, screenY, layerName)
+  local targetLayer = self.layers and self.layers[layerName]
+  if not targetLayer then
+    targetLayer = _findFirstAvailableLayer(self.layers)
+    if not targetLayer then return 1 end
+  end
+
+  local _, mapHeightTiles = targetLayer.tilemap:getSize()
+  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
+  local row = floor(worldY + 1)
+  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
+  return row
+end
+
+-- ! Resort Layers
+function RoxyOrthoTilemap:resortLayers()
+  self:_rebuildOrderedLayers()
+end
+
+-- ! Mark Tiles Dirty
+-- Evict any chunks overlapped by the edited tile region
+function RoxyOrthoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
+  local config = self._staticChunkLayers[layerName]
+  if not config then return end
+
+  local tileWidth, tileHeight = config.layer.tileWidth, config.layer.tileHeight
+  local pixelX = (tileX - 1) * tileWidth
+  local pixelY = (tileY - 1) * tileHeight
+  local pixelWidth = (tileCountWidth  or 1) * tileWidth
+  local pixelHeight = (tileCountHeight or 1) * tileHeight
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, config.size)
+
+  for chunkY = minChunkY, maxChunkY do
+    for chunkX = minChunkX, maxChunkX do
+      evictAsset(self._globalChunkBucket, config.keyPrefix .. chunkX .. ":" .. chunkY)
     end
   end
 end
@@ -159,113 +354,100 @@ end
 
 -- ! Draw
 -- Draw a single tile layer directly (no sprite required)
-function RoxyOrthoTilemap:draw(name)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap or layer.visible == false then return end
-
-  local screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled = _computeDrawParams(layer)
-  if culled then return end
-
-  -- Use drawIgnoringOffset because we already applied camera/offset logic
-  local drawIgnoring = layer.tilemap.drawIgnoringOffset
-  if sourceX then
-    drawIgnoring(layer.tilemap, screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight)
-  else
-    drawIgnoring(layer.tilemap, screenX, screenY)
+function RoxyOrthoTilemap:draw(layerName)
+  if self._staticChunkLayers[layerName] then
+    self:_drawStaticLayerChunked(layerName); return
   end
+
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
+
+  -- Use base helper so tall tiles near edges are included
+  local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+  self:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
 end
 
 -- ! Draw Visible
 -- Draw all visible tile layers by zIndex (ascending)
 function RoxyOrthoTilemap:drawVisible()
-  if not self.layers then return end
-
-  -- Collect visible layers
-  local list = {}
-  for name, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      tableInsert(list, layer)
-    end
-  end
-
-  -- Sort by zIndex to match sprite render order
-  tableSort(list, function(a, b)
-    return (a.zIndex or 0) < (b.zIndex or 0)
-  end)
-
-  -- Draw in order
-  for i = 1, #list do
-    local layer = list[i]
-    local screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight, culled = _computeDrawParams(layer)
-    if not culled then
-      local drawIgnoring = layer.tilemap.drawIgnoringOffset
-      if sourceX then
-        drawIgnoring(layer.tilemap, screenX, screenY, sourceX, sourceY, sourceWidth, sourceHeight)
-      else
-        drawIgnoring(layer.tilemap, screenX, screenY)
+  local ordered = self._orderedLayers
+  for i = 1, #ordered do
+    local item = ordered[i]
+    if item.type == "chunked" then
+      self:_drawStaticLayerChunked(item.name)
+    else
+      local layerData = item.layer
+      if layerData.tilemap and layerData.visible ~= false then
+        local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+        self:drawLayerRegion(item.name, minTileX, maxTileX, minTileY, maxTileY)
       end
     end
   end
 end
 
--- ! Draw Layer Region (for consistency with other tilemap classes)
-function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
-  local layer = self.layers and self.layers[layerName]
-  if not layer or not layer.tilemap or layer.visible == false then return end
+-- ! Draw Visible In Rectangle
+function RoxyOrthoTilemap:drawVisibleInRect(x, y, width, height)
+  setClipRect(x, y, width, height)
+    self:drawVisible()
+  clearClipRect()
+end
 
-  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+-- ! Draw Layer Region
+-- Region-based renderer that batches via tilemap:drawIgnoringOffset.
+function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
+
+  local mapWidthTiles, mapHeightTiles = layerData.tilemap:getSize()
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
 
   -- Clamp bounds
   minTileX = max(1, minTileX)
   maxTileX = min(mapWidthTiles, maxTileX)
   minTileY = max(1, minTileY)
   maxTileY = min(mapHeightTiles, maxTileY)
-
   if minTileX > maxTileX or minTileY > maxTileY then return end
 
-  -- Calculate screen rectangle for the tile region
-  local topLeftX, topLeftY = self:worldToScreen(minTileX - 1, minTileY - 1, layer)
+  -- Convert tiles to pixels
+  local sourceX = (minTileX - 1) * tileWidth
+  local sourceY = (minTileY - 1) * tileHeight
   local regionWidth = (maxTileX - minTileX + 1) * tileWidth
   local regionHeight = (maxTileY - minTileY + 1) * tileHeight
 
-  -- Convert to source rectangle (pixels within the tilemap image)
-  local sourceX = (minTileX - 1) * tileWidth
-  local sourceY = (minTileY - 1) * tileHeight
+  -- Screen position for top-left of region
+  local screenX, screenY = self:worldToScreen(minTileX - 1, minTileY - 1, layerData)
 
-  -- Clamp to screen bounds
-  local screenX, screenY = max(0, topLeftX), max(0, topLeftY)
-  local sourceOffsetX = screenX - topLeftX
-  local sourceOffsetY = screenY - topLeftY
+  -- Clip against the display to avoid overdraw
+  local clippedScreenX = max(0, screenX)
+  local clippedScreenY = max(0, screenY)
+  local sourceOffsetX = clippedScreenX - screenX
+  local sourceOffsetY = clippedScreenY - screenY
 
-  local visibleWidth = min(regionWidth - sourceOffsetX, DISPLAY_WIDTH - screenX)
-  local visibleHeight = min(regionHeight - sourceOffsetY, DISPLAY_HEIGHT - screenY)
+  local visibleWidth = min(regionWidth - sourceOffsetX, DISPLAY_WIDTH - clippedScreenX)
+  local visibleHeight = min(regionHeight - sourceOffsetY, DISPLAY_HEIGHT - clippedScreenY)
+  if visibleWidth <= 0 or visibleHeight <= 0 then return end
 
-  if visibleWidth > 0 and visibleHeight > 0 then
-    layer.tilemap:drawIgnoringOffset(
-      screenX, screenY,
-      sourceX + sourceOffsetX, sourceY + sourceOffsetY,
-      visibleWidth, visibleHeight
-    )
-  end
+  layerData.tilemap:drawIgnoringOffset(
+    clippedScreenX, clippedScreenY,
+    sourceX + sourceOffsetX, sourceY + sourceOffsetY,
+    visibleWidth, visibleHeight
+  )
 end
 
--- ! Draw with Region-Based Culling (optional alternative to current draw method)
-function RoxyOrthoTilemap:drawWithTileCulling(name)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap or layer.visible == false then return end
+--------------------------------------------------------------------------------
+-- Cleanup
+--------------------------------------------------------------------------------
 
-  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+-- ! Destroy
+-- Clean up static layer resources and defer remainder to base class.
+function RoxyOrthoTilemap:destroy()
+  -- Clear pre-rendered chunk cache for this map
+  if self._globalChunkBucket then
+    clearCache(self._globalChunkBucket)
+    self._globalChunkBucket = nil
+  end
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
 
-  -- Calculate visible tile bounds
-  local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
-  local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-
-  local minTileX = max(1, math.floor(topLeftX) + 1)
-  local maxTileX = min(mapWidthTiles, math.ceil(bottomRightX) + 1)
-  local minTileY = max(1, math.floor(topLeftY) + 1)
-  local maxTileY = min(mapHeightTiles, math.ceil(bottomRightY) + 1)
-
-  self:drawLayerRegion(name, minTileX, maxTileX, minTileY, maxTileY)
+  RoxyOrthoTilemap.super.destroy(self)
 end

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -702,8 +702,17 @@ end
 
 -- ! Mark Dirty
 -- Public dirty marker for external animation/parallax/etc
-function RoxyStagTilemap:markDirty()
+function RoxyStagTilemap:markDirty(redrawBackground)
   self._frameDirty = true
+
+  if redrawBackground == nil then redrawBackground = true end
+  if redrawBackground then
+    if Sprite.redrawBackground then
+      Sprite.redrawBackground()
+    else
+      addDirtyRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
+    end
+  end
 end
 
 -- ! Set Tile At
@@ -850,12 +859,14 @@ function RoxyStagTilemap:drawVisible()
   local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
   local hasWarmWork = self:_hasWarmWork()
 
-  if cameraUnchanged and not self._frameDirty and not hasWarmWork then
-    return -- Nothing to do this frame.
+  -- Respect an explicit "force" from drawVisibleInRect to always paint when asked.
+  -- This prevents blank frames after transitions/wake that cleared the buffer.
+  if (not self._forceDraw) and cameraUnchanged and not self._frameDirty and not hasWarmWork then
+    return
   end
 
   self._lastCameraX, self._lastCameraY = cameraX, cameraY
-  self._frameDirty = false -- We will render now; clear until something changes again
+  self._frameDirty = false
 
   self:_primeVisibleChunks()
 
@@ -876,7 +887,10 @@ end
 -- ! Draw Visible in Rectangle
 function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
+    -- Force this draw call to paint regardless of internal 'clean' state.
+    self._forceDraw = true
     self:drawVisible()
+    self._forceDraw = false
   clearClipRect()
 end
 

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -39,11 +39,11 @@ local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
 -- Default chunk settings
 local DEFAULT_CHUNK_SIZE    <const> = 320
-local DEFAULT_CHUNK_CACHE   <const> = 72
+local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
 
 -- Coarse safety margin (in tiles) for dynamic fallback culling
-local TILE_MARGIN <const> = 2
+local TILE_MARGIN <const> = 0.5
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
@@ -54,7 +54,7 @@ local COLOR_CLEAR <const> = Graphics.kColorClear
 -- Helpers
 --------------------------------------------------------------------------------
 
--- ! Row Shift X for Row 0
+-- ! Helper: Row Shift X for Row 0
 -- Shift in pixels for a 0-based row index (Tiled staggered-y)
 local function _rowShiftX_for_row0(self, row0, halfWidth)
   if self.staggerAxis ~= "y" then return 0 end
@@ -74,16 +74,16 @@ local function _rowShiftX_for_row0(self, row0, halfWidth)
   return (direction == "right") and halfWidth or -halfWidth
 end
 
--- ! Visible Layer Rectangle
+-- ! Helper: Visible Layer Rectangle
 -- Compute visible layer-space rect
 local function _visibleLayerRect(self, layer)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
-  -- screen shows [0..W, 0..H]
-  -- which corresponds to layer pixels [-screenX..-screenX+W, -screenY..-screenY+H]
+  -- screen shows [0..width, 0..height]
+  -- which corresponds to layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
   return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
 end
 
--- ! Chunk Indices for Rect
+-- ! Helper: Chunk Indices for Rect
 -- Which chunk indices intersect a pixel rect?
 local function _chunkIndicesForRect(x, y, width, height, size)
   local minChunkX = floor(x / size)
@@ -91,6 +91,15 @@ local function _chunkIndicesForRect(x, y, width, height, size)
   local minChunkY = floor(y / size)
   local maxChunkY = floor((y + height - 1) / size)
   return minChunkX, maxChunkX, minChunkY, maxChunkY
+end
+
+-- ! Helper: Find First Available Layer
+-- Extracted repeated layer finding logic
+local function _findFirstAvailableLayer(layers)
+  for _, layer in pairs(layers or {}) do
+    if layer.tilemap then return layer end
+  end
+  return nil
 end
 
 --------------------------------------------------------------------------------
@@ -109,21 +118,29 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   self.staggerAxis = self.staggerAxis or "y"
   self.staggerDirection = self.staggerDirection or "right" -- "left" | "right"
 
-  self._staticChunkLayers = {}  -- name --> { layer, size, overlap, chunkBucket }
-  self._orderedLayers     = {}  -- array of { layer, type="chunked" | "dynamic" }
+  -- Static / chunk config and ordered layers
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
 
-  self._mapCacheId = jsonPath or tostring(self) -- Used only for namespacing keys
+  -- Map-scoped cache key namespace
+  self._mapCacheId = jsonPath or tostring(self)
 
   self:_initializeStaticLayers(opts)
+  for _, layerData in pairs(self.layers) do
+    if layerData.tilemap then
+      self:_preloadLayerCaches(layerData)
+    end
+  end
+
   self:_rebuildOrderedLayers()
 end
 
 --------------------------------------------------------------------------------
--- Utilities
+-- Static Layer Configuration
 --------------------------------------------------------------------------------
 
--- ! Initialize Static Layers
--- Build chunk/static config per layer
+-- ! Utility: Initialize Static Layers
+-- Build chunk/static configuration per layer
 function RoxyStagTilemap:_initializeStaticLayers(opts)
   local layerOptions = (opts and opts.layerOptions) or {}
   local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
@@ -142,36 +159,11 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
         keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
                     tostring(layer.tiledId or layerName) .. ":",
       }
-      Log.debug("keyPrefix: " .. self._staticChunkLayers[layerName].keyPrefix) --#DEBUG
     end
   end
 end
 
--- ! Get or Build Chunk
--- Build or fetch a prerendered chunk image from the cache
-function RoxyStagTilemap:_getOrBuildChunk(layerInfo, chunkX, chunkY)
-  local key = layerInfo.keyPrefix .. chunkX .. ":" .. chunkY
-  return getOrLoadAsset(self._globalChunkBucket, key, function()
-    local size, overlap = layerInfo.size, layerInfo.overlap
-    local width, height = size + 2 * overlap, size + 2 * overlap
-    local img = newImage(width, height)
-
-    -- Convert chunk indices to layer pixel origin for this chunk
-    local px = chunkX * size - overlap
-    local py = chunkY * size - overlap
-
-    pushContext(img)
-      setClipRect(0, 0, width, height)
-      clear(COLOR_CLEAR)
-      self:_renderLayerToBuffer(layerInfo.layer, -px, -py, width, height)
-      clearClipRect()
-    popContext()
-
-    return img
-  end)
-end
-
--- ! Rebuild Ordered Layers
+-- ! Utility: Rebuild Ordered Layers
 -- Build a stable, z-sorted draw list once (rarely changes)
 function RoxyStagTilemap:_rebuildOrderedLayers()
   local items = {}
@@ -185,45 +177,89 @@ function RoxyStagTilemap:_rebuildOrderedLayers()
   self._orderedLayers = items
 end
 
+-- ! Utility: Preload Layer Caches
+function RoxyStagTilemap:_preloadLayerCaches(layerData)
+  if not layerData.imageTable or not layerData.tileWidth or not layerData.tileHeight then return end
+
+  local n = layerData.imageCount
+  layerData._imageCache = {} -- Overwrite if exists to ensure fresh
+  layerData._offsetCache = {}
+
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+
+  for i = 1, n do
+    local img = layerData.imageTable:getImage(i)
+    if img then
+      layerData._imageCache[i] = img
+      local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+      layerData._offsetCache[i] = offsetX
+      layerData._offsetCache[i + 0.5] = offsetY
+    end
+  end
+end
+
 --------------------------------------------------------------------------------
 -- Chunk building & drawing
 --------------------------------------------------------------------------------
 
--- ! Render Layer to Buffer
--- Render a layer directly to a buffer context (in layer-local coordinates)
-function RoxyStagTilemap:_renderLayerToBuffer(layer, offsetX, offsetY, bufferWidth, bufferHeight)
-  local tilemap     = layer.tilemap
-  local imageTable  = layer.imageTable
-  if not tilemap or not imageTable then return end
+-- ! Utility: Get or Build Chunk
+-- Build or fetch a prerendered chunk image from the cache
+function RoxyStagTilemap:_getOrBuildChunk(layerData, chunkX, chunkY)
+  local key = layerData.keyPrefix .. chunkX .. ":" .. chunkY
+  return getOrLoadAsset(self._globalChunkBucket, key, function()
+    local size, overlap = layerData.size, layerData.overlap
+    local width, height = size + 2 * overlap, size + 2 * overlap
+    local img = newImage(width, height)
 
-  local len = imageTable:getLength()
-  local mapWidthTiles, mapHeightTiles = tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+    -- Convert chunk indices to layer pixel origin for this chunk
+    local pixelX = chunkX * size - overlap
+    local pixelY = chunkY * size - overlap
+
+    pushContext(img)
+      setClipRect(0, 0, width, height)
+      clear(COLOR_CLEAR)
+      self:_renderLayerToBuffer(layerData.layer, -pixelX, -pixelY, width, height)
+      clearClipRect()
+    popContext()
+
+    return img
+  end)
+end
+
+-- ! Utility: Render Layer to Buffer
+-- Render a layer directly to a buffer context (in layer-local coordinates)
+function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, bufferWidth, bufferHeight)
+  local imageTable = layerData.imageTable
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  if not mapWidth or not mapHeight or not imageTable then return end
+
+  local n = layerData.imageCount
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
   -- Parity helper (odd rows shift by half tile width)
   local function rowShiftX(row0) return (row0 % 2 == 0) and 0 or halfWidth end
 
   -- How tall can any tile image be? (margin for tall isometric art)
-  local maxImgH = layer.maxImgH or 0
-  local overdrawRows = ceil(max(0, maxImgH - tileHeight) / max(1, halfHeight)) + 1
+  local maxImageHeight = layerData.maxImgH or 0
+  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1
 
   -- Row range that can touch this buffer (layer-local coords)
   -- drawY = row0 * halfHeight + offsetY
-  local minRow0 = floor((-offsetY - maxImgH) / halfHeight) - 1
+  local minRow0 = floor((-offsetY - maxImageHeight) / halfHeight) - 1
   local maxRow0 = ceil ((bufferHeight - offsetY) / halfHeight) + 1
   minRow0 = max(0, minRow0 - overdrawRows)
-  maxRow0 = min(mapHeightTiles - 1, maxRow0 + overdrawRows)
+  maxRow0 = min(mapHeight - 1, maxRow0 + overdrawRows)
 
   -- Flat tiles + stride (fallback to map width)
-  local tiles  = layer.tilesFlat
-  local stride = layer.tilesStride or mapWidthTiles
+  local tiles  = layerData.tilesFlat
+  local stride = layerData.tilesStride or mapWidth
 
   -- Per-tile offset cache (avoid repeated _isoDrawOffsets calls)
-  local offCache = layer._offCache
-  if not offCache then
-    offCache = {}
-    layer._offCache = offCache
+  local offsetCache = layerData._offsetCache
+  if not offsetCache then
+    offsetCache = {}
+    layerData._offsetCache = offsetCache
   end
 
   for row0 = minRow0, maxRow0 do
@@ -232,78 +268,80 @@ function RoxyStagTilemap:_renderLayerToBuffer(layer, offsetX, offsetY, bufferWid
 
     -- In this row, drawX = baseX + (tileX-1)*tileWidth
     -- Choose tiles whose drawX overlaps the buffer with a 1-tile margin
-    local minTileX = floor((-tileWidth - baseX) / tileWidth)       -- 0-based col
-    local maxTileX = floor((bufferWidth - 1 - baseX) / tileWidth)  -- 0-based col
+    local minTileX = floor((-tileWidth - baseX) / tileWidth)      -- 0-based col
+    local maxTileX = floor((bufferWidth - 1 - baseX) / tileWidth) -- 0-based col
     minTileX = max(0, minTileX - 1)
-    maxTileX = min(mapWidthTiles - 1, maxTileX + 1)
+    maxTileX = min(mapWidth - 1, maxTileX + 1)
 
     if minTileX <= maxTileX then
       local rowIndex = row0 * stride + (minTileX + 1) -- tiles[] is 1-based
-      local drawX    = baseX + minTileX * tileWidth
+      local drawX = baseX + minTileX * tileWidth
 
       for col0 = minTileX, maxTileX do
         local tileIndex = tiles and tiles[rowIndex] or 0
-        if tileIndex and tileIndex > 0 and tileIndex <= len then
-          local img = layer._imgCache[tileIndex]
+        if tileIndex and tileIndex > 0 and tileIndex <= n then
+          local img = layerData._imageCache[tileIndex]
           if not img then
             img = imageTable:getImage(tileIndex)
-            layer._imgCache[tileIndex] = img
+            layerData._imageCache[tileIndex] = img
           end
 
           if img then
-            -- cached isometric draw offsets per tileIndex
-            local offX, offY = offCache[tileIndex]
-            if not offX then
-              offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-              offCache[tileIndex] = offX
-              offCache[tileIndex + 0.5] = offY -- cheap 2nd key to store Y
+            -- Cached isometric draw offsets per tileIndex
+            local offsetX, offsetY = offsetCache[tileIndex]
+            if not offsetX then
+              offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+              offsetCache[tileIndex] = offsetX
+              offsetCache[tileIndex + 0.5] = offsetY -- Cheap 2nd key to store Y
             else
-              offY = offCache[tileIndex + 0.5]
+              offsetY = offsetCache[tileIndex + 0.5]
             end
 
-            local dx, dy = drawX + offX, baseY + offY
+            local drawPositionX, drawPositionY = drawX + offsetX, baseY + offsetY
             -- Quick clip against the buffer (0..bufferWidth/Height)
-            if dx < bufferWidth and dy < bufferHeight and dx > -tileWidth and dy > -tileHeight then
-              img:draw(dx, dy)
+            if drawPositionX < bufferWidth and drawPositionY < bufferHeight
+            and drawPositionX > -tileWidth and drawPositionY > -tileHeight then
+              img:draw(drawPositionX, drawPositionY)
             end
           end
         end
-        rowIndex = rowIndex + 1
-        drawX    = drawX + tileWidth
+        rowIndex += 1
+        drawX += tileWidth
       end
     end
   end
 end
 
--- ! Draw Static Layer Chunked
+-- ! Utility: Draw Static Layer Chunked
+-- Render a chunked layer using prebuilt chunk images
 function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
-  local layerInfo = self._staticChunkLayers[layerName]
-  if not layerInfo then return end
+  local currentLayer = self._staticChunkLayers[layerName]
+  if not currentLayer then return end
 
-  local layer   = layerInfo.layer
-  local size    = layerInfo.size
-  local overlap = layerInfo.overlap
+  local layer   = currentLayer.layer
+  local size    = currentLayer.size
+  local overlap = currentLayer.overlap
 
   -- Visible rect in layer coordinates (inflate by overlap)
-  local vx, vy, vw, vh = _visibleLayerRect(self, layer)
-  vx = vx - overlap; vy = vy - overlap
-  vw = vw + 2 * overlap; vh = vh + 2 * overlap
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+  visibleX -= overlap; visibleY -= overlap
+  visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-  local minCX, maxCX, minCY, maxCY = _chunkIndicesForRect(vx, vy, vw, vh, size)
+  local minChunkX, maxChunkX, minChunkY, maxChunkY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
 
-  for cy = minCY, maxCY do
-    local rowDestY = cy * size - overlap + screenY
-    for cx = minCX, maxCX do
-      local img = self:_getOrBuildChunk(layerInfo, cx, cy)
+  for chunkY = minChunkY, maxChunkY do
+    local rowDestY = chunkY * size - overlap + screenY
+    for chunkX = minChunkX, maxChunkX do
+      local img = self:_getOrBuildChunk(currentLayer, chunkX, chunkY)
       if img then
-        local destX = cx * size - overlap + screenX
+        local destX = chunkX * size - overlap + screenX
         local destY = rowDestY
 
-        -- Simple on-screen test, but DO NOT modify the clip rect here.
-        local iw, ih = img:getSize()
+        -- Simple on-screen test
+        local imageWidth, imageHeight = img:getSize()
         if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
-             or destX + iw <= 0      or destY + ih <= 0) then
+             or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
           img:draw(destX, destY)
         end
       end
@@ -316,20 +354,21 @@ end
 --------------------------------------------------------------------------------
 
 -- ! World to Screen
-function RoxyStagTilemap:worldToScreen(worldX, worldY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+-- Convert world coordinates to screen coordinates with parallax support
+function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
   local row0 = floor(worldY + 1e-6)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
   -- Parallax-origin pivot to mirror sprite behavior
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
@@ -342,29 +381,30 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layer)
 end
 
 -- ! Screen to World
-function RoxyStagTilemap:screenToWorld(screenX, screenY, layer)
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+-- Convert screen coordinates to world coordinates with parallax support
+function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
   -- Parallax-origin pivot to mirror sprite behavior
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
   -- Undo camera and pivot before converting to world
-  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
-  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+  local deltaX = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
+  local deltaY = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldY = dy / halfHeight
+  local worldY = deltaY / halfHeight
   local row0 = floor(worldY + 1e-6)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-  local worldX = (dx - shiftX) / tileWidth
+  local worldX = (deltaX - shiftX) / tileWidth
   return worldX, worldY
 end
 
@@ -392,12 +432,11 @@ function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
 end
 
 -- ! Get Row From Screen
+-- Determine which tile row corresponds to screen coordinates
 function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
-    for _, layer in pairs(self.layers or {}) do
-      if layer.tilemap then targetLayer = layer; break end
-    end
+    targetLayer = _findFirstAvailableLayer(self.layers)
     if not targetLayer then return 1 end
   end
 
@@ -409,6 +448,7 @@ function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
 end
 
 -- ! Resort Layers
+-- Rebuild the layer drawing order (call after changing layer z-indices)
 function RoxyStagTilemap:resortLayers()
   self:_rebuildOrderedLayers()
 end
@@ -416,21 +456,21 @@ end
 -- ! Mark Tiles Dirty
 -- Tile edits --> evict overlapping chunks (they will rebuild lazily)
 function RoxyStagTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
-  local layerInfo = self._staticChunkLayers[layerName]
-  if not layerInfo then return end
+  local currentLayer = self._staticChunkLayers[layerName]
+  if not currentLayer then return end
 
   -- Calculate affected chunks and evict from global bucket
-  local tileWidth, tileHeight = layerInfo.layer.tileWidth, layerInfo.layer.tileHeight
+  local tileWidth, tileHeight = currentLayer.layer.tileWidth, currentLayer.layer.tileHeight
   local pixelX = (tileX - 1) * tileWidth
   local pixelY = (tileY - 1) * (tileHeight * 0.5)
   local pixelWidth = (tileCountWidth or 1) * tileWidth
   local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerInfo.size)
-  for chunkY = minY, maxY do
-    for chunkX = minX, maxX do
-      evictAsset(self._globalChunkBucket, layerInfo.keyPrefix .. chunkX .. ":" .. chunkY)
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, currentLayer.size)
+  for chunkY = minChunkY, maxChunkY do
+    for chunkX = minChunkX, maxChunkX do
+      evictAsset(self._globalChunkBucket, currentLayer.keyPrefix .. chunkX .. ":" .. chunkY)
     end
   end
 end
@@ -440,6 +480,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
+-- Draw a single layer (chunked or dynamic fallback)
 function RoxyStagTilemap:draw(layerName)
   if self._staticChunkLayers[layerName] then
     self:_drawStaticLayerChunked(layerName); return
@@ -447,15 +488,14 @@ function RoxyStagTilemap:draw(layerName)
 
   -- Dynamic fallback (rare):
   -- draw only visible rows/cols with coarse margin
-  local layer = self.layers and self.layers[layerName]
-  if not layer or not layer.tilemap or layer.visible == false then return end
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
 
-  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-  local tileHeight = layer.tileHeight or 0
-  local halfHeight = tileHeight * 0.5
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  local tileHeight = layerData.tileHeight or 0
 
-  local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
-  local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+  local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
+  local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
 
   local margin = TILE_MARGIN
 
@@ -465,15 +505,15 @@ function RoxyStagTilemap:draw(layerName)
   local maxWorldY = max(topWorld, bottomWorld) + margin
 
   local minTileX = max(1, floor(minWorldX) + 1)
-  local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
+  local maxTileX = min(mapWidth, ceil(maxWorldX) + 1)
   local minTileY = max(1, floor(minWorldY) + 1)
-  local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
+  local maxTileY = min(mapHeight, ceil(maxWorldY) + 1)
 
   self:drawLayerRows(layerName, minTileY, maxTileY, minTileX, maxTileX)
 end
 
 -- ! Draw Visible
--- Straight loop using pre-sorted layers
+-- Draw all visible layers in the correct z-order
 function RoxyStagTilemap:drawVisible()
   local ordered = self._orderedLayers
   for i = 1, #ordered do
@@ -487,7 +527,7 @@ function RoxyStagTilemap:drawVisible()
 end
 
 -- ! Draw Visible in Rectangle
--- Draw Visible in Rectangle (unchanged structure, keep the outer clip only)
+-- Draw visible layers within a clipping rectangle
 function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
     self:drawVisible()
@@ -495,58 +535,59 @@ function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
 end
 
 -- ! Draw Layer Rows
--- Dynamic row/column renderer (no per-tile img:getSize culling)
+-- Dynamic row/column renderer with manual sprite positioning
 function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxColumn)
   local restoreX, restoreY = _beginManualDraw()
 
-  local layer = self.layers and self.layers[layerName]
-  if not layer or not layer.tilemap or layer.visible == false then
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then
     _endManualDraw(restoreX, restoreY); return
   end
 
-  local imageTable = layer.imageTable
+  local imageTable = layerData.imageTable
   if not imageTable then
     _endManualDraw(restoreX, restoreY); return
   end
 
-  local len = imageTable:getLength()
-  local tilemap = layer.tilemap
-  local mapWidthTiles, mapHeightTiles = tilemap:getSize()
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local n = layerData.imageCount
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
 
   local rowStart = max(1, minRow or 1)
-  local rowEnd = min(mapHeightTiles, maxRow or mapHeightTiles)
+  local rowEnd = min(mapHeight, maxRow or mapHeight)
   if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
 
   local minX, maxX
   if minColumn and maxColumn then
     minX = max(1, minColumn)
-    maxX = min(mapWidthTiles, maxColumn)
+    maxX = min(mapWidth, maxColumn)
   else
     -- Fallback to coarse bounds if none provided
-    local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
-    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
+    local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
+    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
     local minWorldX = floor(min(leftWorld, rightWorld)) - 2
-    local maxWorldX = ceil (max(leftWorld, rightWorld)) + 2
+    local maxWorldX = ceil(max(leftWorld, rightWorld)) + 2
     minX = max(1, minWorldX + 1)
-    maxX = min(mapWidthTiles, maxWorldX + 1)
+    maxX = min(mapWidth, maxWorldX + 1)
   end
   if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
-  local tiles = layer.tilesFlat
-  local stride = layer.tilesStride
+  local tiles = layerData.tilesFlat
+  local stride = layerData.tilesStride
 
-  -- Hoisted transforms
-  local originX, originY      = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY  = layer.parallaxx or 1, layer.parallaxy or 1
-  local parallaxOriginX       = layer.parallaxoriginx or 0
-  local parallaxOriginY       = layer.parallaxoriginy or 0
+  -- Hoisted transforms to avoid repeated calculations
+  local originX, originY      = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
+  local parallaxOriginX       = layerData.parallaxoriginx or 0
+  local parallaxOriginY       = layerData.parallaxoriginy or 0
   local pivotAdjustX          = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY          = parallaxOriginY * (1 - parallaxY)
   local cameraX, cameraY      = getCameraPosition()
-  local halfHeight, halfWidth = tileHeight * 0.5, tileWidth * 0.5
+  local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local tilesetKeyPrefix = "tilesetimg:" .. tostring(imageTable) .. ":"
+  -- Add lightweight per-layer caches for images and offsets (no LRU overhead)
+  layerData._imageCache  = layerData._imageCache  or {}
+  layerData._offsetCache = layerData._offsetCache or {}
 
   for tileY = rowStart, rowEnd do
     local row0 = tileY - 1
@@ -560,12 +601,23 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
 
     for tileX = minX, maxX do
       local tileIndex = tiles and tiles[rowIndex] or 0
-      if tileIndex and tileIndex > 0 and tileIndex <= len then
-        local key = tilesetKeyPrefix .. tileIndex
-        local img = getOrLoadAsset(key, function() return imageTable:getImage(tileIndex) end)
+      if tileIndex and tileIndex > 0 and tileIndex <= n then
+        local img = layerData._imageCache[tileIndex]
+        if not img then
+          img = imageTable:getImage(tileIndex)
+          layerData._imageCache[tileIndex] = img
+        end
         if img then
-          local offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-          img:draw(currentX + offX, baseScreenY + offY)
+          local offsetX = layerData._offsetCache[tileIndex]
+          local offsetY
+          if not offsetX then
+            offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
+            layerData._offsetCache[tileIndex] = offsetX
+            layerData._offsetCache[tileIndex + 0.5] = offsetY
+          else
+            offsetY = layerData._offsetCache[tileIndex + 0.5]
+          end
+          img:draw(currentX + offsetX, baseScreenY + offsetY)
         end
       end
       currentX += tileWidth
@@ -580,6 +632,7 @@ end
 -- Cleanup
 --------------------------------------------------------------------------------
 
+-- ! Destroy
 -- Clean up static layer resources
 function RoxyStagTilemap:destroy()
   if self._globalChunkBucket then

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -40,6 +40,7 @@ local evictAsset        <const> = Cache.evictAsset
 local clearCache        <const> = Cache.clearCache
 
 local getCameraPosition <const> = Camera.getPosition
+local setCameraBounds   <const> = Camera.setBounds
 
 local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
@@ -49,13 +50,14 @@ local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
 
 -- Default chunk settings
-local DEFAULT_CHUNK_SIZE    <const> = 256 -- Rule of thumb: tileWidth * 4
+local DEFAULT_CHUNK_SIZE    <const> = 256 -- tileWidth * 4
 local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
-local DEFAULT_TILE_WIDTH    <const> = 64 -- Default tile width
 
--- Coarse safety margin (in tiles) for dynamic fallback culling
-local TILE_MARGIN <const> = 0.5
+-- Cull margins / epsilon
+local TILE_MARGIN          <const> = 0.5 -- Coarse safety margin for dynamic draw
+local VISIBLE_MARGIN_TILES <const> = 2
+local FLOAT_EPSILON        <const> = 0.000001
 
 local PREFETCH_RINGS  <const> = 1  -- 1 ring beyond visible
 local BUILD_BUDGET    <const> = 2  -- Build at most 2 chunks per frame
@@ -121,14 +123,14 @@ end
 local function _packTilesU16(tiles)
   if not tiles or #tiles == 0 then return nil end
   local n = #tiles
-  local fmt = stringRep("<I2", n)
-  local tmp = {}
+  local format = stringRep("<I2", n)
+  local temp = {}
   for i = 1, n do
     local v = tiles[i] or 0
     if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
-    tmp[i] = v
+    temp[i] = v
   end
-  return stringPack(fmt, tableUnpack(tmp, 1, n))
+  return stringPack(format, tableUnpack(temp, 1, n))
 end
 
 -- ! Helper: Sanitize a single tile index
@@ -161,6 +163,37 @@ local function _syncNativeTiles(layerData)
   end
 end
 
+-- ! Helper: Warm Score
+-- Warm queue prioritization helper (closest chunk to visible center)
+local function _warmScore(self, job)
+  local layerConfig = job.layerConfig
+  local size = layerConfig.size
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerConfig.layer)
+  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local centerX = (minX + maxX) * 0.5
+  local centerY = (minY + maxY) * 0.5
+  local dx = abs(job.chunkX - centerX)
+  local dy = abs(job.chunkY - centerY)
+  return dx + dy -- Manhattan distance is cheap and good enough
+end
+
+-- ! Helper: Dequeue Best Warm Job
+local function _dequeueBestWarmJob(self)
+  local queue = self._warmQueue
+  local bestIndex, bestScore
+  for idx = 1, #queue do
+    local score = _warmScore(self, queue[idx])
+    if not bestScore or score < bestScore then
+      bestScore, bestIndex = score, idx
+    end
+  end
+  if not bestIndex then return nil end
+  local job = queue[bestIndex]
+  tableRemove(queue, bestIndex)
+  self._warmSet[job.key] = nil
+  return job
+end
+
 --------------------------------------------------------------------------------
 -- Class Definition / Initialize
 --------------------------------------------------------------------------------
@@ -172,6 +205,46 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   opts.wrapInSprites = false
   opts.anchor = "topLeft"
   RoxyStagTilemap.super.init(self, jsonPath, opts, scene)
+
+  -- Override world size for staggered-y projection
+  local mapWidthTiles   = self.mapWidth  or 0
+  local mapHeightTiles  = self.mapHeight or 0
+  local tileWidth       = self.mapTileWidth or 0
+  local tileHeight      = self.mapTileHeight or 0
+
+  local halfWidthPx   = tileWidth * 0.5
+  local halfHeightPx  = tileHeight * 0.5
+
+  -- Horizontal span: columns plus stagger overhang
+  self.worldWidth = mapWidthTiles * tileWidth + halfWidthPx
+
+  -- Vertical span: rows spaced by halfHeight
+  local worldHeightBase = mapHeightTiles * halfHeightPx
+
+  -- Adjust for any tall tiles (maxImageHeight across layers)
+  local maxOverdrawPx = 0
+  for _, layer in pairs(self.layers or {}) do
+    if layer.tilemap then
+      local maxImageHeight = layer.maxImageHeight or 0
+      if maxImageHeight > tileHeight then
+        local over = max(0, (maxImageHeight - tileHeight) * 0.5)
+        if over > maxOverdrawPx then maxOverdrawPx = over end
+      end
+    end
+  end
+  self.worldHeight = worldHeightBase + maxOverdrawPx
+
+  -- Refresh camera bounds if requested
+  if opts and opts.cameraBounds then
+    local x2 = max(0, self.worldWidth - DISPLAY_WIDTH)
+    local y2 = max(0, self.worldHeight - DISPLAY_HEIGHT)
+
+    if type(self.setCameraBounds) == "function" then
+      pcall(function() self:setCameraBounds(0, 0, x2, y2) end)
+    elseif Camera and type(setCameraBounds) == "function" then
+      pcall(function() setCameraBounds({ x1 = 0, y1 = 0, x2 = x2, y2 = y2 }) end)
+    end
+  end
 
   self._projection = "staggered-y"
   self.staggerAxis = self.staggerAxis or "y"
@@ -185,7 +258,6 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   self._warmSet   = {}  -- Tracks keys already queued
 
   self._didPrimeVisible = false -- One-time prime flag
-
   self._frameDirty = true -- Assume dirty until first frame settles
   self._lastCameraX, self._lastCameraY = nil, nil -- Camera stamp
 
@@ -203,9 +275,9 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
         -- Sanitize tiles once on load so the native blob never sees out-of-range values
         _sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
 
-        local isIsometric              = 0
-        local staggerIndexOdd          = (self.staggerIndex == "odd") and 1 or 0
-        local staggerDirectionRight    = (self.staggerDirection == "right") and 1 or 0
+        local isIsometric = 0
+        local staggerIndexOdd = (self.staggerIndex == "odd") and 1 or 0
+        local staggerDirectionRight = (self.staggerDirection == "right") and 1 or 0
 
         --#DEBUG START
         if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
@@ -220,10 +292,10 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
           staggerDirectionRight,
           layerData.mapWidth,       -- Tiles
           layerData.mapHeight,      -- Tiles
-          layerData.tileWidth,      -- Pixels
-          layerData.tileHeight,     -- Pixels
-          layerData.halfWidth,      -- Pixels
-          layerData.halfHeight,     -- Pixels
+          layerData.tileWidth,      -- px
+          layerData.tileHeight,     -- px
+          layerData.halfWidth,      -- px
+          layerData.halfHeight,     -- px
           layerData.maxImageHeight, -- Tall art overdraw
           layerData.imageTable,     -- LCDBitmapTable
           layerData.imageCount,     -- Frames in table
@@ -272,6 +344,7 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
         size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
         overlap   = overlap,
         keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
+        _dirty    = true, -- Per-layer dirty bit
       }
     end
   end
@@ -281,28 +354,25 @@ end
 -- Build currently visible chunks once to avoid first-frame misses
 function RoxyStagTilemap:_primeVisibleChunks()
   if self._didPrimeVisible then return end
-
   for _, layerConfig in pairs(self._staticChunkLayers) do
     local layer = layerConfig.layer
     local size, overlap = layerConfig.size, layerConfig.overlap
 
-    local vx, vy, vw, vh = _visibleLayerRect(self, layer)
-    vx -= overlap; vy -= overlap; vw += 2 * overlap; vh += 2 * overlap
+    local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+    visibleX -= overlap; visibleY -= overlap; visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-    local minChunkX, maxChunkX, minChunkY, maxChunkY = _chunkIndicesForRect(vx, vy, vw, vh, size)
-
-    for cy = minChunkY, maxChunkY do
-      for cx = minChunkX, maxChunkX do
-        local key = layerConfig.keyPrefix .. cx .. ":" .. cy
+    local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    for chunkY = minY, maxY do
+      for chunkX = minX, maxX do
+        local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
         if not getIsAssetCached(self._globalChunkBucket, key) then
-          local img = self:_buildChunk(layerConfig, cx, cy)
-          if img then putAsset(self._globalChunkBucket, key, img) end
+          self:_enqueueWarm(layerConfig, chunkX, chunkY)
         end
       end
     end
   end
-
   self._didPrimeVisible = true
+  self._frameDirty = true
 end
 
 -- ! Rebuild Ordered Layers
@@ -321,27 +391,12 @@ end
 
 -- ! Preload Layer Caches
 function RoxyStagTilemap:_preloadLayerCaches(layerData)
-  if not layerData.imageTable or not layerData.tileWidth or not layerData.tileHeight then return end
-
-  local n = layerData.imageCount
-  layerData._imageCache = {}
-  layerData._offsetCache = {}
-
-  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
-
-  for i = 1, n do
-    local img = layerData.imageTable:getImage(i)
-    if img then
-      layerData._imageCache[i] = img
-      local offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
-      layerData._offsetCache[i] = offsetX
-      layerData._offsetCache[i + 0.5] = offsetY
-    end
-  end
+  layerData._imageCache  = layerData._imageCache  or {}
+  layerData._offsetCache = layerData._offsetCache or {}
 end
 
 --
--- Chunk building & drawing
+-- Chunk building & warming
 --
 
 -- ! Enqueue Warm
@@ -362,8 +417,8 @@ end
 function RoxyStagTilemap:_warmSomeChunks()
   local built = 0
   while built < BUILD_BUDGET and #self._warmQueue > 0 do
-    local job = tableRemove(self._warmQueue)
-    self._warmSet[job.key] = nil
+    local job = _dequeueBestWarmJob(self) -- Pick closest
+    if not job then break end
     if not getIsAssetCached(self._globalChunkBucket, job.key) then
       local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
       if img then
@@ -389,6 +444,11 @@ function RoxyStagTilemap:_buildChunk(layerConfig, chunkX, chunkY)
   local size, overlap = layerConfig.size, layerConfig.overlap
   local width, height = size + 2 * overlap, size + 2 * overlap
   local img = newImage(width, height)
+  if not img then
+    -- Low-memory guard
+    Log.warn("[RoxyStagTilemap] Failed to allocate chunk image (%dx%d)", width, height)
+    return nil
+  end
 
   local pixelX = chunkX * size - overlap
   local pixelY = chunkY * size - overlap
@@ -459,7 +519,7 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
   local function rowShiftX(row0) return (row0 % 2 == 0) and 0 or halfWidth end
 
   local maxImageHeight = layerData.maxImageHeight or 0
-  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1
+  local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1 -- Safety +1
 
   local minRow0 = floor((-offsetY - maxImageHeight) / halfHeight) - 1
   local maxRow0 = ceil ((bufferHeight - offsetY) / halfHeight) + 1
@@ -467,7 +527,7 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
   maxRow0 = min(mapHeight - 1, maxRow0 + overdrawRows)
 
   local tiles  = layerData.tilesFlat
-  local stride = layerData.tilesStride or mapWidth
+  local stride = layerData.tilesStride or mapWidth  -- Restore fallback
 
   local offsetCache = layerData._offsetCache
   if not offsetCache then
@@ -519,6 +579,10 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
   end
 end
 
+--
+-- Chunked draw (with single-pass fallback)
+--
+
 -- ! Draw Static Layer Chunked
 -- Render a chunked layer using prebuilt chunk images (row-clipped fallback)
 function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
@@ -528,40 +592,52 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
   local layer         = layerConfig.layer
   local size, overlap = layerConfig.size, layerConfig.overlap
 
+  -- Visible rect in layer coords, padded by overlap.
   local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
   visibleX -= overlap; visibleY -= overlap
-  visibleWidth  += 2 * overlap; visibleHeight += 2 * overlap
+  visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-  local minChunkX, maxChunkX, minChunkY, maxChunkY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
 
-  for chunkY = minChunkY, maxChunkY do
+  -- First pass — scan for any missing chunks and enqueue builds.
+  local anyMissing = false
+  local toDraw = {} -- {img, dx, dy, imageWidth, imageHeight}
+  local imageWidth, imageHeight = size + 2 * overlap, size + 2 * overlap
+
+  for chunkY = minY, maxY do
     local rowDeltaY = chunkY * size - overlap + screenY
-    for chunkX = minChunkX, maxChunkX do
+    for chunkX = minX, maxX do
       local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
-
-      local dx = chunkX * size - overlap + screenX
-      local dy = rowDeltaY
-      local imageWidth = size + 2 * overlap
-      local imageHeight = size + 2 * overlap
-
-      -- Try blitting the prebuilt chunk image
       local img = getCachedAsset(self._globalChunkBucket, key)
       if img then
-        img:draw(floor(dx), floor(dy))
-      else
-        -- Fallback: clip to chunk rect and render rows
-        local imageX, imageY = floor(dx), floor(dy)
-        local imageWidthFloored, imageHeightFloored = floor(imageWidth), floor(imageHeight)
-        if imageWidthFloored > 0 and imageHeightFloored > 0 then
-          setClipRect(imageX, imageY, imageWidthFloored, imageHeightFloored)
-            self:drawLayerRows(layerName, nil, nil, nil, nil)
-          clearClipRect()
+        local dx = chunkX * size - overlap + screenX
+        local dy = rowDeltaY
+        -- Offscreen culling
+        if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
+          toDraw[#toDraw + 1] = { img = img, dx = dx, dy = dy } -- ints already
         end
-        -- Queue this chunk to build for future frames
+      else
+        anyMissing = true
         self:_enqueueWarm(layerConfig, chunkX, chunkY)
       end
     end
+  end
+
+  if anyMissing then
+    -- Single-pass fallback — render the layer once (native rows or Lua), not per-miss.
+    -- Clip to screen to be safe.
+    setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
+      self:drawLayerRows(layerName, nil, nil, nil, nil)
+    clearClipRect()
+    return
+  end
+
+  -- All chunks available — draw them.
+  for index = 1, #toDraw do
+    local element = toDraw[index]
+    -- dx/dy are already integers; removed floor() for tiny win.
+    element.img:draw(element.dx, element.dy)
   end
 end
 
@@ -579,10 +655,9 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  local row0 = floor(worldY + 1e-6)
+  local row0 = floor(worldY + FLOAT_EPSILON)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-  -- Parallax-origin pivot to mirror sprite behavior.
   local parallaxOriginX = layerData.parallaxoriginx or 0
   local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
@@ -610,14 +685,14 @@ function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
-  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+  local deltaX = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
+  local deltaY = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldY = dy / halfHeight
-  local row0 = floor(worldY + 1e-6)
+  local worldY = deltaY / halfHeight
+  local row0 = floor(worldY + FLOAT_EPSILON)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-  local worldX = (dx - shiftX) / tileWidth
+  local worldX = (deltaX - shiftX) / tileWidth
   return worldX, worldY
 end
 
@@ -625,37 +700,45 @@ end
 -- Public API
 --------------------------------------------------------------------------------
 
+-- ! Mark Dirty
+-- Public dirty marker for external animation/parallax/etc
+function RoxyStagTilemap:markDirty()
+  self._frameDirty = true
+end
+
 -- ! Set Tile At
 -- Override setTileAt to handle static layer updates
 function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
   local layer = self.layers and self.layers[layerName]
   if not layer then return end
 
-  -- Sanitize incoming edit
+  -- CHANGE: explicit bounds check to avoid native issues
+  local mapWidth, mapHeight = layer.mapWidth or 0, layer.mapHeight or 0
+  if x < 1 or y < 1 or x > mapWidth or y > mapHeight then
+    Log.warn("[RoxyStagTilemap] setTileAt out of bounds (".. x .. ", ".. y .. ") not in [1..".. mapWidth .. ",1.." .. mapHeight .."]") --#DEBUG
+    return
+  end
+
   local cleanIndex = _sanitizeTileIndex(tileIndex, layer.imageCount)
 
-  -- Write to Tiled tilemap.
   layer.tilemap:setTileAtPosition(x, y, cleanIndex)
 
-  -- Update cached flat data used by dynamic paths
   local tiles = layer.tilesFlat
   if tiles then
     local stride = layer.tilesStride or layer.mapWidth
     if stride and stride > 0 then
-      local idx = (y - 1) * stride + x
-      if idx >= 1 and idx <= #tiles then
-        tiles[idx] = cleanIndex
+      local index = (y - 1) * stride + x
+      if index >= 1 and index <= #tiles then
+        tiles[index] = cleanIndex
       end
     end
   end
 
-  -- Mirror to native renderer for C-side fast paths
   local nativeRenderer = layer._nativeRenderer
   if nativeRenderer then
     nativeRenderer:setTileAt(x, y, cleanIndex)
   end
 
-  -- Evict overlapping chunks so they rebuild lazily
   if self._staticChunkLayers[layerName] then
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
@@ -665,6 +748,21 @@ function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
     addDirtyRect(screenX, screenY, tileWidth, tileHeight)
   end
+end
+
+-- ! Get Row From Screen
+function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
+  local targetLayer = self.layers and self.layers[layerName]
+  if not targetLayer then
+    targetLayer = _findFirstAvailableLayer(self.layers)
+    if not targetLayer then return 1 end
+  end
+
+  local _, mapHeightTiles = targetLayer.tilemap:getSize()
+  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
+  local row = floor(worldY + 1)
+  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
+  return row
 end
 
 -- ! Get Row From Screen
@@ -856,15 +954,15 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   else
     local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
     local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
-    local minWorldX = floor(min(leftWorld, rightWorld)) - 2
-    local maxWorldX = ceil(max(leftWorld, rightWorld)) + 2
+    local minWorldX = floor(min(leftWorld, rightWorld)) - VISIBLE_MARGIN_TILES
+    local maxWorldX = ceil (max(leftWorld, rightWorld)) + VISIBLE_MARGIN_TILES
     minX = max(1, minWorldX + 1)
     maxX = min(mapWidth, maxWorldX + 1)
   end
   if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
   local tiles = layerData.tilesFlat
-  local stride = layerData.tilesStride
+  local stride = layerData.tilesStride or mapWidth
 
   local originX, originY      = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -195,7 +195,7 @@ local function _dequeueBestWarmJob(self)
 end
 
 --------------------------------------------------------------------------------
--- Class Definition / Initialize
+-- ! Class Definition / Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyStagTilemap").extends(RoxyTilemap)
@@ -259,6 +259,7 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
 
   self._didPrimeVisible = false -- One-time prime flag
   self._frameDirty = true -- Assume dirty until first frame settles
+  self._forceDrawFrames = 0 -- Track a small "force draw" window for explicit repaints
   self._lastCameraX, self._lastCameraY = nil, nil -- Camera stamp
 
   -- Map-scoped cache key namespace
@@ -859,14 +860,18 @@ function RoxyStagTilemap:drawVisible()
   local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
   local hasWarmWork = self:_hasWarmWork()
 
-  -- Respect an explicit "force" from drawVisibleInRect to always paint when asked.
-  -- This prevents blank frames after transitions/wake that cleared the buffer.
-  if (not self._forceDraw) and cameraUnchanged and not self._frameDirty and not hasWarmWork then
-    return
+  -- Do not early-out if we are within a forced-draw window
+  if (self._forceDrawFrames or 0) == 0 and cameraUnchanged and not self._frameDirty and not hasWarmWork then
+    return -- Nothing to do this frame.
   end
 
   self._lastCameraX, self._lastCameraY = cameraX, cameraY
-  self._frameDirty = false
+  self._frameDirty = false -- We will render now; clear until something changes again
+
+  -- Consume one forced frame if active
+  if self._forceDrawFrames and self._forceDrawFrames > 0 then
+    self._forceDrawFrames -= 1
+  end
 
   self:_primeVisibleChunks()
 
@@ -887,11 +892,24 @@ end
 -- ! Draw Visible in Rectangle
 function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
-    -- Force this draw call to paint regardless of internal 'clean' state.
-    self._forceDraw = true
+    -- Force this paint to occur at least this frame
+    -- This does not make the renderer "always repaint"
+    -- It is one-shot unless bumped again
+    local n = (self._forceDrawFrames or 0)
+    if n < 1 then self._forceDrawFrames = 1 end
+
     self:drawVisible()
-    self._forceDraw = false
   clearClipRect()
+end
+
+-- ! Force Redraw
+-- Request forced redraws for N frames (e.g., 1–2 frames around transition end)
+function RoxyStagTilemap:forceRedraw(frames)
+  -- Keep the largest pending window; do not shrink an existing request
+  local n = max(0, frames or 1)
+  if (self._forceDrawFrames or 0) < n then
+    self._forceDrawFrames = n
+  end
 end
 
 -- ! Draw Layer Rows

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -12,10 +12,16 @@ local min   <const> = math.min
 local max   <const> = math.max
 local floor <const> = math.floor
 local ceil  <const> = math.ceil
+local abs   <const> = math.abs
 local round <const> = r.Math.round
 
+local stringRep   <const> = string.rep
+local stringPack  <const> = string.pack
+
 local tableInsert <const> = table.insert
+local tableRemove <const> = table.remove
 local tableSort   <const> = table.sort
+local tableUnpack <const> = table.unpack
 
 local pushContext   <const> = Graphics.pushContext
 local popContext    <const> = Graphics.popContext
@@ -26,10 +32,12 @@ local clear         <const> = Graphics.clear
 
 local addDirtyRect <const> = Sprite.addDirtyRect
 
-local newCacheBucket  <const> = Cache.newBucket
-local getOrLoadAsset  <const> = Cache.getOrLoadAsset
-local evictAsset      <const> = Cache.evictAsset
-local clearCache      <const> = Cache.clearCache
+local newCacheBucket    <const> = Cache.newBucket
+local getIsAssetCached  <const> = Cache.getIsAssetCached
+local getCachedAsset    <const> = Cache.getCachedAsset
+local putAsset          <const> = Cache.putAsset
+local evictAsset        <const> = Cache.evictAsset
+local clearCache        <const> = Cache.clearCache
 
 local getCameraPosition <const> = Camera.getPosition
 
@@ -37,13 +45,20 @@ local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+-- C-side bindings
+local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
+
 -- Default chunk settings
-local DEFAULT_CHUNK_SIZE    <const> = 320
+local DEFAULT_CHUNK_SIZE    <const> = 256 -- Rule of thumb: tileWidth * 4
 local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
+local DEFAULT_TILE_WIDTH    <const> = 64 -- Default tile width
 
 -- Coarse safety margin (in tiles) for dynamic fallback culling
 local TILE_MARGIN <const> = 0.5
+
+local PREFETCH_RINGS  <const> = 1  -- 1 ring beyond visible
+local BUILD_BUDGET    <const> = 2  -- Build at most 2 chunks per frame
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
@@ -55,7 +70,7 @@ local COLOR_CLEAR <const> = Graphics.kColorClear
 --------------------------------------------------------------------------------
 
 -- ! Helper: Row Shift X for Row 0
--- Shift in pixels for a 0-based row index (Tiled staggered-y)
+-- Shift, in pixels, for a 0-based row index (Tiled staggered-y)
 local function _rowShiftX_for_row0(self, row0, halfWidth)
   if self.staggerAxis ~= "y" then return 0 end
 
@@ -78,8 +93,8 @@ end
 -- Compute visible layer-space rect
 local function _visibleLayerRect(self, layer)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
-  -- screen shows [0..width, 0..height]
-  -- which corresponds to layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
+  -- The screen shows [0..width, 0..height] which corresponds to
+  -- layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
   return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
 end
 
@@ -94,7 +109,6 @@ local function _chunkIndicesForRect(x, y, width, height, size)
 end
 
 -- ! Helper: Find First Available Layer
--- Extracted repeated layer finding logic
 local function _findFirstAvailableLayer(layers)
   for _, layer in pairs(layers or {}) do
     if layer.tilemap then return layer end
@@ -102,8 +116,53 @@ local function _findFirstAvailableLayer(layers)
   return nil
 end
 
+-- ! Helper: Pack Tiles U16
+-- Pack tiles as little-endian uint16 with clamping
+local function _packTilesU16(tiles)
+  if not tiles or #tiles == 0 then return nil end
+  local n = #tiles
+  local fmt = stringRep("<I2", n)
+  local tmp = {}
+  for i = 1, n do
+    local v = tiles[i] or 0
+    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
+    tmp[i] = v
+  end
+  return stringPack(fmt, tableUnpack(tmp, 1, n))
+end
+
+-- ! Helper: Sanitize a single tile index
+-- Returns 0 for out-of-range/invalid, else the original index (1..imageCount)
+local function _sanitizeTileIndex(tileIndex, imageCount)
+  if tileIndex == nil or type(tileIndex) ~= "number" then return 0 end
+  if tileIndex == 0 then return 0 end
+  if tileIndex < 1 or (imageCount and tileIndex > imageCount) then return 0 end
+  return tileIndex
+end
+
+-- ! Helper: Sanitize tiles in place
+-- Ensures every tile is 0 or in [1..imageCount]
+local function _sanitizeTilesInPlace(tiles, imageCount)
+  if not tiles then return end
+  for i = 1, #tiles do
+    tiles[i] = _sanitizeTileIndex(tiles[i], imageCount)
+  end
+end
+
+-- ! Helper: Sync Native Tiles
+-- Sync native tiles from current tilesFlat
+local function _syncNativeTiles(layerData)
+  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then return end
+  local blob = _packTilesU16(layerData.tilesFlat)
+  if blob then
+    layerData._nativeRenderer:updateTilesBytes(blob)
+    local selfRef = layerData.ownerTilemap
+    if selfRef then selfRef._frameDirty = true end
+  end
+end
+
 --------------------------------------------------------------------------------
--- ! Class Definition and Initialize
+-- Class Definition / Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyStagTilemap").extends(RoxyTilemap)
@@ -122,13 +181,57 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   self._staticChunkLayers = {}
   self._orderedLayers = {}
 
+  self._warmQueue = {}  -- Queue of { layerConfig, chunkX, chunkY, key }
+  self._warmSet   = {}  -- Tracks keys already queued
+
+  self._didPrimeVisible = false -- One-time prime flag
+
+  self._frameDirty = true -- Assume dirty until first frame settles
+  self._lastCameraX, self._lastCameraY = nil, nil -- Camera stamp
+
   -- Map-scoped cache key namespace
   self._mapCacheId = jsonPath or tostring(self)
 
   self:_initializeStaticLayers(opts)
+
   for _, layerData in pairs(self.layers) do
     if layerData.tilemap then
       self:_preloadLayerCaches(layerData)
+
+      -- Create native renderer instance for this layer
+      if layerData.imageTable and newTileRenderer_C then
+        -- Sanitize tiles once on load so the native blob never sees out-of-range values
+        _sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+
+        local isIsometric              = 0
+        local staggerIndexOdd          = (self.staggerIndex == "odd") and 1 or 0
+        local staggerDirectionRight    = (self.staggerDirection == "right") and 1 or 0
+
+        --#DEBUG START
+        if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
+           or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
+          Log.error("[RoxyStagTilemap] Invalid tile metrics; width/height/halves must be > 0")
+        end
+        --#DEBUG END
+
+        layerData._nativeRenderer = newTileRenderer_C(
+          isIsometric,
+          staggerIndexOdd,
+          staggerDirectionRight,
+          layerData.mapWidth,       -- Tiles
+          layerData.mapHeight,      -- Tiles
+          layerData.tileWidth,      -- Pixels
+          layerData.tileHeight,     -- Pixels
+          layerData.halfWidth,      -- Pixels
+          layerData.halfHeight,     -- Pixels
+          layerData.maxImageHeight, -- Tall art overdraw
+          layerData.imageTable,     -- LCDBitmapTable
+          layerData.imageCount,     -- Frames in table
+          nil                       -- Optional tiles blob
+        )
+        layerData.ownerTilemap = self
+        _syncNativeTiles(layerData)
+      end
     end
   end
 
@@ -136,35 +239,74 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
 end
 
 --------------------------------------------------------------------------------
--- Static Layer Configuration
+-- Internal API
 --------------------------------------------------------------------------------
 
--- ! Utility: Initialize Static Layers
+--
+-- Static Layer Configuration
+--
+
+-- ! Initialize Static Layers
 -- Build chunk/static configuration per layer
 function RoxyStagTilemap:_initializeStaticLayers(opts)
   local layerOptions = (opts and opts.layerOptions) or {}
   local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
 
-  -- One shared bucket for all chunk images on this map
   self._globalChunkBucket = newCacheBucket(totalChunkCache)
 
   for layerName, layer in pairs(self.layers) do
     local layerOpts = layerOptions[layerName] or {}
     if layerOpts.preRenderChunked then
+      local halfWidth = layer.halfWidth or floor((layer.tileWidth or DEFAULT_TILE_WIDTH) * 0.5)
+
+      local tallOverdraw = 0
+      if layer.maxImageHeight and layer.tileHeight then
+        tallOverdraw = max(0, ceil((layer.maxImageHeight - layer.tileHeight) * 0.5))
+      end
+
+      local overlap = layerOpts.overlapPx or max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+
       self._staticChunkLayers[layerName] = {
         name      = layerName,
         layer     = layer,
         size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
-        overlap   = layerOpts.overlapPx or DEFAULT_CHUNK_OVERLAP,
-        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
-                    tostring(layer.tiledId or layerName) .. ":",
+        overlap   = overlap,
+        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
       }
     end
   end
 end
 
--- ! Utility: Rebuild Ordered Layers
--- Build a stable, z-sorted draw list once (rarely changes)
+-- ! Prime Visible Chunks
+-- Build currently visible chunks once to avoid first-frame misses
+function RoxyStagTilemap:_primeVisibleChunks()
+  if self._didPrimeVisible then return end
+
+  for _, layerConfig in pairs(self._staticChunkLayers) do
+    local layer = layerConfig.layer
+    local size, overlap = layerConfig.size, layerConfig.overlap
+
+    local vx, vy, vw, vh = _visibleLayerRect(self, layer)
+    vx -= overlap; vy -= overlap; vw += 2 * overlap; vh += 2 * overlap
+
+    local minChunkX, maxChunkX, minChunkY, maxChunkY = _chunkIndicesForRect(vx, vy, vw, vh, size)
+
+    for cy = minChunkY, maxChunkY do
+      for cx = minChunkX, maxChunkX do
+        local key = layerConfig.keyPrefix .. cx .. ":" .. cy
+        if not getIsAssetCached(self._globalChunkBucket, key) then
+          local img = self:_buildChunk(layerConfig, cx, cy)
+          if img then putAsset(self._globalChunkBucket, key, img) end
+        end
+      end
+    end
+  end
+
+  self._didPrimeVisible = true
+end
+
+-- ! Rebuild Ordered Layers
+-- Build a stable, z-sorted draw list (rarely changes)
 function RoxyStagTilemap:_rebuildOrderedLayers()
   local items = {}
   for name, layer in pairs(self.layers) do
@@ -177,12 +319,12 @@ function RoxyStagTilemap:_rebuildOrderedLayers()
   self._orderedLayers = items
 end
 
--- ! Utility: Preload Layer Caches
+-- ! Preload Layer Caches
 function RoxyStagTilemap:_preloadLayerCaches(layerData)
   if not layerData.imageTable or not layerData.tileWidth or not layerData.tileHeight then return end
 
   local n = layerData.imageCount
-  layerData._imageCache = {} -- Overwrite if exists to ensure fresh
+  layerData._imageCache = {}
   layerData._offsetCache = {}
 
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
@@ -198,37 +340,114 @@ function RoxyStagTilemap:_preloadLayerCaches(layerData)
   end
 end
 
---------------------------------------------------------------------------------
+--
 -- Chunk building & drawing
---------------------------------------------------------------------------------
+--
 
--- ! Utility: Get or Build Chunk
--- Build or fetch a prerendered chunk image from the cache
-function RoxyStagTilemap:_getOrBuildChunk(layerData, chunkX, chunkY)
-  local key = layerData.keyPrefix .. chunkX .. ":" .. chunkY
-  return getOrLoadAsset(self._globalChunkBucket, key, function()
-    local size, overlap = layerData.size, layerData.overlap
-    local width, height = size + 2 * overlap, size + 2 * overlap
-    local img = newImage(width, height)
-
-    -- Convert chunk indices to layer pixel origin for this chunk
-    local pixelX = chunkX * size - overlap
-    local pixelY = chunkY * size - overlap
-
-    pushContext(img)
-      setClipRect(0, 0, width, height)
-      clear(COLOR_CLEAR)
-      self:_renderLayerToBuffer(layerData.layer, -pixelX, -pixelY, width, height)
-      clearClipRect()
-    popContext()
-
-    return img
-  end)
+-- ! Enqueue Warm
+function RoxyStagTilemap:_enqueueWarm(layerConfig, chunkX, chunkY)
+  local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+  if self._warmSet[key] then return end
+  self._warmSet[key] = true
+  self._warmQueue[#self._warmQueue + 1] = {
+    layerConfig = layerConfig,
+    chunkX = chunkX,
+    chunkY = chunkY,
+    key = key
+  }
 end
 
--- ! Utility: Render Layer to Buffer
--- Render a layer directly to a buffer context (in layer-local coordinates)
-function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, bufferWidth, bufferHeight)
+-- ! Warm Some Chunks
+-- Amortize chunk builds across frames
+function RoxyStagTilemap:_warmSomeChunks()
+  local built = 0
+  while built < BUILD_BUDGET and #self._warmQueue > 0 do
+    local job = tableRemove(self._warmQueue)
+    self._warmSet[job.key] = nil
+    if not getIsAssetCached(self._globalChunkBucket, job.key) then
+      local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
+      if img then
+        putAsset(self._globalChunkBucket, job.key, img)
+        built += 1
+      end
+    end
+  end
+
+  if built > 0 then
+    self._frameDirty = true
+  end
+end
+
+-- ! Has Warm Work
+-- True when there are chunks waiting to build
+function RoxyStagTilemap:_hasWarmWork()
+  return self._warmQueue and #self._warmQueue > 0
+end
+
+-- ! Build Chunk
+function RoxyStagTilemap:_buildChunk(layerConfig, chunkX, chunkY)
+  local size, overlap = layerConfig.size, layerConfig.overlap
+  local width, height = size + 2 * overlap, size + 2 * overlap
+  local img = newImage(width, height)
+
+  local pixelX = chunkX * size - overlap
+  local pixelY = chunkY * size - overlap
+
+  pushContext(img)
+    setClipRect(0, 0, width, height)
+    clear(COLOR_CLEAR)
+    self:_renderLayerToBuffer(layerConfig.layer, img, -pixelX, -pixelY, width, height)
+    clearClipRect()
+  popContext()
+  return img
+end
+
+-- ! Enqueue Ring
+function RoxyStagTilemap:_enqueueRing(layerData, layerConfig)
+  local size, overlap = layerConfig.size, layerConfig.overlap
+
+  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  visibleX -= (overlap + size * PREFETCH_RINGS)
+  visibleY -= (overlap + size * PREFETCH_RINGS)
+  visibleWidth  += 2 * (overlap + size * PREFETCH_RINGS)
+  visibleHeight += 2 * (overlap + size * PREFETCH_RINGS)
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+
+  -- Skip if ring bounds didn’t change
+  local last = layerConfig._lastRingBounds
+  if last
+    and last.minX == minChunkX and last.maxX == maxChunkX
+    and last.minY == minChunkY and last.maxY == maxChunkY
+  then
+    return
+  end
+  layerConfig._lastRingBounds = { minX = minChunkX, maxX = maxChunkX, minY = minChunkY, maxY = maxChunkY }
+
+  for chunkY = minChunkY, maxChunkY do
+    for chunkX = minChunkX, maxChunkX do
+      local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
+      if not getIsAssetCached(self._globalChunkBucket, key) then
+        self:_enqueueWarm(layerConfig, chunkX, chunkY)
+      end
+    end
+  end
+end
+
+-- ! Render Layer to Buffer
+function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
+  local nativeRenderer = layerData._nativeRenderer
+
+  -- Fast path: native renderer to a real LCDBitmap
+  if nativeRenderer and targetImage ~= nil then
+    nativeRenderer:renderToBuffer(targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
+    return
+  end
+
+  -- Fallback Lua implementation (rare in practice)
+  Log.debug("[_renderLayerToBuffer] Falling back on Lua implementation") --#DEBUG
+
   local imageTable = layerData.imageTable
   local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
   if not mapWidth or not mapHeight or not imageTable then return end
@@ -237,25 +456,19 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffe
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  -- Parity helper (odd rows shift by half tile width)
   local function rowShiftX(row0) return (row0 % 2 == 0) and 0 or halfWidth end
 
-  -- How tall can any tile image be? (margin for tall isometric art)
-  local maxImageHeight = layerData.maxImgH or 0
+  local maxImageHeight = layerData.maxImageHeight or 0
   local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1
 
-  -- Row range that can touch this buffer (layer-local coords)
-  -- drawY = row0 * halfHeight + offsetY
   local minRow0 = floor((-offsetY - maxImageHeight) / halfHeight) - 1
   local maxRow0 = ceil ((bufferHeight - offsetY) / halfHeight) + 1
   minRow0 = max(0, minRow0 - overdrawRows)
   maxRow0 = min(mapHeight - 1, maxRow0 + overdrawRows)
 
-  -- Flat tiles + stride (fallback to map width)
   local tiles  = layerData.tilesFlat
   local stride = layerData.tilesStride or mapWidth
 
-  -- Per-tile offset cache (avoid repeated _isoDrawOffsets calls)
   local offsetCache = layerData._offsetCache
   if not offsetCache then
     offsetCache = {}
@@ -266,15 +479,13 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffe
     local baseX = rowShiftX(row0) + offsetX
     local baseY = row0 * halfHeight + offsetY
 
-    -- In this row, drawX = baseX + (tileX-1)*tileWidth
-    -- Choose tiles whose drawX overlaps the buffer with a 1-tile margin
-    local minTileX = floor((-tileWidth - baseX) / tileWidth)      -- 0-based col
-    local maxTileX = floor((bufferWidth - 1 - baseX) / tileWidth) -- 0-based col
+    local minTileX = floor((-tileWidth - baseX) / tileWidth)
+    local maxTileX = floor((bufferWidth - 1 - baseX) / tileWidth)
     minTileX = max(0, minTileX - 1)
     maxTileX = min(mapWidth - 1, maxTileX + 1)
 
     if minTileX <= maxTileX then
-      local rowIndex = row0 * stride + (minTileX + 1) -- tiles[] is 1-based
+      local rowIndex = row0 * stride + (minTileX + 1)
       local drawX = baseX + minTileX * tileWidth
 
       for col0 = minTileX, maxTileX do
@@ -287,21 +498,17 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffe
           end
 
           if img then
-            -- Cached isometric draw offsets per tileIndex
-            local offsetX, offsetY = offsetCache[tileIndex]
-            if not offsetX then
-              offsetX, offsetY = _isoDrawOffsets(tileWidth, tileHeight, img)
-              offsetCache[tileIndex] = offsetX
-              offsetCache[tileIndex + 0.5] = offsetY -- Cheap 2nd key to store Y
-            else
-              offsetY = offsetCache[tileIndex + 0.5]
+            local offsetX2, offsetY2 = offsetCache[tileIndex], offsetCache[tileIndex + 0.5]
+            if not offsetX2 then
+              offsetX2, offsetY2 = _isoDrawOffsets(tileWidth, tileHeight, img)
+              offsetCache[tileIndex] = offsetX2
+              offsetCache[tileIndex + 0.5] = offsetY2
             end
 
-            local drawPositionX, drawPositionY = drawX + offsetX, baseY + offsetY
-            -- Quick clip against the buffer (0..bufferWidth/Height)
-            if drawPositionX < bufferWidth and drawPositionY < bufferHeight
-            and drawPositionX > -tileWidth and drawPositionY > -tileHeight then
-              img:draw(drawPositionX, drawPositionY)
+            local drawPosX, drawPosY = drawX + offsetX2, baseY + offsetY2
+            if drawPosX < bufferWidth and drawPosY < bufferHeight
+            and drawPosX > -tileWidth and drawPosY > -tileHeight then
+              img:draw(drawPosX, drawPosY)
             end
           end
         end
@@ -312,46 +519,55 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, offsetX, offsetY, buffe
   end
 end
 
--- ! Utility: Draw Static Layer Chunked
--- Render a chunked layer using prebuilt chunk images
+-- ! Draw Static Layer Chunked
+-- Render a chunked layer using prebuilt chunk images (row-clipped fallback)
 function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
-  local currentLayer = self._staticChunkLayers[layerName]
-  if not currentLayer then return end
+  local layerConfig = self._staticChunkLayers[layerName]
+  if not layerConfig then return end
 
-  local layer   = currentLayer.layer
-  local size    = currentLayer.size
-  local overlap = currentLayer.overlap
+  local layer         = layerConfig.layer
+  local size, overlap = layerConfig.size, layerConfig.overlap
 
-  -- Visible rect in layer coordinates (inflate by overlap)
   local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
   visibleX -= overlap; visibleY -= overlap
-  visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
+  visibleWidth  += 2 * overlap; visibleHeight += 2 * overlap
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
 
   for chunkY = minChunkY, maxChunkY do
-    local rowDestY = chunkY * size - overlap + screenY
+    local rowDeltaY = chunkY * size - overlap + screenY
     for chunkX = minChunkX, maxChunkX do
-      local img = self:_getOrBuildChunk(currentLayer, chunkX, chunkY)
-      if img then
-        local destX = chunkX * size - overlap + screenX
-        local destY = rowDestY
+      local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
 
-        -- Simple on-screen test
-        local imageWidth, imageHeight = img:getSize()
-        if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
-             or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
-          img:draw(destX, destY)
+      local dx = chunkX * size - overlap + screenX
+      local dy = rowDeltaY
+      local imageWidth = size + 2 * overlap
+      local imageHeight = size + 2 * overlap
+
+      -- Try blitting the prebuilt chunk image
+      local img = getCachedAsset(self._globalChunkBucket, key)
+      if img then
+        img:draw(floor(dx), floor(dy))
+      else
+        -- Fallback: clip to chunk rect and render rows
+        local imageX, imageY = floor(dx), floor(dy)
+        local imageWidthFloored, imageHeightFloored = floor(imageWidth), floor(imageHeight)
+        if imageWidthFloored > 0 and imageHeightFloored > 0 then
+          setClipRect(imageX, imageY, imageWidthFloored, imageHeightFloored)
+            self:drawLayerRows(layerName, nil, nil, nil, nil)
+          clearClipRect()
         end
+        -- Queue this chunk to build for future frames
+        self:_enqueueWarm(layerConfig, chunkX, chunkY)
       end
     end
   end
 end
 
---------------------------------------------------------------------------------
+--
 -- Projection (Staggered-Y)
---------------------------------------------------------------------------------
+--
 
 -- ! World to Screen
 -- Convert world coordinates to screen coordinates with parallax support
@@ -366,7 +582,7 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
   local row0 = floor(worldY + 1e-6)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-  -- Parallax-origin pivot to mirror sprite behavior
+  -- Parallax-origin pivot to mirror sprite behavior.
   local parallaxOriginX = layerData.parallaxoriginx or 0
   local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
@@ -375,13 +591,12 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
   local screenX = originX + worldX * tileWidth + shiftX
   local screenY = originY + worldY * halfHeight
 
-  -- Apply pivotAdjust* before subtracting camera
   return round(screenX + pivotAdjustX - cameraX * parallaxX),
          round(screenY + pivotAdjustY - cameraY * parallaxY)
 end
 
 -- ! Screen to World
--- Convert screen coordinates to world coordinates with parallax support
+-- Convert screen coordinates to world coordinates with parallax support.
 function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
@@ -390,21 +605,19 @@ function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
 
-  -- Parallax-origin pivot to mirror sprite behavior
   local parallaxOriginX = layerData.parallaxoriginx or 0
   local parallaxOriginY = layerData.parallaxoriginy or 0
   local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-  -- Undo camera and pivot before converting to world
-  local deltaX = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
-  local deltaY = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
+  local dx = (screenX + cameraX * parallaxX) - (originX + pivotAdjustX)
+  local dy = (screenY + cameraY * parallaxY) - (originY + pivotAdjustY)
 
-  local worldY = deltaY / halfHeight
+  local worldY = dy / halfHeight
   local row0 = floor(worldY + 1e-6)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-  local worldX = (deltaX - shiftX) / tileWidth
+  local worldX = (dx - shiftX) / tileWidth
   return worldX, worldY
 end
 
@@ -417,9 +630,32 @@ end
 function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
   local layer = self.layers and self.layers[layerName]
   if not layer then return end
-  layer.tilemap:setTileAtPosition(x, y, tileIndex)
 
-  -- Mark region as dirty for static layers
+  -- Sanitize incoming edit
+  local cleanIndex = _sanitizeTileIndex(tileIndex, layer.imageCount)
+
+  -- Write to Tiled tilemap.
+  layer.tilemap:setTileAtPosition(x, y, cleanIndex)
+
+  -- Update cached flat data used by dynamic paths
+  local tiles = layer.tilesFlat
+  if tiles then
+    local stride = layer.tilesStride or layer.mapWidth
+    if stride and stride > 0 then
+      local idx = (y - 1) * stride + x
+      if idx >= 1 and idx <= #tiles then
+        tiles[idx] = cleanIndex
+      end
+    end
+  end
+
+  -- Mirror to native renderer for C-side fast paths
+  local nativeRenderer = layer._nativeRenderer
+  if nativeRenderer then
+    nativeRenderer:setTileAt(x, y, cleanIndex)
+  end
+
+  -- Evict overlapping chunks so they rebuild lazily
   if self._staticChunkLayers[layerName] then
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
@@ -432,7 +668,6 @@ function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
 end
 
 -- ! Get Row From Screen
--- Determine which tile row corresponds to screen coordinates
 function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
@@ -448,7 +683,6 @@ function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
 end
 
 -- ! Resort Layers
--- Rebuild the layer drawing order (call after changing layer z-indices)
 function RoxyStagTilemap:resortLayers()
   self:_rebuildOrderedLayers()
 end
@@ -456,21 +690,22 @@ end
 -- ! Mark Tiles Dirty
 -- Tile edits --> evict overlapping chunks (they will rebuild lazily)
 function RoxyStagTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
-  local currentLayer = self._staticChunkLayers[layerName]
-  if not currentLayer then return end
+  local layerConfig = self._staticChunkLayers[layerName]
+  if not layerConfig then return end
 
-  -- Calculate affected chunks and evict from global bucket
-  local tileWidth, tileHeight = currentLayer.layer.tileWidth, currentLayer.layer.tileHeight
+  self._frameDirty = true
+
+  local tileWidth, tileHeight = layerConfig.layer.tileWidth, layerConfig.layer.tileHeight
   local pixelX = (tileX - 1) * tileWidth
   local pixelY = (tileY - 1) * (tileHeight * 0.5)
   local pixelWidth = (tileCountWidth or 1) * tileWidth
   local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, currentLayer.size)
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
   for chunkY = minChunkY, maxChunkY do
     for chunkX = minChunkX, maxChunkX do
-      evictAsset(self._globalChunkBucket, currentLayer.keyPrefix .. chunkX .. ":" .. chunkY)
+      evictAsset(self._globalChunkBucket, layerConfig.keyPrefix .. chunkX .. ":" .. chunkY)
     end
   end
 end
@@ -486,13 +721,11 @@ function RoxyStagTilemap:draw(layerName)
     self:_drawStaticLayerChunked(layerName); return
   end
 
-  -- Dynamic fallback (rare):
-  -- draw only visible rows/cols with coarse margin
+  -- Dynamic fallback (rare): draw only visible rows/cols with coarse margin
   local layerData = self.layers and self.layers[layerName]
   if not layerData or not layerData.tilemap or layerData.visible == false then return end
 
   local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
-  local tileHeight = layerData.tileHeight or 0
 
   local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
   local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
@@ -513,21 +746,36 @@ function RoxyStagTilemap:draw(layerName)
 end
 
 -- ! Draw Visible
--- Draw all visible layers in the correct z-order
+-- Draw all visible layers in z-order, with smart skipping
 function RoxyStagTilemap:drawVisible()
+  local cameraX, cameraY = getCameraPosition()
+  local cameraUnchanged = (self._lastCameraX == cameraX) and (self._lastCameraY == cameraY)
+  local hasWarmWork = self:_hasWarmWork()
+
+  if cameraUnchanged and not self._frameDirty and not hasWarmWork then
+    return -- Nothing to do this frame.
+  end
+
+  self._lastCameraX, self._lastCameraY = cameraX, cameraY
+  self._frameDirty = false -- We will render now; clear until something changes again
+
+  self:_primeVisibleChunks()
+
   local ordered = self._orderedLayers
   for i = 1, #ordered do
     local item = ordered[i]
     if item.type == "chunked" then
+      self:_enqueueRing(item.layer, self._staticChunkLayers[item.name])
       self:_drawStaticLayerChunked(item.name)
     else
       self:draw(item.name)
     end
   end
+
+  self:_warmSomeChunks()
 end
 
 -- ! Draw Visible in Rectangle
--- Draw visible layers within a clipping rectangle
 function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
   setClipRect(x, y, width, height)
     self:drawVisible()
@@ -543,6 +791,50 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   if not layerData or not layerData.tilemap or layerData.visible == false then
     _endManualDraw(restoreX, restoreY); return
   end
+
+  -- Fast path: native renderer draws rows directly
+  if RoxyTileRendererC and layerData._nativeRenderer then
+    local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+    local rowStart = max(1, minRow or 1)
+    local rowEnd   = min(mapHeight, maxRow or mapHeight)
+    if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
+
+    local minX, maxX
+    if minColumn and maxColumn then
+      minX = max(1, minColumn)
+      maxX = min(mapWidth, maxColumn)
+    else
+      local x1, _, x2, _ = self:getVisibleTileBounds(layerData)
+      minX, maxX = x1, x2
+    end
+    if minX > maxX then _endManualDraw(restoreX, restoreY); return end
+
+    local originX, originY      = layerData.originX or 0, layerData.originY or 0
+    local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
+    local parallaxOriginX       = layerData.parallaxoriginx or 0
+    local parallaxOriginY       = layerData.parallaxoriginy or 0
+    local cameraX, cameraY      = getCameraPosition()
+
+    local tr = layerData._nativeRenderer
+    if tr then
+      tr:drawRows(
+        rowStart, rowEnd,
+        minX, maxX,
+        originX, originY,
+        parallaxX, parallaxY,
+        parallaxOriginX, parallaxOriginY,
+        cameraX, cameraY
+      )
+      _endManualDraw(restoreX, restoreY)
+      return
+    end
+  end
+
+  --
+  -- Fallback Lua Implementation
+  --
+
+  Log.debug("[drawLayerRows] Falling back on Lua implementation") --#DEBUG
 
   local imageTable = layerData.imageTable
   if not imageTable then
@@ -562,7 +854,6 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
     minX = max(1, minColumn)
     maxX = min(mapWidth, maxColumn)
   else
-    -- Fallback to coarse bounds if none provided
     local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
     local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layerData)
     local minWorldX = floor(min(leftWorld, rightWorld)) - 2
@@ -575,7 +866,6 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   local tiles = layerData.tilesFlat
   local stride = layerData.tilesStride
 
-  -- Hoisted transforms to avoid repeated calculations
   local originX, originY      = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
   local parallaxOriginX       = layerData.parallaxoriginx or 0
@@ -585,7 +875,6 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   local cameraX, cameraY      = getCameraPosition()
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  -- Add lightweight per-layer caches for images and offsets (no LRU overhead)
   layerData._imageCache  = layerData._imageCache  or {}
   layerData._offsetCache = layerData._offsetCache or {}
 
@@ -635,11 +924,21 @@ end
 -- ! Destroy
 -- Clean up static layer resources
 function RoxyStagTilemap:destroy()
+  -- Destroy native renderers first
+  for _, layerData in pairs(self.layers or {}) do
+    if layerData._nativeRenderer then
+      layerData._nativeRenderer:destroy()
+      layerData._nativeRenderer = nil
+    end
+  end
+
   if self._globalChunkBucket then
     clearCache(self._globalChunkBucket)
     self._globalChunkBucket = nil
   end
+
   self._staticChunkLayers = {}
   self._orderedLayers = {}
+
   RoxyStagTilemap.super.destroy(self)
 end

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -1,13 +1,12 @@
 -- core/tilemaps/RoxyStagTilemap.lua
--- Staggered-Y isometric tilemaps that match Tiled:
--- Only rows whose parity matches Tiled's staggerindex are shifted.
--- Direction is configurable via self.staggerDirection = "left" | "right" (default "right").
 
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
+local Sprite    <const> = Graphics.sprite
 
 local r       <const> = roxy
 local Camera  <const> = r.Camera
+local Cache   <const> = roxy.Cache
 
 local min   <const> = math.min
 local max   <const> = math.max
@@ -18,8 +17,19 @@ local round <const> = r.Math.round
 local tableInsert <const> = table.insert
 local tableSort   <const> = table.sort
 
-local setDrawOffset <const> = Graphics.setDrawOffset
-local getDrawOffset <const> = Graphics.getDrawOffset
+local pushContext   <const> = Graphics.pushContext
+local popContext    <const> = Graphics.popContext
+local setClipRect   <const> = Graphics.setClipRect
+local clearClipRect <const> = Graphics.clearClipRect
+local newImage      <const> = Graphics.image.new
+local clear         <const> = Graphics.clear
+
+local addDirtyRect <const> = Sprite.addDirtyRect
+
+local newCacheBucket  <const> = Cache.newBucket
+local getOrLoadAsset  <const> = Cache.getOrLoadAsset
+local evictAsset      <const> = Cache.evictAsset
+local clearCache      <const> = Cache.clearCache
 
 local getCameraPosition <const> = Camera.getPosition
 
@@ -27,16 +37,25 @@ local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+-- Default chunk settings
+local DEFAULT_CHUNK_SIZE    <const> = 320
+local DEFAULT_CHUNK_CACHE   <const> = 72
+local DEFAULT_CHUNK_OVERLAP <const> = 32
+
+-- Coarse safety margin (in tiles) for dynamic fallback culling
+local TILE_MARGIN <const> = 2
+
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+
+local COLOR_CLEAR <const> = Graphics.kColorClear
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
 -- ! Row Shift X for Row 0
--- Return the horizontal row shift (in pixels) for a given 0-based row index.
--- Matches Tiled: shift ONLY rows whose parity equals self.staggerIndex.
+-- Shift in pixels for a 0-based row index (Tiled staggered-y)
 local function _rowShiftX_for_row0(self, row0, halfWidth)
   if self.staggerAxis ~= "y" then return 0 end
 
@@ -52,27 +71,26 @@ local function _rowShiftX_for_row0(self, row0, halfWidth)
   if not shouldShift then return 0 end
 
   local direction = self.staggerDirection or "right"
-  return (direction == "right") and (halfWidth) or (-halfWidth)
+  return (direction == "right") and halfWidth or -halfWidth
 end
 
--- ! Get Max Image Height
--- Helper to compute and cache max image height for the layer
-local function _getMaxImgHeight(layer)
-  if layer._maxImgH then return layer._maxImgH end
-  local imagetable = layer.imageTable
-  local imagetableLength = imagetable and imagetable:getLength() or 0
-  local maxH = layer.tileHeight or 0
-  for i = 1, imagetableLength do
-    local img = imagetable:getImage(i)
-    if img then
-      local _, height = img:getSize()
-      if height and height > maxH then
-        maxH = height
-      end
-    end
-  end
-  layer._maxImgH = maxH
-  return maxH
+-- ! Visible Layer Rectangle
+-- Compute visible layer-space rect
+local function _visibleLayerRect(self, layer)
+  local screenX, screenY = self:worldToScreen(0, 0, layer)
+  -- screen shows [0..W, 0..H]
+  -- which corresponds to layer pixels [-screenX..-screenX+W, -screenY..-screenY+H]
+  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
+end
+
+-- ! Chunk Indices for Rect
+-- Which chunk indices intersect a pixel rect?
+local function _chunkIndicesForRect(x, y, width, height, size)
+  local minChunkX = floor(x / size)
+  local maxChunkX = floor((x + width  - 1) / size)
+  local minChunkY = floor(y / size)
+  local maxChunkY = floor((y + height - 1) / size)
+  return minChunkX, maxChunkX, minChunkY, maxChunkY
 end
 
 --------------------------------------------------------------------------------
@@ -88,20 +106,213 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   RoxyStagTilemap.super.init(self, jsonPath, opts, scene)
 
   self._projection = "staggered-y"
-
-  -- Tiled fields read in base class:
-  --   self.staggerAxis  -> expected "y"
-  --   self.staggerIndex -> "odd" | "even"
-  -- Direction knob: which way the shifted rows move horizontally in pixels
+  self.staggerAxis = self.staggerAxis or "y"
   self.staggerDirection = self.staggerDirection or "right" -- "left" | "right"
+
+  self._staticChunkLayers = {}  -- name --> { layer, size, overlap, chunkBucket }
+  self._orderedLayers     = {}  -- array of { layer, type="chunked" | "dynamic" }
+
+  self._mapCacheId = jsonPath or tostring(self) -- Used only for namespacing keys
+
+  self:_initializeStaticLayers(opts)
+  self:_rebuildOrderedLayers()
+end
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- ! Initialize Static Layers
+-- Build chunk/static config per layer
+function RoxyStagTilemap:_initializeStaticLayers(opts)
+  local layerOptions = (opts and opts.layerOptions) or {}
+  local totalChunkCache = opts.totalChunkCache or DEFAULT_CHUNK_CACHE
+
+  -- One shared bucket for all chunk images on this map
+  self._globalChunkBucket = newCacheBucket(totalChunkCache)
+
+  for layerName, layer in pairs(self.layers) do
+    local layerOpts = layerOptions[layerName] or {}
+    if layerOpts.preRenderChunked then
+      self._staticChunkLayers[layerName] = {
+        name      = layerName,
+        layer     = layer,
+        size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
+        overlap   = layerOpts.overlapPx or DEFAULT_CHUNK_OVERLAP,
+        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
+                    tostring(layer.tiledId or layerName) .. ":",
+      }
+      Log.debug("keyPrefix: " .. self._staticChunkLayers[layerName].keyPrefix) --#DEBUG
+    end
+  end
+end
+
+-- ! Get or Build Chunk
+-- Build or fetch a prerendered chunk image from the cache
+function RoxyStagTilemap:_getOrBuildChunk(layerInfo, chunkX, chunkY)
+  local key = layerInfo.keyPrefix .. chunkX .. ":" .. chunkY
+  return getOrLoadAsset(self._globalChunkBucket, key, function()
+    local size, overlap = layerInfo.size, layerInfo.overlap
+    local width, height = size + 2 * overlap, size + 2 * overlap
+    local img = newImage(width, height)
+
+    -- Convert chunk indices to layer pixel origin for this chunk
+    local px = chunkX * size - overlap
+    local py = chunkY * size - overlap
+
+    pushContext(img)
+      setClipRect(0, 0, width, height)
+      clear(COLOR_CLEAR)
+      self:_renderLayerToBuffer(layerInfo.layer, -px, -py, width, height)
+      clearClipRect()
+    popContext()
+
+    return img
+  end)
+end
+
+-- ! Rebuild Ordered Layers
+-- Build a stable, z-sorted draw list once (rarely changes)
+function RoxyStagTilemap:_rebuildOrderedLayers()
+  local items = {}
+  for name, layer in pairs(self.layers) do
+    if layer.tilemap and layer.visible ~= false then
+      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
+      tableInsert(items, { layer = layer, name = name, type = renderType, z = layer.zIndex or 0 })
+    end
+  end
+  tableSort(items, function(a, b) return a.z < b.z end)
+  self._orderedLayers = items
+end
+
+--------------------------------------------------------------------------------
+-- Chunk building & drawing
+--------------------------------------------------------------------------------
+
+-- ! Render Layer to Buffer
+-- Render a layer directly to a buffer context (in layer-local coordinates)
+function RoxyStagTilemap:_renderLayerToBuffer(layer, offsetX, offsetY, bufferWidth, bufferHeight)
+  local tilemap     = layer.tilemap
+  local imageTable  = layer.imageTable
+  if not tilemap or not imageTable then return end
+
+  local len = imageTable:getLength()
+  local mapWidthTiles, mapHeightTiles = tilemap:getSize()
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local halfWidth, halfHeight = tileWidth * 0.5, tileHeight * 0.5
+
+  -- Parity helper (odd rows shift by half tile width)
+  local function rowShiftX(row0) return (row0 % 2 == 0) and 0 or halfWidth end
+
+  -- How tall can any tile image be? (margin for tall isometric art)
+  local maxImgH = layer.maxImgH or 0
+  local overdrawRows = ceil(max(0, maxImgH - tileHeight) / max(1, halfHeight)) + 1
+
+  -- Row range that can touch this buffer (layer-local coords)
+  -- drawY = row0 * halfHeight + offsetY
+  local minRow0 = floor((-offsetY - maxImgH) / halfHeight) - 1
+  local maxRow0 = ceil ((bufferHeight - offsetY) / halfHeight) + 1
+  minRow0 = max(0, minRow0 - overdrawRows)
+  maxRow0 = min(mapHeightTiles - 1, maxRow0 + overdrawRows)
+
+  -- Flat tiles + stride (fallback to map width)
+  local tiles  = layer.tilesFlat
+  local stride = layer.tilesStride or mapWidthTiles
+
+  -- Per-tile offset cache (avoid repeated _isoDrawOffsets calls)
+  local offCache = layer._offCache
+  if not offCache then
+    offCache = {}
+    layer._offCache = offCache
+  end
+
+  for row0 = minRow0, maxRow0 do
+    local baseX = rowShiftX(row0) + offsetX
+    local baseY = row0 * halfHeight + offsetY
+
+    -- In this row, drawX = baseX + (tileX-1)*tileWidth
+    -- Choose tiles whose drawX overlaps the buffer with a 1-tile margin
+    local minTileX = floor((-tileWidth - baseX) / tileWidth)       -- 0-based col
+    local maxTileX = floor((bufferWidth - 1 - baseX) / tileWidth)  -- 0-based col
+    minTileX = max(0, minTileX - 1)
+    maxTileX = min(mapWidthTiles - 1, maxTileX + 1)
+
+    if minTileX <= maxTileX then
+      local rowIndex = row0 * stride + (minTileX + 1) -- tiles[] is 1-based
+      local drawX    = baseX + minTileX * tileWidth
+
+      for col0 = minTileX, maxTileX do
+        local tileIndex = tiles and tiles[rowIndex] or 0
+        if tileIndex and tileIndex > 0 and tileIndex <= len then
+          local img = layer._imgCache[tileIndex]
+          if not img then
+            img = imageTable:getImage(tileIndex)
+            layer._imgCache[tileIndex] = img
+          end
+
+          if img then
+            -- cached isometric draw offsets per tileIndex
+            local offX, offY = offCache[tileIndex]
+            if not offX then
+              offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
+              offCache[tileIndex] = offX
+              offCache[tileIndex + 0.5] = offY -- cheap 2nd key to store Y
+            else
+              offY = offCache[tileIndex + 0.5]
+            end
+
+            local dx, dy = drawX + offX, baseY + offY
+            -- Quick clip against the buffer (0..bufferWidth/Height)
+            if dx < bufferWidth and dy < bufferHeight and dx > -tileWidth and dy > -tileHeight then
+              img:draw(dx, dy)
+            end
+          end
+        end
+        rowIndex = rowIndex + 1
+        drawX    = drawX + tileWidth
+      end
+    end
+  end
+end
+
+-- ! Draw Static Layer Chunked
+function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
+  local layerInfo = self._staticChunkLayers[layerName]
+  if not layerInfo then return end
+
+  local layer   = layerInfo.layer
+  local size    = layerInfo.size
+  local overlap = layerInfo.overlap
+
+  -- Visible rect in layer coordinates (inflate by overlap)
+  local vx, vy, vw, vh = _visibleLayerRect(self, layer)
+  vx = vx - overlap; vy = vy - overlap
+  vw = vw + 2 * overlap; vh = vh + 2 * overlap
+
+  local minCX, maxCX, minCY, maxCY = _chunkIndicesForRect(vx, vy, vw, vh, size)
+  local screenX, screenY = self:worldToScreen(0, 0, layer)
+
+  for cy = minCY, maxCY do
+    local rowDestY = cy * size - overlap + screenY
+    for cx = minCX, maxCX do
+      local img = self:_getOrBuildChunk(layerInfo, cx, cy)
+      if img then
+        local destX = cx * size - overlap + screenX
+        local destY = rowDestY
+
+        -- Simple on-screen test, but DO NOT modify the clip rect here.
+        local iw, ih = img:getSize()
+        if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
+             or destX + iw <= 0      or destY + ih <= 0) then
+          img:draw(destX, destY)
+        end
+      end
+    end
+  end
 end
 
 --------------------------------------------------------------------------------
 -- Projection (Staggered-Y)
--- Row spacing = halfHeight; Column step = tileWidth.
--- Shift rule (Tiled):
---   If row parity matches staggerIndex -> shift by ±halfWidth (dir knob)
---   Otherwise -> no shift
 --------------------------------------------------------------------------------
 
 -- ! World to Screen
@@ -162,16 +373,65 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Set Tile At
-function RoxyStagTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
-  local layer = self.layers and self.layers[name]
+-- Override setTileAt to handle static layer updates
+function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
+  local layer = self.layers and self.layers[layerName]
   if not layer then return end
-
   layer.tilemap:setTileAtPosition(x, y, tileIndex)
+
+  -- Mark region as dirty for static layers
+  if self._staticChunkLayers[layerName] then
+    self:markTilesDirty(layerName, x, y, 1, 1)
+  end
 
   if updateSprite and layer.imageTable then
     local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
     local screenX, screenY = self:worldToScreen(x - 1, y - 1, layer)
-    Graphics.sprite.addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+    addDirtyRect(screenX, screenY, tileWidth, tileHeight)
+  end
+end
+
+-- ! Get Row From Screen
+function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
+  local targetLayer = self.layers and self.layers[layerName]
+  if not targetLayer then
+    for _, layer in pairs(self.layers or {}) do
+      if layer.tilemap then targetLayer = layer; break end
+    end
+    if not targetLayer then return 1 end
+  end
+
+  local _, mapHeightTiles = targetLayer.tilemap:getSize()
+  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
+  local row = floor(worldY + 1)
+  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
+  return row
+end
+
+-- ! Resort Layers
+function RoxyStagTilemap:resortLayers()
+  self:_rebuildOrderedLayers()
+end
+
+-- ! Mark Tiles Dirty
+-- Tile edits --> evict overlapping chunks (they will rebuild lazily)
+function RoxyStagTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, tileCountHeight)
+  local layerInfo = self._staticChunkLayers[layerName]
+  if not layerInfo then return end
+
+  -- Calculate affected chunks and evict from global bucket
+  local tileWidth, tileHeight = layerInfo.layer.tileWidth, layerInfo.layer.tileHeight
+  local pixelX = (tileX - 1) * tileWidth
+  local pixelY = (tileY - 1) * (tileHeight * 0.5)
+  local pixelWidth = (tileCountWidth or 1) * tileWidth
+  local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
+
+  local minChunkX, maxChunkX, minChunkY, maxChunkY =
+    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerInfo.size)
+  for chunkY = minY, maxY do
+    for chunkX = minX, maxX do
+      evictAsset(self._globalChunkBucket, layerInfo.keyPrefix .. chunkX .. ":" .. chunkY)
+    end
   end
 end
 
@@ -180,83 +440,63 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Draw
-function RoxyStagTilemap:draw(name)
-  local layer = self.layers and self.layers[name]
+function RoxyStagTilemap:draw(layerName)
+  if self._staticChunkLayers[layerName] then
+    self:_drawStaticLayerChunked(layerName); return
+  end
+
+  -- Dynamic fallback (rare):
+  -- draw only visible rows/cols with coarse margin
+  local layer = self.layers and self.layers[layerName]
   if not layer or not layer.tilemap or layer.visible == false then return end
 
   local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
   local tileHeight = layer.tileHeight or 0
   local halfHeight = tileHeight * 0.5
-  
-  -- Get screen corners in world space
+
   local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
   local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-  
-  -- Calculate margin based on tallest image (like RoxyIsoTilemap)
-  local maxImgH = _getMaxImgHeight(layer)
-  local overdraw = max(0, maxImgH - tileHeight)
-  local margin = ceil(overdraw / max(1, halfHeight)) + 1
-  
-  -- Calculate bounds with proper margin
+
+  local margin = TILE_MARGIN
+
   local minWorldX = min(leftWorld, rightWorld) - margin
   local maxWorldX = max(leftWorld, rightWorld) + margin
   local minWorldY = min(topWorld, bottomWorld) - margin
   local maxWorldY = max(topWorld, bottomWorld) + margin
-  
-  -- Convert to tile coordinates (1-based)
+
   local minTileX = max(1, floor(minWorldX) + 1)
   local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
   local minTileY = max(1, floor(minWorldY) + 1)
   local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
 
-  self:drawLayerRows(name, minTileY, maxTileY, minTileX, maxTileX)
+  self:drawLayerRows(layerName, minTileY, maxTileY, minTileX, maxTileX)
 end
 
 -- ! Draw Visible
+-- Straight loop using pre-sorted layers
 function RoxyStagTilemap:drawVisible()
-  if not self.layers then return end
-
-  local list = {}
-  for _, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      tableInsert(list, layer)
+  local ordered = self._orderedLayers
+  for i = 1, #ordered do
+    local item = ordered[i]
+    if item.type == "chunked" then
+      self:_drawStaticLayerChunked(item.name)
+    else
+      self:draw(item.name)
     end
-  end
-  tableSort(list, function(a, b) return (a.zIndex or 0) < (b.zIndex or 0) end)
-
-  for i = 1, #list do
-    local layer = list[i]
-    local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
-    local tileHeight = layer.tileHeight or 0
-    local halfHeight = tileHeight * 0.5
-    
-    -- Get screen corners in world space
-    local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
-    local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
-    
-    -- Calculate margin based on tallest image
-    local maxImgH = _getMaxImgHeight(layer)
-    local overdraw = max(0, maxImgH - tileHeight)
-    local margin = ceil(overdraw / max(1, halfHeight)) + 1
-    
-    -- Calculate bounds with proper margin
-    local minWorldX = min(leftWorld, rightWorld) - margin
-    local maxWorldX = max(leftWorld, rightWorld) + margin
-    local minWorldY = min(topWorld, bottomWorld) - margin
-    local maxWorldY = max(topWorld, bottomWorld) + margin
-    
-    -- Convert to tile coordinates (1-based)
-    local minTileX = max(1, floor(minWorldX) + 1)
-    local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
-    local minTileY = max(1, floor(minWorldY) + 1)
-    local maxTileY = min(mapHeightTiles, ceil(maxWorldY) + 1)
-
-    self:drawLayerRows(layer.name, minTileY, maxTileY, minTileX, maxTileX)
   end
 end
 
+-- ! Draw Visible in Rectangle
+-- Draw Visible in Rectangle (unchanged structure, keep the outer clip only)
+function RoxyStagTilemap:drawVisibleInRect(x, y, width, height)
+  setClipRect(x, y, width, height)
+    self:drawVisible()
+  clearClipRect()
+end
+
 -- ! Draw Layer Rows
-function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minCol, maxCol)
+-- Dynamic row/column renderer (no per-tile img:getSize culling)
+function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxColumn)
   local restoreX, restoreY = _beginManualDraw()
 
   local layer = self.layers and self.layers[layerName]
@@ -269,24 +509,21 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minCol, maxCol
     _endManualDraw(restoreX, restoreY); return
   end
 
-  local cache = layer._imgCache
-  if not cache then cache = {}; layer._imgCache = cache end
-
+  local len = imageTable:getLength()
   local tilemap = layer.tilemap
   local mapWidthTiles, mapHeightTiles = tilemap:getSize()
   local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
 
   local rowStart = max(1, minRow or 1)
-  local rowEnd   = min(mapHeightTiles, maxRow or mapHeightTiles)
+  local rowEnd = min(mapHeightTiles, maxRow or mapHeightTiles)
   if rowStart > rowEnd then _endManualDraw(restoreX, restoreY); return end
 
-  -- Use passed column bounds if provided, otherwise calculate them
   local minX, maxX
-  if minCol and maxCol then
-    minX = max(1, minCol)
-    maxX = min(mapWidthTiles, maxCol)
+  if minColumn and maxColumn then
+    minX = max(1, minColumn)
+    maxX = min(mapWidthTiles, maxColumn)
   else
-    -- Fallback to old calculation for backwards compatibility
+    -- Fallback to coarse bounds if none provided
     local leftWorld, topWorld = self:screenToWorld(0, 0, layer)
     local rightWorld, bottomWorld = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
     local minWorldX = floor(min(leftWorld, rightWorld)) - 2
@@ -294,70 +531,62 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minCol, maxCol
     minX = max(1, minWorldX + 1)
     maxX = min(mapWidthTiles, maxWorldX + 1)
   end
-
   if minX > maxX then _endManualDraw(restoreX, restoreY); return end
 
-  local tiles, widthFromTileMap = tilemap:getTiles()
-  local stride = widthFromTileMap or mapWidthTiles
+  local tiles = layer.tilesFlat
+  local stride = layer.tilesStride
 
-  -- Use the same pivot adjust as worldToScreen/sprite path (like RoxyIsoTilemap)
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
-  local parallaxOriginX = layer.parallaxoriginx or 0
-  local parallaxOriginY = layer.parallaxoriginy or 0
-  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
-  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
-  
-  local cameraX, cameraY = getCameraPosition()
+  -- Hoisted transforms
+  local originX, originY      = layer.originX or 0, layer.originY or 0
+  local parallaxX, parallaxY  = layer.parallaxx or 1, layer.parallaxy or 1
+  local parallaxOriginX       = layer.parallaxoriginx or 0
+  local parallaxOriginY       = layer.parallaxoriginy or 0
+  local pivotAdjustX          = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY          = parallaxOriginY * (1 - parallaxY)
+  local cameraX, cameraY      = getCameraPosition()
   local halfHeight, halfWidth = tileHeight * 0.5, tileWidth * 0.5
+
+  local tilesetKeyPrefix = "tilesetimg:" .. tostring(imageTable) .. ":"
 
   for tileY = rowStart, rowEnd do
     local row0 = tileY - 1
     local rowShiftX = _rowShiftX_for_row0(self, row0, halfWidth)
 
-    -- Apply pivot adjustments consistently
     local baseScreenX = round(originX + rowShiftX + pivotAdjustX - cameraX * parallaxX)
     local baseScreenY = round(originY + row0 * halfHeight + pivotAdjustY - cameraY * parallaxY)
 
     local currentX = baseScreenX + (minX - 1) * tileWidth
-    local currentY = baseScreenY
+    local rowIndex = row0 * stride + minX
 
-    local i = row0 * stride + minX
     for tileX = minX, maxX do
-      local idx = tiles and tiles[i] or 0
-      if idx and idx ~= 0 then
-        local img = cache[idx]
-        if not img then img = imageTable:getImage(idx); cache[idx] = img end
+      local tileIndex = tiles and tiles[rowIndex] or 0
+      if tileIndex and tileIndex > 0 and tileIndex <= len then
+        local key = tilesetKeyPrefix .. tileIndex
+        local img = getOrLoadAsset(key, function() return imageTable:getImage(tileIndex) end)
         if img then
           local offX, offY = _isoDrawOffsets(tileWidth, tileHeight, img)
-          local drawX, drawY = currentX + offX, currentY + offY
-          local imgWidth, imgHeight = img:getSize()
-          if not (drawX > DISPLAY_WIDTH or drawY > DISPLAY_HEIGHT or
-                  drawX + imgWidth < 0 or drawY + imgHeight < 0) then
-            img:draw(drawX, drawY)
-          end
+          img:draw(currentX + offX, baseScreenY + offY)
         end
       end
-
-      currentX = currentX + tileWidth
-      i += 1
+      currentX += tileWidth
+      rowIndex += 1
     end
   end
 
   _endManualDraw(restoreX, restoreY)
 end
 
--- ! Get Row From Screen
-function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
-  local targetLayer = self.layers and self.layers[layerName]
-  if not targetLayer then
-    for _, layer in pairs(self.layers or {}) do if layer.tilemap then targetLayer = layer; break end end
-    if not targetLayer then return 1 end
-  end
+--------------------------------------------------------------------------------
+-- Cleanup
+--------------------------------------------------------------------------------
 
-  local _, mapHeightTiles = targetLayer.tilemap:getSize()
-  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
-  local row = floor(worldY + 1)
-  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
-  return row
+-- Clean up static layer resources
+function RoxyStagTilemap:destroy()
+  if self._globalChunkBucket then
+    clearCache(self._globalChunkBucket)
+    self._globalChunkBucket = nil
+  end
+  self._staticChunkLayers = {}
+  self._orderedLayers = {}
+  RoxyStagTilemap.super.destroy(self)
 end

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -476,7 +476,7 @@ function RoxyStagTilemap:_enqueueRing(layerData, layerConfig)
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
     _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
 
-  -- Skip if ring bounds didn’t change
+  -- Skip if ring bounds didn't change
   local last = layerConfig._lastRingBounds
   if last
     and last.minX == minChunkX and last.maxX == maxChunkX

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -562,6 +562,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
           indices[i] = (gid ~= 0) and (gid - firstgid + 1) or 0
         end
         tilemap:setTiles(indices, layer.width)
+        local tiles, stride = tilemap:getTiles()
 
         -- Use logical map tile size (e.g., 64x32) for iso math/culling
         -- Actual image size (e.g., 64x64) is handled via per-image offsets
@@ -572,18 +573,37 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         local mapPixelWidth  = width  * tileWidth
         local mapPixelHeight = height * tileHeight
 
+        local maxImgH = 0
+        do
+          local tbl = usedTileset.imageTable
+          local n = tbl and tbl:getLength() or 0
+          for i = 1, n do
+            local img = tbl:getImage(i)
+            if img then
+              local _, h = img:getSize()
+              if h and h > maxImgH then maxImgH = h end
+            end
+          end
+        end
+
         local layerData = {
           name = layer.name,
           tilemap = tilemap,
+          tiledId = layer.id,
           anchor = opts.anchor,
-          tileWidth = tileWidth,
-          tileHeight = tileHeight,
           imageTable = usedTileset.imageTable,
           imagePath = usedTileset.imagePath,
+          tileWidth = tileWidth,
+          tileHeight = tileHeight,
+          tilesFlat  = tiles,
+          tilesStride = stride or layer.width,
+          maxImgH = maxImgH,
           zIndex = (layerOptions.zIndex or opts.zIndices[layer.name] or 0),
           visible = (layerOptions.visible ~= false),
           mapPixelWidth = mapPixelWidth,
-          mapPixelHeight = mapPixelHeight
+          mapPixelHeight = mapPixelHeight,
+          _imgCache = {},
+          _offCache = {},
         }
 
         -- Compute origin/parallax regardless of wrapping in sprites
@@ -683,7 +703,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   end
   self.sprites = newSprites
 
-  -- Process object layers (NEW SECTION)
+  -- Process object layers
   local objectSprites = {}
   for _, layer in ipairs(mapData.layers or {}) do
     if layer.type == "objectgroup" and (processAll or opts.objectLayers[layer.name]) then
@@ -965,6 +985,22 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
   layer.tilemap:setImageTable(newTable)
   layer.imageTable = newTable
   layer._imgCache = {}
+  layer._offCache = {}  -- reset offset cache
+
+  -- Recompute max image height (use newTable, not usedTileset)
+  local maxImgH = 0
+  do
+    local tbl = newTable
+    local n = tbl and tbl:getLength() or 0
+    for i = 1, n do
+      local img = tbl:getImage(i)
+      if img then
+        local _, h = img:getSize()
+        if h and h > maxImgH then maxImgH = h end
+      end
+    end
+  end
+  layer.maxImgH = maxImgH
 
   -- Update asset retention (if a path swap)
   if newPath then

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -24,6 +24,8 @@ local loadJSON <const> = r.JSON.loadJson
 
 local pushContext     <const> = Graphics.pushContext
 local popContext      <const> = Graphics.popContext
+local getDrawOffset   <const> = Graphics.getDrawOffset
+local setDrawOffset   <const> = Graphics.setDrawOffset
 local setColor        <const> = Graphics.setColor
 local newImage        <const> = Graphics.image.new
 local newImagetable   <const> = Graphics.imagetable.new
@@ -56,58 +58,64 @@ local EMPTY_TABLE <const> = {}
 -- Shared reference counts for all RoxyTilemap instances.
 -- Be sure to call retain/release in pairs so you don't
 -- evict an asset another map still needs.
-local refCount = {}
+local referenceCount = {}
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
--- ! Retain
-local function retain(path, tbl)
-  refCount[path] = (refCount[path] or 0) + 1
+-- ! Helper: Retain Asset
+local function retain(path, table)
+  referenceCount[path] = (referenceCount[path] or 0) + 1
   if not getIsAssetCached(path) then
-    cacheAsset(path, function() return tbl end)
+    cacheAsset(path, function() return table end)
   end
 end
 
--- ! Release
+-- ! Helper: Release Asset
 local function release(path)
-  local n = refCount[path]
-  if not n then return end
-  if n <= 1 then
+  local count = referenceCount[path]
+  if not count then return end
+  if count <= 1 then
     evictAsset(path)
-    refCount[path] = nil
+    referenceCount[path] = nil
   else
-    refCount[path] = n - 1
+    referenceCount[path] = count - 1
   end
 end
 
--- ! Normalize Image Path
-local function normalizeImgPath(tiledImgPath)
-  if type(tiledImgPath) ~= "string" then
-    Log.warn("[normalizeImgPath] Expected string, got " .. type(tiledImgPath)) --#DEBUG
+-- ! Helper: Normalize Image Path
+-- Converts Tiled-exported image paths to Roxy's expected format
+local function normalizeImagePath(tiledImagePath)
+  if type(tiledImagePath) ~= "string" then
+    Log.warn("[normalizeImagePath] Expected string, got " .. type(tiledImagePath)) --#DEBUG
     return nil
   end
-  local filename = tiledImgPath:match("([^/]+)$") or ""
+
+  local filename = tiledImagePath:match("([^/]+)$") or ""
   local base = filename:gsub("%-table%-%d+%-%d+%.png$", "")
+
   if base == filename then
-    Log.warn("[normalizeImgPath] Unexpected image path pattern: " .. tostring(tiledImgPath)) --#DEBUG
+    Log.warn("[normalizeImagePath] Unexpected image path pattern: " .. tostring(tiledImagePath)) --#DEBUG
     return IMAGE_PATH_PREFIX .. filename
   end
+
   return IMAGE_PATH_PREFIX .. base
 end
 
--- ! Get Imagetable
+-- ! Helper: Get Imagetable
+-- Loads or retrieves cached imagetable from path
 local function getImagetable(path)
   if type(path) ~= "string" or path == "" then
     Log.warn("[getImagetable] Invalid or missing path: " .. tostring(path))
     return nil
   end
+
   local cached = getCachedAsset(path)
   if cached then
     -- If cached is a thunk, call it
-    local tbl = (type(cached) == "function") and cached() or cached
-    return tbl
+    local table = (type(cached) == "function") and cached() or cached
+    return table
   end
 
   local loaded = newImagetable(path)
@@ -120,202 +128,238 @@ local function getImagetable(path)
   return loaded
 end
 
--- ! Validate Options
-local function validateOptions(opts)
-  -- Mutate the original opts table instead of creating a new one
-  opts = opts or {}
+-- ! Helper: Get Image (cached)
+-- Loads or retrieves a cached image from a path and retains it.
+local function getImageCached(path)
+  if type(path) ~= "string" or path == "" then
+    Log.warn("[getImageCached] Invalid or missing path: " .. tostring(path)) --#DEBUG
+    return nil
+  end
+
+  local cached = getCachedAsset(path)
+  if cached then
+    local img = (type(cached) == "function") and cached() or cached
+    return img
+  end
+
+  local loaded = newImage(path)
+  if loaded then
+    cacheAsset(path, function() return loaded end)
+  else --#DEBUG
+    Log.warn("[getImageCached] Failed to load image at path: " .. path) --#DEBUG
+  end
+
+  return loaded
+end
+
+-- ! Helper: Validate Options
+-- Ensures all required options have sensible defaults
+local function validateOptions(options)
+  -- Mutate the original options table instead of creating a new one
+  options = options or {}
 
   -- Only create layerOptions table if it doesn't exist
-  if not opts.layerOptions then
-    opts.layerOptions = EMPTY_TABLE
+  if not options.layerOptions then
+    options.layerOptions = EMPTY_TABLE
   end
-  local layerOptions = opts.layerOptions
+
+  local layerOptions = options.layerOptions
 
   -- Validate per-layer emptyIDs
-  for layerName, layerOpts in pairs(layerOptions) do
-    if layerOpts.emptyIDs ~= nil then
-      if type(layerOpts.emptyIDs) ~= "table" then
+  for layerName, layerOptions in pairs(layerOptions) do
+    if layerOptions.emptyIDs ~= nil then
+      if type(layerOptions.emptyIDs) ~= "table" then
         Log.warn("[validateOptions] layerOptions['" .. layerName .. "'].emptyIDs must be a table") --#DEBUG
-        layerOpts.emptyIDs = EMPTY_TABLE
+        layerOptions.emptyIDs = EMPTY_TABLE
       else
-        for i, id in ipairs(layerOpts.emptyIDs) do
-          if type(id) ~= "number" then
-            Log.warn("[validateOptions] emptyIDs contains non-number at index " .. i .. " for layer '" .. layerName .. "'") --#DEBUG
-            layerOpts.emptyIDs[i] = 0
+        for index, identifier in ipairs(layerOptions.emptyIDs) do
+          if type(identifier) ~= "number" then
+            Log.warn("[validateOptions] emptyIDs contains non-number at index " .. index .. " for layer '" .. layerName .. "'") --#DEBUG
+            layerOptions.emptyIDs[index] = 0
           end
         end
       end
     end
   end
 
-  -- Set defaults directly on opts
-  if opts.layers == nil then opts.layers = EMPTY_TABLE end
-  if opts.wrapInSprites == nil then opts.wrapInSprites = true end
-  if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = EMPTY_TABLE end
-  if opts.cameraBounds == nil then opts.cameraBounds = false end
-  if opts.anchor == nil or opts.anchor ~= "topLeft" then opts.anchor = "center" end
-  if opts.collisionResponse == nil then opts.collisionResponse = "overlap" end
-  if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = EMPTY_TABLE end
-  if opts.objectLayers == nil then opts.objectLayers = EMPTY_TABLE end
+  -- Set defaults directly on options
+  if options.layers == nil then options.layers = EMPTY_TABLE end
+  if options.wrapInSprites == nil then options.wrapInSprites = true end
+  if options.zIndices == nil or type(options.zIndices) ~= "table" then options.zIndices = EMPTY_TABLE end
+  if options.cameraBounds == nil then options.cameraBounds = false end
+  if options.anchor == nil or options.anchor ~= "topLeft" then options.anchor = "center" end
+  if options.collisionResponse == nil then options.collisionResponse = "overlap" end
+  if options.wallCollidesWithGroups == nil then options.wallCollidesWithGroups = EMPTY_TABLE end
+  if options.objectLayers == nil then options.objectLayers = EMPTY_TABLE end
 
-  -- Return the mutated opts instead of a new table
-  return opts
+  -- Return the mutated options instead of a new table
+  return options
 end
 
--- ! Create default Object Sprite
-local function createDefaultObjectSprite(obj, layerOpts)
-  -- Check if object has parallax properties
-  local hasParallax = false
+-- ! Helper: Create Default Object Sprite
+-- Creates a sprite from a Tiled object, with parallax support
+local function createDefaultObjectSprite(object, layerOptions)
+  -- Initialize parallax values and object properties
   local parallaxX, parallaxY = 1, 1
   local parallaxOriginX, parallaxOriginY = 0, 0
-  local objectProps = {}
+  local objectProperties = {}
 
   -- Parse object properties
-  if obj.properties then
-    for _, prop in ipairs(obj.properties) do
-      objectProps[prop.name] = prop.value
+  if object.properties then
+    for _, property in ipairs(object.properties) do
+      local name = property.name
+      local value = property.value
 
-      -- Check for parallax properties
-      if prop.name == "parallaxX" or prop.name == "parallaxx" then
-        parallaxX = tonumber(prop.value) or 1
-        hasParallax = hasParallax or (parallaxX ~= 1)
-      elseif prop.name == "parallaxY" or prop.name == "parallaxy" then
-        parallaxY = tonumber(prop.value) or 1
-        hasParallax = hasParallax or (parallaxY ~= 1)
-      elseif prop.name == "parallaxOriginX" or prop.name == "parallaxoriginx" then
-        parallaxOriginX = tonumber(prop.value) or 0
-      elseif prop.name == "parallaxOriginY" or prop.name == "parallaxoriginy" then
-        parallaxOriginY = tonumber(prop.value) or 0
+      objectProperties[name] = value
+
+      -- Handle parallax properties
+      if name == "parallaxX" then
+        parallaxX = tonumber(value) or 1
+      elseif name == "parallaxY" then
+        parallaxY = tonumber(value) or 1
+      elseif name == "parallaxOriginX" then
+        parallaxOriginX = tonumber(value) or 0
+      elseif name == "parallaxOriginY" then
+        parallaxOriginY = tonumber(value) or 0
       end
     end
   end
 
-  -- Try to load image based on object properties
+  -- Determine if parallax is needed (single check after parsing)
+  local hasParallax = parallaxX ~= 1 or parallaxY ~= 1
+
+  -- Determine image path
   local imagePath = nil
-
-  -- Check for image in object properties (common Tiled pattern)
-  if objectProps.image or objectProps.sprite then
-    imagePath = IMAGE_PATH_PREFIX .. (objectProps.image or objectProps.sprite)
-  end
-
-  -- Fallback to type-based or name-based image loading
-  if not imagePath then
-    local baseName = obj.type or obj.name or "default"
+  if objectProperties.image or objectProperties.sprite then
+    imagePath = IMAGE_PATH_PREFIX .. (objectProperties.image or objectProperties.sprite)
+  else
+    local baseName = object.type or object.name or "default"
     imagePath = IMAGE_PATH_PREFIX .. baseName
   end
 
   -- Try to load the image
-  local image = nil
-  local ok, err = pcall(function()
-    image = newImage(imagePath)
+  local img = nil
+  local success, errorMsg = pcall(function()
+    img = getImageCached(imagePath)
   end)
-  if not ok or not image then
+
+  --#DEBUG START
+  if not success or not img then
     Log.warn("[createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
   end
+  --#DEBUG END
 
-  -- Create parallax sprite if needed
+  -- Retain image if successfully loaded
+  if img then
+    retain(imagePath, img)
+  end
+
+  -- Create appropriate sprite type
   local sprite
   if hasParallax then
-    local spriteOpts = {
-      view = image,
-      worldX = obj.x or 0,
-      worldY = obj.y or 0,
+    sprite = r.RoxyParallaxSprite({
+      view = img,
+      worldX = object.x or 0,
+      worldY = object.y or 0,
       parallaxX = parallaxX,
       parallaxY = parallaxY,
       parallaxOriginX = parallaxOriginX,
       parallaxOriginY = parallaxOriginY
-    }
-    sprite = r.RoxyParallaxSprite(spriteOpts)
+    })
   else
     sprite = newSprite()
-    if image then sprite:setImage(image) end
+    if img then
+      sprite:setImage(img)
+    --#DEBUG START
+    else
+      -- Create fallback image for debugging
+      local width = object.width or SPRITE_DEFAULT_DIMS
+      local height = object.height or SPRITE_DEFAULT_DIMS
+      local fallbackImage = newImage(width, height)
+      pushContext(fallbackImage)
+        setColor(COLOR_BLACK)
+        fillRect(0, 0, width, height)
+      popContext()
+      sprite:setImage(fallbackImage)
+    --#DEBUG END
+    end
   end
 
-  -- Fallback image creation for regular sprites
-  if not image and not hasParallax then
-    -- Create a simple rectangle sprite as fallback
-    local width = obj.width or SPRITE_DEFAULT_DIMS
-    local height = obj.height or SPRITE_DEFAULT_DIMS
-    local fallbackImage = newImage(width, height)
-    pushContext(fallbackImage)
-      setColor(COLOR_BLACK)
-      fillRect(0, 0, width, height)
-    popContext()
-    sprite:setImage(fallbackImage)
-  end
-
-  -- Store all object properties on the sprite for reference
-  sprite.objectProps = objectProps
-
+  -- Store object properties on sprite
+  sprite.objectProps = objectProperties
   return sprite
 end
 
--- ! Process Object Layer
-local function processObjectLayer(self, layer, opts, layerOpts, autoAdd, scene, sceneHasAdd, newSprites)
+-- ! Helper: Process Object Layer
+-- Converts Tiled object layer into sprites
+local function processObjectLayer(self, layer, options, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
   local objects = layer.objects or {}
 
-  -- Preallocate Object-Layer Tables
+  -- Preallocate object layer tables
   local layerSprites = createTable(#objects, 0)
 
-  for _, obj in ipairs(objects) do
+  for _, object in ipairs(objects) do
     local sprite = nil
 
-    -- Use custom sprite factory if provided
-    if opts.spriteFactory and type(opts.spriteFactory) == "function" then
-      sprite = opts.spriteFactory(obj, layer.name, layerOpts)
-    elseif layerOpts.spriteFactory and type(layerOpts.spriteFactory) == "function" then
-      sprite = layerOpts.spriteFactory(obj, layer.name, layerOpts)
+    -- Use custom sprite factory if provided (check global first, then layer-specific)
+    if options.spriteFactory and type(options.spriteFactory) == "function" then
+      sprite = options.spriteFactory(object, layer.name, layerOptions)
+    elseif layerOptions.spriteFactory and type(layerOptions.spriteFactory) == "function" then
+      sprite = layerOptions.spriteFactory(object, layer.name, layerOptions)
     else
       -- Default sprite creation
-      sprite = createDefaultObjectSprite(obj, layerOpts)
+      sprite = createDefaultObjectSprite(object, layerOptions)
     end
 
     if sprite then
-      -- Base object position in world‐pixels (top‐left or centered)
-      local x, y = obj.x or 0, obj.y or 0
-      if opts.anchor == "center" then
-        x = x + (obj.width  or 0) * 0.5
-        y = y + (obj.height or 0) * 0.5
+      -- Calculate object position in world pixels (top-left or centered based on anchor)
+      local positionX, positionY = object.x or 0, object.y or 0
+      if options.anchor == "center" then
+        positionX += (object.width  or 0) * 0.5
+        positionY += (object.height or 0) * 0.5
       end
 
-      -- Compute final screen coordinates (screenX, screenY)
-      local screenX, screenY = x, y
+      -- Compute final screen coordinates
+      local screenX, screenY = positionX, positionY
 
-      -- Position the sprite
+      -- Position the sprite appropriately
       if sprite.setWorldPosition then
-        -- Parallax‐aware sprite
+        -- Parallax-aware sprite
         sprite:setWorldPosition(screenX, screenY)
       else
-        -- Normal screen‐positioned sprite
+        -- Normal screen-positioned sprite
         sprite:moveTo(screenX, screenY)
       end
 
       -- Set z-index if specified
-      local zIndex = layerOpts.zIndex or opts.zIndices[layer.name] or 0
+      local zIndex = layerOptions.zIndex or options.zIndices[layer.name] or 0
       sprite:setZIndex(zIndex)
 
       -- Set visibility
-      sprite:setVisible(layerOpts.visible ~= false)
+      sprite:setVisible(layerOptions.visible ~= false)
 
       -- Store object data on sprite for reference
-      sprite.tiledObject = obj
+      sprite.tiledObject = object
 
       -- Add collision if requested
-      if layerOpts.collidable == true then
-        sprite:setTag(layerOpts.tag or 2) -- Different from wall sprites (tag 1)
+      if layerOptions.collidable == true then
+        sprite:setTag(layerOptions.tag or 2) -- Different from wall sprites (tag 1)
         sprite:setCollideRect(0, 0, sprite:getSize())
-        if layerOpts.spriteGroup then
-          sprite:setGroups(type(layerOpts.spriteGroup) == "table" and layerOpts.spriteGroup or {layerOpts.spriteGroup})
+
+        if layerOptions.spriteGroup then
+          sprite:setGroups(type(layerOptions.spriteGroup) == "table" and layerOptions.spriteGroup or {layerOptions.spriteGroup})
         end
-        if layerOpts.collidesWithGroups and type(layerOpts.collidesWithGroups) == "table" and #layerOpts.collidesWithGroups > 0 then
-          sprite:setCollidesWithGroups(layerOpts.collidesWithGroups)
+
+        if layerOptions.collidesWithGroups and type(layerOptions.collidesWithGroups) == "table" and #layerOptions.collidesWithGroups > 0 then
+          sprite:setCollidesWithGroups(layerOptions.collidesWithGroups)
         end
-        sprite.collisionResponse = layerOpts.collisionResponse or opts.collisionResponse
+
+        sprite.collisionResponse = layerOptions.collisionResponse or options.collisionResponse
       end
 
       tableInsert(layerSprites, sprite)
 
-      -- Directly Append Sprites
+      -- Directly append sprites to the global list
       if newSprites then
         tableInsert(newSprites, sprite)
       end
@@ -334,20 +378,18 @@ local function processObjectLayer(self, layer, opts, layerOpts, autoAdd, scene, 
   return layerSprites
 end
 
--- ! Create Parallax Update
--- Hoist and Cache sprite:update - Move parallax update function outside per-sprite loop
--- Define the parallax update function once, outside the sprite creation loop
--- This avoids creating new function instances for each sprite
-local function createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, rnd, camGetter, anchor, mapPixelWidth, mapPixelHeight)
+-- ! Helper: Create Parallax Update Function
+-- Creates an update function for parallax sprites (hoisted to avoid per-sprite function creation)
+local function createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter, anchor, mapPixelWidth, mapPixelHeight)
   return function(self)
-    local cameraX, cameraY = camGetter()
+    local cameraX, cameraY = cameraGetter()
 
     -- Apply parallax origin pivot (consistent with projection classes)
     local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
     local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
-    local screenX = rnd(worldX + pivotAdjustX - cameraX * parallaxX)
-    local screenY = rnd(worldY + pivotAdjustY - cameraY * parallaxY)
+    local screenX = roundFn(worldX + pivotAdjustX - cameraX * parallaxX)
+    local screenY = roundFn(worldY + pivotAdjustY - cameraY * parallaxY)
 
     local currentX, currentY = self:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
@@ -366,37 +408,44 @@ class("RoxyTilemap").extends(Object)
 -- Isometric helpers (shared by iso/staggered leaves)
 --------------------------------------------------------------------------------
 
--- ! Isometric Draw Offsets
+-- ! Shared: Isometric Draw Offsets
 -- Per-tile draw offsets so diamonds align with Tiled.
 function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, img)
-  local imgWidth, imgHeight = img:getSize()
-  local offsetX = (tileWidth - imgWidth) * 0.5
-  local offsetY = (tileHeight - imgHeight)
+  local imageWidth, imageHeight = img:getSize()
+  local offsetX = (tileWidth - imageWidth) * 0.5
+  local offsetY = (tileHeight - imageHeight)
   return offsetX, offsetY
 end
 
--- ! Begin Manual Draw
+-- ! Shared: Begin Manual Draw
 -- Temporarily zero draw offset when doing manual placement.
 function RoxyTilemap._beginManualDraw()
-  local offsetX, offsetY = playdate.graphics.getDrawOffset()
-  if offsetX ~= 0 or offsetY ~= 0 then playdate.graphics.setDrawOffset(0, 0) end
+  local offsetX, offsetY = getDrawOffset()
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(0, 0)
+  end
   return offsetX, offsetY
 end
 
--- ! End Manual Draw
+-- ! Shared: End Manual Draw
 -- Restore draw offset after manual placement.
 function RoxyTilemap._endManualDraw(offsetX, offsetY)
-  if offsetX ~= 0 or offsetY ~= 0 then playdate.graphics.setDrawOffset(offsetX, offsetY) end
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(offsetX, offsetY)
+  end
 end
 
--- ! Get Valid Layer
+-- ! Shared: Get Valid Layer
+-- Returns a layer if it exists and is drawable
 function RoxyTilemap._getValidLayer(layerName)
   if not layerName or not self.layers then return nil end
-  local layer = self.layers[layerName]
-  if not layer or not layer.tilemap or layer.visible == false then
+
+  local layerData = self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then
     return nil
   end
-  return layer
+
+  return layerData
 end
 
 --------------------------------------------------------------------------------
@@ -405,17 +454,16 @@ end
 
 --[[
   jsonPath: string - Path to Tiled JSON map
-  opts:     table  - Configuration opts (see validateOptions)
+  options:  table  - Configuration options (see validateOptions)
   scene:    table? - Optional scene object with addSprite method
 ]]
-function RoxyTilemap:init(jsonPath, opts, scene)
-  opts = validateOptions(opts)
+function RoxyTilemap:init(jsonPath, options, scene)
+  options = validateOptions(options)
 
   self.scene = scene
-
   self._retainedPaths = {}
 
-  local autoAdd = opts.wrapInSprites and (opts.autoAddSprites ~= false)
+  local autoAdd = options.wrapInSprites and (options.autoAddSprites ~= false)
   local sceneHasAdd = scene and type(scene) == "table" and type(scene.addSprite) == "function" or false
 
   --#DEBUG START
@@ -426,9 +474,9 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   --#DEBUG END
 
   -- Load the map JSON
-  local mapData, err = loadJSON(jsonPath)
+  local mapData, error = loadJSON(jsonPath)
   if not mapData then
-    Log.error("[RoxyTilemap:init] " .. (err or "unknown error")) --#DEBUG
+    Log.error("[RoxyTilemap:init] " .. (error or "unknown error")) --#DEBUG
     self.layers, self.sprites, self.tilesets, self.objectLayers, self.objectSprites = {}, {}, nil, nil, {}
     self.worldWidth, self.worldHeight = 0, 0
     return
@@ -445,7 +493,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   self.staggerAxis = mapData.staggeraxis -- "x" | "y" | nil
   self.staggerIndex = mapData.staggerindex -- "odd" | "even" | nil
 
-  -- Your original world size (orthographic assumption)
+  -- Calculate world size (orthographic assumption)
   self.worldWidth = (mapData.width or 0) * (mapData.tilewidth or 0)
   self.worldHeight = (mapData.height or 0) * (mapData.tileheight or 0)
 
@@ -458,14 +506,16 @@ function RoxyTilemap:init(jsonPath, opts, scene)
       tileset = tileset
     }
   end
-  tableSort(gidRanges, function(a, b) return a.first < b.first end)
+  tableSort(gidRanges, function(rangeA, rangeB) return rangeA.first < rangeB.first end)
 
-  -- Cache First Tileset per Layer
+  -- Helper: Find tileset for a given GID
   local function tilesetForGid(gid)
-    for i = #gidRanges, 1, -1 do
-      local range = gidRanges[i]
+    for index = #gidRanges, 1, -1 do
+      local range = gidRanges[index]
       if gid >= range.first then
-        if gid <= range.last then return range.tileset end
+        if gid <= range.last then
+          return range.tileset
+        end
         break
       end
     end
@@ -473,7 +523,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   end
 
   -- Apply camera bounds if requested
-  if opts.cameraBounds then
+  if options.cameraBounds then
     setCameraBounds({
       x1 = 0,
       y1 = 0,
@@ -482,21 +532,22 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     })
   end
 
-  local mapPox = tonumber(mapData.parallaxoriginx) or 0
-  local mapPoy = tonumber(mapData.parallaxoriginy) or 0
+  -- Get map-level parallax origins
+  local mapParallaxOriginX = tonumber(mapData.parallaxoriginx) or 0
+  local mapParallaxOriginY = tonumber(mapData.parallaxoriginy) or 0
 
   -- Build tileset lookup (for loading imageTables)
   local tilesets = {}
   for _, tileset in ipairs(mapData.tilesets or {}) do
-    local normPath = normalizeImgPath(tileset.image)
-    if not normPath then
+    local normalizedPath = normalizeImagePath(tileset.image)
+    if not normalizedPath then
       Log.warn("[RoxyTilemap:init] Skipping tileset '" .. tostring(tileset.name) .. "' due to invalid image path") --#DEBUG
       goto continueTileset
     end
 
-    tileset.imagePath = normPath -- Store normalized path
-    tileset.imageTable = getImagetable(normPath)
-    retain(normPath, tileset.imageTable)
+    tileset.imagePath = normalizedPath -- Store normalized path
+    tileset.imageTable = getImagetable(normalizedPath)
+    retain(normalizedPath, tileset.imageTable)
     tilesets[tileset.name] = tileset
 
     ::continueTileset::
@@ -506,18 +557,18 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   -- Build layers
   self.layers = {}
   local newSprites = {}
-  local processAll = next(opts.layers) == nil
+  local processAllLayers = next(options.layers) == nil -- Process all if none specified
 
   for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "tilelayer" and (processAll or opts.layers[layer.name]) then
-      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
+    if layer.type == "tilelayer" and (processAllLayers or options.layers[layer.name]) then
+      local layerOptions = (options.layerOptions and options.layerOptions[layer.name]) or {}
       local data = layer.data or {}
 
-      -- Cache First Tileset per Layer - Find first nonzero GID and cache the tileset
+      -- Find first nonzero GID and cache the tileset
       local usedTileset = nil
-      for i = 1, #data do
-        local rawGid = data[i]
-        local gid = rawGid & 0x1FFFFFFF
+      for index = 1, #data do
+        local rawGid = data[index]
+        local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
         if gid ~= 0 then
           usedTileset = tilesetForGid(gid)
           break
@@ -526,13 +577,13 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 
       if not usedTileset then
         Log.warn("[RoxyTilemap:init] Layer '"..layer.name.."' has no matching tileset") --#DEBUG
-        goto continue -- Skip this layer if no valid tileset
+        goto continueLayer -- Skip this layer if no valid tileset
       end
 
-      -- Check for non-empty layer
+      -- Check if layer is non-empty
       local isEmpty = true
-      for i = 1, #data do
-        if data[i] ~= 0 then
+      for index = 1, #data do
+        if data[index] ~= 0 then
           isEmpty = false
           break
         end
@@ -547,19 +598,20 @@ function RoxyTilemap:init(jsonPath, opts, scene)
       end
       --#DEBUG END
 
+      -- Only process layers with valid tilesets and non-empty data
       if usedTileset and not isEmpty and usedTileset.imageTable then
         local firstgid = usedTileset.firstgid
         local tilemap = newTilemap()
         tilemap:setSize(layer.width, layer.height)
         tilemap:setImageTable(usedTileset.imageTable)
 
-        -- Set the tiles in the tilemap
+        -- Convert GIDs to tilemap indices
         local indices = createTable(#data, 0)
-        for i = 1, #data do
-          local rawGid = data[i]
-          local gid = rawGid & 0x1FFFFFFF
+        for index = 1, #data do
+          local rawGid = data[index]
+          local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
           -- Use cached usedTileset instead of calling tilesetForGid for each tile
-          indices[i] = (gid ~= 0) and (gid - firstgid + 1) or 0
+          indices[index] = (gid ~= 0) and (gid - firstgid + 1) or 0
         end
         tilemap:setTiles(indices, layer.width)
         local tiles, stride = tilemap:getTiles()
@@ -568,49 +620,56 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         -- Actual image size (e.g., 64x64) is handled via per-image offsets
         local tileWidth, tileHeight = self.mapTileWidth, self.mapTileHeight
 
-        -- Precompute map pixel size for direct draw
-        local width, height = tilemap:getSize()
-        local mapPixelWidth  = width  * tileWidth
-        local mapPixelHeight = height * tileHeight
+        -- Precompute map pixel size
+        local mapWidth, mapHeight = tilemap:getSize()
+        local mapPixelWidth  = mapWidth  * tileWidth
+        local mapPixelHeight = mapHeight * tileHeight
 
-        local maxImgH = 0
-        do
-          local tbl = usedTileset.imageTable
-          local n = tbl and tbl:getLength() or 0
-          for i = 1, n do
-            local img = tbl:getImage(i)
-            if img then
-              local _, h = img:getSize()
-              if h and h > maxImgH then maxImgH = h end
+        -- Calculate maximum image height for this layer's tileset
+        local maxImageHeight = 0
+        local imageTable = usedTileset.imageTable
+        local imageCount = imageTable and imageTable:getLength() or 0
+        for index = 1, imageCount do
+          local img = imageTable:getImage(index)
+          if img then
+            local _, height = img:getSize()
+            if height and height > maxImageHeight then
+              maxImageHeight = height
             end
           end
         end
 
+        -- Create layer data structure
         local layerData = {
           name = layer.name,
           tilemap = tilemap,
           tiledId = layer.id,
-          anchor = opts.anchor,
-          imageTable = usedTileset.imageTable,
+          anchor = options.anchor,
           imagePath = usedTileset.imagePath,
+          imageTable = imageTable,
+          imageCount = imageCount,
           tileWidth = tileWidth,
           tileHeight = tileHeight,
+          halfWidth = tileWidth * 0.5,
+          halfHeight = tileHeight * 0.5,
           tilesFlat  = tiles,
           tilesStride = stride or layer.width,
-          maxImgH = maxImgH,
-          zIndex = (layerOptions.zIndex or opts.zIndices[layer.name] or 0),
+          maxImageHeight = maxImageHeight,
+          zIndex = (layerOptions.zIndex or options.zIndices[layer.name] or 0),
           visible = (layerOptions.visible ~= false),
+          mapWidth = mapWidth,
+          mapHeight = mapHeight,
           mapPixelWidth = mapPixelWidth,
           mapPixelHeight = mapPixelHeight,
-          _imgCache = {},
-          _offCache = {},
+          _imageCache = {},
+          _offsetCache = {},
         }
 
-        -- Compute origin/parallax regardless of wrapping in sprites
+        -- Compute origin/parallax values
         local offsetX = tonumber(layer.offsetx) or 0
         local offsetY = tonumber(layer.offsety) or 0
         local originX, originY
-        if opts.anchor == "topLeft" then
+        if options.anchor == "topLeft" then
           originX, originY = offsetX, offsetY
         else
           originX = (mapPixelWidth  * 0.5) + offsetX
@@ -621,42 +680,43 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 
         local parallaxX = tonumber(layer.parallaxx) or 1
         local parallaxY = tonumber(layer.parallaxy) or 1
-        local pox = opts.parallaxOriginX or mapPox
-        local poy = opts.parallaxOriginY or mapPoy
+        local parallaxOriginX = options.parallaxOriginX or mapParallaxOriginX
+        local parallaxOriginY = options.parallaxOriginY or mapParallaxOriginY
         layerData.parallaxx = parallaxX
         layerData.parallaxy = parallaxY
-        layerData.parallaxoriginx = pox
-        layerData.parallaxoriginy = poy
+        layerData.parallaxoriginx = parallaxOriginX
+        layerData.parallaxoriginy = parallaxOriginY
 
         -- Wrap in sprite if requested
-        if opts.wrapInSprites then
+        if options.wrapInSprites then
           local sprite = newSprite()
           sprite:setTilemap(tilemap)
-          if opts.anchor == "topLeft" then
+
+          if options.anchor == "topLeft" then
             sprite:setCenter(0, 0)
           else
             sprite:setCenter(0.5, 0.5)
           end
+
           sprite:setZIndex(layerData.zIndex)
 
-          local camGetter = getCameraPosition
-          local rnd = round
+          local cameraGetter = getCameraPosition
+          local roundFn = round
           local useParallax = (layerOptions.parallax ~= false)
+
           if useParallax and (parallaxX ~= 1 or parallaxY ~= 1 or offsetX ~= 0 or offsetY ~= 0) then
             sprite:setIgnoresDrawOffset(true)
             sprite:setUpdatesEnabled(true)
 
             -- Use consistent pivot calculation like projection classes
-            local pivotAdjustX = pox * (1 - parallaxX)
-            local pivotAdjustY = poy * (1 - parallaxY)
             local worldX, worldY = originX, originY
 
             sprite.update = createParallaxUpdate(
               worldX, worldY,
               parallaxX, parallaxY,
-              pox, poy,
-              rnd, camGetter,
-              opts.anchor, mapPixelWidth, mapPixelHeight
+              parallaxOriginX, parallaxOriginY,
+              roundFn, cameraGetter,
+              options.anchor, mapPixelWidth, mapPixelHeight
             )
           else
             sprite:moveTo(originX, originY)
@@ -664,6 +724,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 
           tableInsert(newSprites, sprite)
           layerData.sprite = sprite
+
           if autoAdd then
             if sceneHasAdd then
               scene:addSprite(sprite)
@@ -675,23 +736,26 @@ function RoxyTilemap:init(jsonPath, opts, scene)
           sprite:setVisible(layerData.visible)
         end
 
-        -- Add collision sprites (if collidable)
+        -- Add collision sprites if layer is collidable
         if layerOptions.collidable == true then
           local emptyIDs = layerOptions.emptyIDs or {}
-          local wallGroup = layerOptions.wallSpriteGroup or opts.wallSpriteGroup
-          local layerCollidesWithGroups = layerOptions.wallCollidesWithGroups or opts.wallCollidesWithGroups
+          local wallGroup = layerOptions.wallSpriteGroup or options.wallSpriteGroup
+          local layerCollidesWithGroups = layerOptions.wallCollidesWithGroups or options.wallCollidesWithGroups
 
           local collisionSprites = addWallSprites(tilemap, emptyIDs)
           for _, sprite in ipairs(collisionSprites) do
             sprite:setTag(1)
             sprite:setCollideRect(0, 0, sprite:getSize())
+
             if wallGroup then
               sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
             end
+
             if layerCollidesWithGroups and type(layerCollidesWithGroups) == "table" and #layerCollidesWithGroups > 0 then
               sprite:setCollidesWithGroups(layerCollidesWithGroups)
             end
-            sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
+
+            sprite.collisionResponse = layerOptions.collisionResponse or options.collisionResponse
           end
           layerData.collisionSprites = collisionSprites
         end
@@ -699,23 +763,24 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         self.layers[layer.name] = layerData
       end
     end
-    ::continue::
+    ::continueLayer::
   end
   self.sprites = newSprites
 
   -- Process object layers
   local objectSprites = {}
   for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "objectgroup" and (processAll or opts.objectLayers[layer.name]) then
-      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
+    if layer.type == "objectgroup" and (processAllLayers or options.objectLayers[layer.name]) then
+      local layerOptions = (options.layerOptions and options.layerOptions[layer.name]) or {}
 
       -- Pass newSprites to processObjectLayer for direct insertion
-      local sprites = processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
+      local sprites = processObjectLayer(self, layer, options, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
       objectSprites[layer.name] = sprites
     end
   end
-  self.objectSprites = objectSprites -- Store object sprites
+  self.objectSprites = objectSprites
 
+  -- Store object layer data for reference
   self.objectLayers = {}
   for _, layer in ipairs(mapData.layers or {}) do
     if layer.type == "objectgroup" then
@@ -723,7 +788,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     end
   end
 
-  -- Attach to a scene immediately
+  -- Attach to a scene immediately if it supports tilemaps
   if scene and scene.addTilemap then
     scene:addTilemap(self)
   end
@@ -734,16 +799,19 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Get Tilemap
+-- Returns the Playdate tilemap for the specified layer
 function RoxyTilemap:getTilemap(name)
   return self.layers[name] and self.layers[name].tilemap
 end
 
 -- ! Get Sprite
+-- Returns the display sprite for the specified layer (if wrapInSprites was enabled)
 function RoxyTilemap:getSprite(name)
   return self.layers[name] and self.layers[name].sprite
 end
 
 -- ! Get Objects
+-- Returns the raw Tiled object data for the specified object layer
 function RoxyTilemap:getObjects(name)
   return self.objectLayers and self.objectLayers[name]
 end
@@ -775,16 +843,16 @@ end
 -- ! Find Object Sprites By Type
 -- Returns all sprites from the layer whose Tiled objects have the specified type
 function RoxyTilemap:findObjectSpritesByType(layerName, objectType)
-  return self:findObjectSprites(layerName, function(obj)
-    return obj.type == objectType
+  return self:findObjectSprites(layerName, function(object)
+    return object.type == objectType
   end)
 end
 
 -- ! Find Object Sprites By Name
 -- Returns all sprites from the layer whose Tiled objects have the specified name
 function RoxyTilemap:findObjectSpritesByName(layerName, objectName)
-  return self:findObjectSprites(layerName, function(obj)
-    return obj.name == objectName
+  return self:findObjectSprites(layerName, function(object)
+    return object.name == objectName
   end)
 end
 
@@ -802,6 +870,7 @@ function RoxyTilemap:findObjectSprites(layerName, predicate)
 end
 
 -- ! Remove Object Layer
+-- Removes all sprites from an object layer and cleans up references
 function RoxyTilemap:removeObjectLayer(layerName)
   local sprites = self:getObjectSprites(layerName)
   for _, sprite in ipairs(sprites) do
@@ -817,11 +886,11 @@ function RoxyTilemap:removeObjectLayer(layerName)
 end
 
 -- ! Get Tile At
--- Returns the tile index at the given tile coordinates (x, y) on the specified layer.
--- Note: Coordinates are in tile units, not pixels.
-function RoxyTilemap:getTileAt(name, x, y)
+-- Returns the tile index at the given tile coordinates (x, y) on the specified layer
+-- Note: Coordinates are in tile units, not pixels
+function RoxyTilemap:getTileAt(name, tileX, tileY)
   local tilemap = self:getTilemap(name)
-  return tilemap and tilemap:getTileAtPosition(x, y) or nil
+  return tilemap and tilemap:getTileAtPosition(tileX, tileY) or nil
 end
 
 -- ! For Each Tile
@@ -832,87 +901,98 @@ function RoxyTilemap:forEachTile(name, fn)
   if not tilemap or type(fn) ~= "function" then return end
 
   local width, height = tilemap:getSize()
-  for y = 1, height do
-    for x = 1, width do
-      fn(x, y, tilemap:getTileAtPosition(x, y))
+  for tileY = 1, height do
+    for tileX = 1, width do
+      fn(tileX, tileY, tilemap:getTileAtPosition(tileX, tileY))
     end
   end
 end
 
 -- ! Get World Size
--- Returns the pixel dimensions of the tilemap, based on the first tile layer.
--- This is cached at init-time and available even if cameraBounds is false.
+-- Returns the pixel dimensions of the tilemap, based on the first tile layer
+-- This is cached at init-time and available even if cameraBounds is false
 function RoxyTilemap:getWorldSize()
   return self.worldWidth, self.worldHeight
 end
 
 -- ! Hide Layer
+-- Hides a tile layer from rendering (affects both sprites and direct drawing)
 function RoxyTilemap:hideLayer(name)
-  local layer = self.layers and self.layers[name]
-  if not layer then return end
+  local layerData = self.layers and self.layers[name]
+  if not layerData then return end
 
-  -- Ensure direct draw respects visibility
-  layer.visible = false
+  -- Update visibility flag for direct draw
+  layerData.visible = false
 
-  local sprite = layer.sprite
+  -- Hide sprite if it exists
+  local sprite = layerData.sprite
   if sprite then
     sprite:setVisible(false)
   end
 end
 
 -- ! Show Layer
+-- Shows a previously hidden tile layer
 function RoxyTilemap:showLayer(name)
-  local layer = self.layers and self.layers[name]
-  if not layer then return end
+  local layerData = self.layers and self.layers[name]
+  if not layerData then return end
 
-  -- Ensure direct draw respects visibility
-  layer.visible = true
+  -- Update visibility flag for direct draw
+  layerData.visible = true
 
-  local sprite = layer.sprite
+  -- Show sprite if it exists
+  local sprite = layerData.sprite
   if sprite then
     sprite:setVisible(true)
   end
 end
 
 -- ! Remove Layer
+-- Completely removes a tile layer and cleans up all associated resources
 function RoxyTilemap:removeLayer(name)
-  local layer = self.layers[name]
-  if not layer then return end
+  local layerData = self.layers[name]
+  if not layerData then return end
 
-  -- Release only paths this instance retained
-  if layer.imagePath and self._retainedPaths and self._retainedPaths[layer.imagePath] then
-    release(layer.imagePath)
-    self._retainedPaths[layer.imagePath] = nil
+  -- Release assets that this instance retained
+  if layerData.imagePath and self._retainedPaths and self._retainedPaths[layerData.imagePath] then
+    release(layerData.imagePath)
+    self._retainedPaths[layerData.imagePath] = nil
   end
 
-  -- Remove display sprite & keep scene list in sync
-  if layer.sprite then
-    local sprite = layer.sprite
+  -- Remove display sprite and keep scene list in sync
+  if layerData.sprite then
+    local sprite = layerData.sprite
     if self.scene and self.scene.removeSprite then
       self.scene:removeSprite(sprite)
     else
       sprite:remove()
     end
+
+    -- Remove from sprite list
     if self.sprites then
-      for i = #self.sprites, 1, -1 do
-        if self.sprites[i] == sprite then tableRemove(self.sprites, i) break end
+      for index = #self.sprites, 1, -1 do
+        if self.sprites[index] == sprite then
+          tableRemove(self.sprites, index)
+          break
+        end
       end
     end
-    layer.sprite = nil
+    layerData.sprite = nil
   end
 
-  -- Remove collision sprites (they were not added via scene list, so display remove is fine)
-  if layer.collisionSprites then
-    for _, sprite in ipairs(layer.collisionSprites) do
+  -- Remove collision sprites
+  if layerData.collisionSprites then
+    for _, sprite in ipairs(layerData.collisionSprites) do
       sprite:remove()
     end
-    layer.collisionSprites = nil
+    layerData.collisionSprites = nil
   end
 
   -- Clear heavy references
-  layer.tilemap = nil
-  layer.imageTable = nil
-  layer._imgCache = nil
+  layerData.tilemap = nil
+  layerData.imageTable = nil
+  layerData._imageCache = nil
+  layerData._offsetCache = nil
 
   self.layers[name] = nil
 end
@@ -924,21 +1004,21 @@ end
 -- ! Set Layer ImageTable
 -- Swap the imagetable used by a tile layer at runtime.
 -- newImageTableOrPath: a playdate.graphics.imagetable or a string path (Tiled/normalized)
--- remap: optional table or function to remap tile indices (oldIndex --> newIndex)
---   - If a table, remap[oldIndex] = newIndex
---   - If a function, newIndex = remap(oldIndex) (return nil to keep oldIndex)
-function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap then
+-- remapFn: optional table or function to remap tile indices (oldIndex --> newIndex)
+--   - If a table, remapFn[oldIndex] = newIndex
+--   - If a function, newIndex = remapFn(oldIndex) (return nil to keep oldIndex)
+function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
+  local layerData = self.layers and self.layers[name]
+  if not layerData or not layerData.tilemap then
     Log.warn("[RoxyTilemap:setLayerImageTable] No layer or tilemap for '" .. tostring(name) .. "'") --#DEBUG
     return false
   end
 
-  -- Resolve imagetable
+  -- Resolve imagetable from path or direct reference
   local newPath, newTable
   if type(newImageTableOrPath) == "string" then
     -- Normalize path like tileset loader does
-    newPath = normalizeImgPath(newImageTableOrPath) or newImageTableOrPath
+    newPath = normalizeImagePath(newImageTableOrPath) or newImageTableOrPath
     newTable = getImagetable(newPath)
     if not newTable then
       Log.warn("[RoxyTilemap:setLayerImageTable] Failed to load imagetable: " .. tostring(newPath)) --#DEBUG
@@ -952,83 +1032,87 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remap)
     end
   end
 
-  -- Optional remap of existing tile indices
-  if remap then
-    local data, width = layer.tilemap:getTiles()
+  -- Apply optional remapping of existing tile indices
+  if remapFn then
+    local data, width = layerData.tilemap:getTiles()
     if data and width then
-      if type(remap) == "function" then
-        for i = 1, #data do
-          local idx = data[i]
-          if idx ~= 0 then
-            local mapped = remap(idx)
-            if mapped ~= nil then data[i] = mapped end -- Allow mapping to 0
+      if type(remapFn) == "function" then
+        for index = 1, #data do
+          local tileIndex = data[index]
+          if tileIndex ~= 0 then
+            local mapped = remapFn(tileIndex)
+            if mapped ~= nil then
+              data[index] = mapped -- Allow mapping to 0
+            end
           end
         end
-      elseif type(remap) == "table" then
-        for i = 1, #data do
-          local idx = data[i]
-          if idx ~= 0 then
-            local mapped = remap[idx]
+      elseif type(remapFn) == "table" then
+        for index = 1, #data do
+          local tileIndex = data[index]
+          if tileIndex ~= 0 then
+            local mapped = remapFn[tileIndex]
             if mapped ~= nil then
-              data[i] = mapped -- Allow mapping to 0
+              data[index] = mapped -- Allow mapping to 0
             end
           end
         end
       else
-        Log.warn("[RoxyTilemap:setLayerImageTable] Invalid remap; expected table or function") --#DEBUG
+        Log.warn("[RoxyTilemap:setLayerImageTable] Invalid remapFn; expected table or function") --#DEBUG
       end
-      layer.tilemap:setTiles(data, width)
+      layerData.tilemap:setTiles(data, width)
     end
   end
 
-  -- Swap imagetable
-  layer.tilemap:setImageTable(newTable)
-  layer.imageTable = newTable
-  layer._imgCache = {}
-  layer._offCache = {}  -- reset offset cache
+  -- Swap the imagetable
+  layerData.tilemap:setImageTable(newTable)
+  layerData.imageTable = newTable
+  layerData._imageCache = {}
+  layerData._offsetCache = {}
 
-  -- Recompute max image height (use newTable, not usedTileset)
-  local maxImgH = 0
+  -- Recompute maximum image height using the new imagetable
+  local maxImageHeight = 0
   do
-    local tbl = newTable
-    local n = tbl and tbl:getLength() or 0
-    for i = 1, n do
-      local img = tbl:getImage(i)
+    local imageTable = newTable
+    local imageCount = imageTable and imageTable:getLength() or 0
+    for index = 1, imageCount do
+      local img = imageTable:getImage(index)
       if img then
-        local _, h = img:getSize()
-        if h and h > maxImgH then maxImgH = h end
+        local _, height = img:getSize()
+        if height and height > maxImageHeight then
+          maxImageHeight = height
+        end
       end
     end
   end
-  layer.maxImgH = maxImgH
+  layerData.maxImageHeight = maxImageHeight
+  layerData.imageCount = imageCount
 
-  -- Update asset retention (if a path swap)
+  -- Update asset retention (if this was a path swap)
   if newPath then
     if not self._retainedPaths[newPath] then
       retain(newPath, newTable) -- Retain the newly used imagetable path
       self._retainedPaths[newPath] = true -- Track so we can release on destroy
     end
 
-    local oldPath = layer.imagePath
+    local oldPath = layerData.imagePath
     if oldPath and oldPath ~= newPath and self._retainedPaths[oldPath] then
       release(oldPath) -- Only release paths this instance retained
       self._retainedPaths[oldPath] = nil
     end
-    layer.imagePath = newPath
+    layerData.imagePath = newPath
   end
 
-  -- Force a redraw of the area this layer covers (sprite or direct draw)
-  -- Note: Sprites use dirty-rect optimization; we proactively invalidate.
-  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
-  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
+  -- Force a redraw by marking the layer area as dirty
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local mapWidthTiles, mapHeightTiles = layerData.tilemap:getSize()
   local mapPixelWidth  = mapWidthTiles  * tileWidth
   local mapPixelHeight = mapHeightTiles * tileHeight
 
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
   local cameraX, cameraY = getCameraPosition()
-  local originX, originY = layer.originX or 0, layer.originY or 0
-  local centerX = (layer.anchor == "topLeft") and 0 or 0.5
-  local centerY = (layer.anchor == "topLeft") and 0 or 0.5
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local centerX = (layerData.anchor == "topLeft") and 0 or 0.5
+  local centerY = (layerData.anchor == "topLeft") and 0 or 0.5
 
   local screenX = round(originX - mapPixelWidth * centerX  - cameraX * parallaxX)
   local screenY = round(originY - mapPixelHeight * centerY - cameraY * parallaxY)
@@ -1042,52 +1126,58 @@ end
 -- Recreates wall sprites for a tile layer using the provided emptyIDs.
 -- Use when a tileset swap changes which tile indices should be passable vs solid.
 function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesWithGroups, collisionResponse)
-  local layer = self.layers and self.layers[name]
-  if not layer or not layer.tilemap then return end
+  local layerData = self.layers and self.layers[name]
+  if not layerData or not layerData.tilemap then return end
 
-  -- Remove previous collision sprites (if any)
-  if layer.collisionSprites then
-    for _, sprite in ipairs(layer.collisionSprites) do
+  -- Remove previous collision sprites
+  if layerData.collisionSprites then
+    for _, sprite in ipairs(layerData.collisionSprites) do
       sprite:remove()
     end
-    layer.collisionSprites = nil
+    layerData.collisionSprites = nil
   end
 
   -- Build new collision sprites from current tile indices
-  local collisionSprites = addWallSprites(layer.tilemap, emptyIDs or {})
+  local collisionSprites = addWallSprites(layerData.tilemap, emptyIDs or {})
 
-  -- Configure sprites similar to init-time setup
+  -- Configure sprites with collision properties
   for _, sprite in ipairs(collisionSprites) do
     sprite:setTag(1)
     sprite:setCollideRect(0, 0, sprite:getSize())
+
     if wallGroup then
       sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
     end
+
     if collidesWithGroups and type(collidesWithGroups) == "table" and #collidesWithGroups > 0 then
       sprite:setCollidesWithGroups(collidesWithGroups)
     end
+
     sprite.collisionResponse = collisionResponse or "overlap"
   end
 
-  layer.collisionSprites = collisionSprites
+  layerData.collisionSprites = collisionSprites
 end
 
 --------------------------------------------------------------------------------
--- Projection methods
+-- Projection Methods (abstract -- implemented by subclasses)
 --------------------------------------------------------------------------------
 
 -- ! World to Screen (abstract method)
+-- Converts world coordinates to screen coordinates for the given layer
 function RoxyTilemap:worldToScreen(worldX, worldY, layer)
   Log.error("[RoxyTilemap:worldToScreen] Abstract method - must be implemented by projection subclass")
 end
 
 -- ! Screen to World (abstract method)
+-- Converts screen coordinates to world coordinates for the given layer
 function RoxyTilemap:screenToWorld(screenX, screenY, layer)
   Log.error("[RoxyTilemap:screenToWorld] Abstract method - must be implemented by projection subclass")
 end
 
 -- ! Set Tile At (abstract method)
-function RoxyTilemap:setTileAt(name, x, y, tileIndex, updateSprite)
+-- Sets a tile at the given coordinates and optionally updates the display sprite
+function RoxyTilemap:setTileAt(name, tileX, tileY, tileIndex, updateSprite)
   Log.error("[RoxyTilemap:setTileAt] Abstract method - must be implemented by projection subclass")
 end
 
@@ -1098,37 +1188,37 @@ end
 -- ! Set Layer Origin
 -- Updates the origin for a single layer and keeps any display sprite in sync.
 function RoxyTilemap:setLayerOrigin(name, originX, originY)
-  local layer = self.layers and self.layers[name]
-  if not layer then return false end
+  local layerData = self.layers and self.layers[name]
+  if not layerData then return false end
 
   -- Update stored origin used by both sprite and direct draw
-  layer.originX = originX or 0
-  layer.originY = originY or 0
+  layerData.originX = originX or 0
+  layerData.originY = originY or 0
 
-  -- Keep an existing sprite in sync
-  local sprite = layer.sprite
+  -- Keep existing sprite in sync
+  local sprite = layerData.sprite
   if sprite then
-    local parallaxX = layer.parallaxx or 1
-    local parallaxY = layer.parallaxy or 1
-    local pox = layer.parallaxoriginx or 0
-    local poy = layer.parallaxoriginy or 0
+    local parallaxX = layerData.parallaxx or 1
+    local parallaxY = layerData.parallaxy or 1
+    local parallaxOriginX = layerData.parallaxoriginx or 0
+    local parallaxOriginY = layerData.parallaxoriginy or 0
 
-    -- If this layer was using a parallax update closure, rebuild it with the new origin.
+    -- If this layer was using a parallax update closure, rebuild it with the new origin
     if sprite.update and sprite.setUpdatesEnabled then
       -- Recreate the cached updater using the helper
       sprite.update = createParallaxUpdate(
-        layer.originX, layer.originY,
+        layerData.originX, layerData.originY,
         parallaxX, parallaxY,
-        pox, poy, -- Pass origins separately for consistency
+        parallaxOriginX, parallaxOriginY,
         round, getCameraPosition,
-        layer.anchor, layer.mapPixelWidth, layer.mapPixelHeight
+        layerData.anchor, layerData.mapPixelWidth, layerData.mapPixelHeight
       )
       -- Ensure we do not double-apply draw offset
       sprite:setIgnoresDrawOffset(true)
       sprite:setUpdatesEnabled(true)
     else
       -- No parallax updater; just move the sprite to the new origin
-      sprite:moveTo(layer.originX, layer.originY)
+      sprite:moveTo(layerData.originX, layerData.originY)
     end
   end
 
@@ -1136,11 +1226,11 @@ function RoxyTilemap:setLayerOrigin(name, originX, originY)
 end
 
 -- ! Set Origin For All Layers
--- Convenience to apply the same origin to every tile layer.
+-- Convenience method to apply the same origin to every tile layer
 function RoxyTilemap:setOriginForAllLayers(originX, originY)
   if not self.layers then return end
-  for name, _ in pairs(self.layers) do
-    self:setLayerOrigin(name, originX, originY)
+  for layerName, _ in pairs(self.layers) do
+    self:setLayerOrigin(layerName, originX, originY)
   end
 end
 
@@ -1153,11 +1243,13 @@ end
 function RoxyTilemap:getScreenBoundsInWorld(layer)
   if not layer then return 0, 0, 0, 0 end
 
+  -- Get world coordinates of each screen corner
   local topLeftX, topLeftY = self:screenToWorld(0, 0, layer)
   local topRightX, topRightY = self:screenToWorld(DISPLAY_WIDTH, 0, layer)
   local bottomLeftX, bottomLeftY = self:screenToWorld(0, DISPLAY_HEIGHT, layer)
   local bottomRightX, bottomRightY = self:screenToWorld(DISPLAY_WIDTH, DISPLAY_HEIGHT, layer)
 
+  -- Find the bounding box
   local minX = min(topLeftX, topRightX, bottomLeftX, bottomRightX)
   local maxX = max(topLeftX, topRightX, bottomLeftX, bottomRightX)
   local minY = min(topLeftY, topRightY, bottomLeftY, bottomRightY)
@@ -1167,7 +1259,7 @@ function RoxyTilemap:getScreenBoundsInWorld(layer)
 end
 
 -- ! Get Visible Tile Bounds
--- Calculate which tiles are potentially visible with proper margin
+-- Calculate which tiles are potentially visible with proper margin for tall sprites
 function RoxyTilemap:getVisibleTileBounds(layer, extraMargin)
   if not layer then return 1, 1, 1, 1 end
 
@@ -1176,36 +1268,23 @@ function RoxyTilemap:getVisibleTileBounds(layer, extraMargin)
   -- Get world bounds of screen
   local minWorldX, minWorldY, maxWorldX, maxWorldY = self:getScreenBoundsInWorld(layer)
 
-  -- Calculate margin based on image heights (if needed)
+  -- Calculate margin based on image heights if not provided
   local margin = extraMargin or 0
   if not extraMargin and layer.imageTable then
-    -- Calculate proper margin like the projection classes do
     local tileHeight = layer.tileHeight or 0
     local halfHeight = tileHeight * 0.5
 
-    -- Find max image height (similar to _getMaxImgH in projection classes)
-    local maxImgH = 0
-    local imageTable = layer.imageTable
-    local imageTableLength = imageTable and imageTable:getLength() or 0
-    for i = 1, imageTableLength do
-      local img = imageTable:getImage(i)
-      if img then
-        local _, height = img:getSize()
-        if height and height > maxImgH then
-          maxImgH = height
-        end
-      end
-    end
-
-    local overdraw = max(0, maxImgH - tileHeight)
+    -- Use the precomputed max image height
+    local maxImageHeight = layer.maxImageHeight or 0
+    local overdraw = max(0, maxImageHeight - tileHeight)
     margin = ceil(overdraw / max(1, halfHeight)) + 1
   end
 
   -- Apply margin and convert to tile coordinates
-  minWorldX = minWorldX - margin
-  maxWorldX = maxWorldX + margin
-  minWorldY = minWorldY - margin
-  maxWorldY = maxWorldY + margin
+  minWorldX -= margin
+  maxWorldX += margin
+  minWorldY -= margin
+  maxWorldY += margin
 
   local minTileX = max(1, floor(minWorldX) + 1)
   local maxTileX = min(mapWidthTiles, ceil(maxWorldX) + 1)
@@ -1216,19 +1295,35 @@ function RoxyTilemap:getVisibleTileBounds(layer, extraMargin)
 end
 
 --------------------------------------------------------------------------------
--- Drawing
+-- Drawing (abstract methods -- implemented by projection subclasses)
 --------------------------------------------------------------------------------
 
 -- ! Draw
+-- Draws the specified layer (or all layers if no name provided)
 function RoxyTilemap:draw(name)
-  -- Subclasses should implement their own drawing.
-  Log.warn("[RoxyTilemap:draw] Abstract. Implement in a projection leaf.") --#DEBUG
+  -- Subclasses should implement their own drawing logic
+  Log.warn("[RoxyTilemap:draw] Abstract method. Implement in a projection leaf.") --#DEBUG
 end
 
 -- ! Draw Visible
+-- Draws only the visible portions of layers for performance
 function RoxyTilemap:drawVisible()
-  -- Subclasses should implement their own drawing.
-  Log.warn("[RoxyTilemap:drawVisible] Abstract. Implement in a projection leaf.") --#DEBUG
+  -- Subclasses should implement their own drawing logic
+  Log.warn("[RoxyTilemap:drawVisible] Abstract method. Implement in a projection leaf.") --#DEBUG
+end
+
+-- ! Draw Visible in Rectangle
+-- Draws visible portions within a specific screen rectangle
+function RoxyTilemap:drawVisibleInRect(screenX, screenY, width, height)
+  -- Subclasses should implement their own drawing logic
+  Log.warn("[RoxyTilemap:drawVisibleInRect] Abstract method. Implement in a projection leaf.") --#DEBUG
+end
+
+-- ! Draw Layer Rows
+-- Dynamic row/column renderer with manual sprite positioning
+function RoxyTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxColumn)
+  -- Subclasses should implement their own drawing logic
+  Log.warn("[RoxyTilemap:drawLayerRows] Abstract method. Implement in a projection leaf.") --#DEBUG
 end
 
 --------------------------------------------------------------------------------
@@ -1236,31 +1331,34 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Destroy
+-- Cleans up all resources and removes sprites from display
 function RoxyTilemap:destroy()
-  -- Remove layer sprites & collision sprites
-  for _, layer in pairs(self.layers) do
-    if layer.sprite then
+  -- Remove layer sprites and collision sprites
+  for _, layerData in pairs(self.layers) do
+    if layerData.sprite then
       if self.scene and self.scene.removeSprite then
-        self.scene:removeSprite(layer.sprite)
+        self.scene:removeSprite(layerData.sprite)
       else
-        layer.sprite:remove()
+        layerData.sprite:remove()
       end
-      layer.sprite = nil
+      layerData.sprite = nil
     end
-    if layer.collisionSprites then
-      for _, sprite in ipairs(layer.collisionSprites) do
+
+    if layerData.collisionSprites then
+      for _, sprite in ipairs(layerData.collisionSprites) do
         sprite:remove()
       end
-      layer.collisionSprites = nil
+      layerData.collisionSprites = nil
     end
 
     -- Clear heavy references
-    layer.tilemap = nil
-    layer.imageTable = nil
-    layer._imgCache = nil
+    layerData.tilemap = nil
+    layerData.imageTable = nil
+    layerData._imageCache = nil
+    layerData._offsetCache = nil
   end
 
-  -- Remove object sprites (tracked by scene if added that way)
+  -- Remove object sprites
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
       if self.scene and self.scene.removeSprite then
@@ -1271,7 +1369,7 @@ function RoxyTilemap:destroy()
     end
   end
 
-  -- Clean up tilesets retained at init
+  -- Clean up tilesets retained at initialization
   for _, tileset in pairs(self.tilesets or {}) do
     if tileset.imagePath then
       release(tileset.imagePath)
@@ -1286,13 +1384,14 @@ function RoxyTilemap:destroy()
     self._retainedPaths = nil
   end
 
+  -- Clear all references
   self.layers = {}
   self.sprites = {}
   self.objectSprites = {}
   self.tilesets = nil
   self.objectLayers = nil
 
-  -- Detach from scene and let it drop us from its tilemaps list
+  -- Detach from scene and let it remove us from its tilemaps list
   if self.scene then
     local scene = self.scene
     self.scene = nil
@@ -1301,49 +1400,3 @@ function RoxyTilemap:destroy()
     end
   end
 end
-
---#DEBUG START
---------------------------------------------------------------------------------
--- Debugging
--- Useful for troubleshooting the projection classes
---------------------------------------------------------------------------------
-
--- ! Debug Layer Info
-function RoxyTilemap:debugLayerInfo(layerName)
-  local layer = self.layers and self.layers[layerName]
-  if not layer then
-    Log.debug("Layer '" .. tostring(layerName) .. "' not found")
-    return
-  end
-
-  Log.debug("**Layer: " .. layerName .. "**")
-  Log.debug("Projection: " .. tostring(self._projection))
-  Log.debug("Origin: " .. tostring(layer.originX) .. ", " .. tostring(layer.originY))
-  Log.debug("Parallax: " .. tostring(layer.parallaxx) .. ", " .. tostring(layer.parallaxy))
-  Log.debug("Parallax Origin: " .. tostring(layer.parallaxoriginx) .. ", " .. tostring(layer.parallaxoriginy))
-  Log.debug("Tile Size: " .. tostring(layer.tileWidth) .. "x" .. tostring(layer.tileHeight))
-  Log.debug("Map Size: " .. tostring(layer.mapPixelWidth) .. "x" .. tostring(layer.mapPixelHeight))
-  Log.debug("Visible: " .. tostring(layer.visible))
-  Log.debug("Has Sprite: " .. tostring(layer.sprite ~= nil))
-  Log.debug("Has Collisions: " .. tostring(layer.collisionSprites ~= nil))
-end
-
--- ! Debug Visible Bounds
-function RoxyTilemap:debugVisibleBounds(layerName)
-  local layer = self.layers and self.layers[layerName]
-  if not layer then
-    log.debug("Layer '" .. tostring(layerName) .. "' not found")
-    return
-  end
-
-  local minWorldX, minWorldY, maxWorldX, maxWorldY = self:getScreenBoundsInWorld(layer)
-  local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layer)
-
-  log.debug("**Visible Bounds for " .. layerName .. "**")
-  log.debug("World bounds: (" .. minWorldX .. ", " .. minWorldY .. ") to (" .. maxWorldX .. ", " .. maxWorldY .. ")")
-  log.debug("Tile bounds: (" .. minTileX .. ", " .. minTileY .. ") to (" .. maxTileX .. ", " .. maxTileY .. ")")
-
-  local cameraX, cameraY = getCameraPosition()
-  log.debug("Camera: (" .. cameraX .. ", " .. cameraY .. ")")
-end
---#DEBUG END

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -53,10 +53,13 @@ local COLOR_BLACK <const> = Graphics.kColorBlack
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 
+local WALL_TAG   <const> = 1
+local OBJECT_TAG <const> = 2
+
 local EMPTY_TABLE <const> = {}
 
 -- Shared reference counts for all RoxyTilemap instances.
--- Be sure to call retain/release in pairs so you don't
+-- Be sure to call _retain/_release in pairs so you don't
 -- evict an asset another map still needs.
 local referenceCount = {}
 
@@ -64,16 +67,24 @@ local referenceCount = {}
 -- Helpers
 --------------------------------------------------------------------------------
 
+--
+-- Asset Management Helpers
+--
+
 -- ! Helper: Retain Asset
-local function retain(path, table)
+-- Note on "thunk" caching.
+-- We store either the asset or a thunk (a function returning the asset).
+-- Thunks defer allocation until first use, which keeps memory lower when an
+-- imagetable/image is referenced but never actually drawn.
+local function _retain(path, tbl)
   referenceCount[path] = (referenceCount[path] or 0) + 1
   if not getIsAssetCached(path) then
-    cacheAsset(path, function() return table end)
+    cacheAsset(path, function() return tbl end) -- Thunk
   end
 end
 
 -- ! Helper: Release Asset
-local function release(path)
+local function _release(path)
   local count = referenceCount[path]
   if not count then return end
   if count <= 1 then
@@ -86,9 +97,9 @@ end
 
 -- ! Helper: Normalize Image Path
 -- Converts Tiled-exported image paths to Roxy's expected format
-local function normalizeImagePath(tiledImagePath)
+local function _normalizeImagePath(tiledImagePath)
   if type(tiledImagePath) ~= "string" then
-    Log.warn("[normalizeImagePath] Expected string, got " .. type(tiledImagePath)) --#DEBUG
+    Log.warn("[_normalizeImagePath] Expected string, got " .. type(tiledImagePath)) --#DEBUG
     return nil
   end
 
@@ -96,7 +107,7 @@ local function normalizeImagePath(tiledImagePath)
   local base = filename:gsub("%-table%-%d+%-%d+%.png$", "")
 
   if base == filename then
-    Log.warn("[normalizeImagePath] Unexpected image path pattern: " .. tostring(tiledImagePath)) --#DEBUG
+    Log.warn("[_normalizeImagePath] Unexpected image path pattern: " .. tostring(tiledImagePath)) --#DEBUG
     return IMAGE_PATH_PREFIX .. filename
   end
 
@@ -105,39 +116,39 @@ end
 
 -- ! Helper: Get Imagetable
 -- Loads or retrieves cached imagetable from path
-local function getImagetable(path)
+local function _getImagetable(path)
   if type(path) ~= "string" or path == "" then
-    Log.warn("[getImagetable] Invalid or missing path: " .. tostring(path))
+    Log.warn("[_getImagetable] Invalid or missing path: " .. tostring(path))
     return nil
   end
 
   local cached = getCachedAsset(path)
   if cached then
-    -- If cached is a thunk, call it
-    local table = (type(cached) == "function") and cached() or cached
-    return table
+    local imagetable = (type(cached) == "function") and cached() or cached
+    return imagetable
   end
 
   local loaded = newImagetable(path)
   if loaded then
     cacheAsset(path, function() return loaded end)
   else --#DEBUG
-    Log.warn("[getImagetable] Failed to load imagetable at path: " .. path) --#DEBUG
+    Log.warn("[_getImagetable] Failed to load imagetable at path: " .. path) --#DEBUG
   end
 
   return loaded
 end
 
 -- ! Helper: Get Image (cached)
--- Loads or retrieves a cached image from a path and retains it.
-local function getImageCached(path)
+-- Loads or retrieves a cached image from a path
+local function _getImageCached(path)
   if type(path) ~= "string" or path == "" then
-    Log.warn("[getImageCached] Invalid or missing path: " .. tostring(path)) --#DEBUG
+    Log.warn("[_getImageCached] Invalid or missing path: " .. tostring(path)) --#DEBUG
     return nil
   end
 
   local cached = getCachedAsset(path)
   if cached then
+    -- Realize thunk if needed
     local img = (type(cached) == "function") and cached() or cached
     return img
   end
@@ -146,36 +157,40 @@ local function getImageCached(path)
   if loaded then
     cacheAsset(path, function() return loaded end)
   else --#DEBUG
-    Log.warn("[getImageCached] Failed to load image at path: " .. path) --#DEBUG
+    Log.warn("[_getImageCached] Failed to load image at path: " .. path) --#DEBUG
   end
 
   return loaded
 end
 
+--
+-- Configuration & Validation Helpers
+--
+
 -- ! Helper: Validate Options
 -- Ensures all required options have sensible defaults
-local function validateOptions(options)
+local function _validateOptions(opts)
   -- Mutate the original options table instead of creating a new one
-  options = options or {}
+  opts = opts or {}
 
   -- Only create layerOptions table if it doesn't exist
-  if not options.layerOptions then
-    options.layerOptions = EMPTY_TABLE
+  if not opts.layerOptions then
+    opts.layerOptions = EMPTY_TABLE
   end
 
-  local layerOptions = options.layerOptions
+  local layerOptions = opts.layerOptions
 
   -- Validate per-layer emptyIDs
-  for layerName, layerOptions in pairs(layerOptions) do
-    if layerOptions.emptyIDs ~= nil then
-      if type(layerOptions.emptyIDs) ~= "table" then
-        Log.warn("[validateOptions] layerOptions['" .. layerName .. "'].emptyIDs must be a table") --#DEBUG
-        layerOptions.emptyIDs = EMPTY_TABLE
+  for layerName, layerConfig in pairs(layerOptions) do
+    if layerConfig.emptyIDs ~= nil then
+      if type(layerConfig.emptyIDs) ~= "table" then
+        Log.warn("[_validateOptions] layerOptions['" .. layerName .. "'].emptyIDs must be a table") --#DEBUG
+        layerConfig.emptyIDs = EMPTY_TABLE
       else
-        for index, identifier in ipairs(layerOptions.emptyIDs) do
+        for index, identifier in ipairs(layerConfig.emptyIDs) do
           if type(identifier) ~= "number" then
-            Log.warn("[validateOptions] emptyIDs contains non-number at index " .. index .. " for layer '" .. layerName .. "'") --#DEBUG
-            layerOptions.emptyIDs[index] = 0
+            Log.warn("[_validateOptions] emptyIDs contains non-number at index " .. index .. " for layer '" .. layerName .. "'") --#DEBUG
+            layerConfig.emptyIDs[index] = 0
           end
         end
       end
@@ -183,22 +198,26 @@ local function validateOptions(options)
   end
 
   -- Set defaults directly on options
-  if options.layers == nil then options.layers = EMPTY_TABLE end
-  if options.wrapInSprites == nil then options.wrapInSprites = true end
-  if options.zIndices == nil or type(options.zIndices) ~= "table" then options.zIndices = EMPTY_TABLE end
-  if options.cameraBounds == nil then options.cameraBounds = false end
-  if options.anchor == nil or options.anchor ~= "topLeft" then options.anchor = "center" end
-  if options.collisionResponse == nil then options.collisionResponse = "overlap" end
-  if options.wallCollidesWithGroups == nil then options.wallCollidesWithGroups = EMPTY_TABLE end
-  if options.objectLayers == nil then options.objectLayers = EMPTY_TABLE end
+  if opts.layers == nil then opts.layers = EMPTY_TABLE end
+  if opts.wrapInSprites == nil then opts.wrapInSprites = true end
+  if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = EMPTY_TABLE end
+  if opts.cameraBounds == nil then opts.cameraBounds = false end
+  if opts.anchor == nil or opts.anchor ~= "topLeft" then opts.anchor = "center" end
+  if opts.collisionResponse == nil then opts.collisionResponse = "overlap" end
+  if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = EMPTY_TABLE end
+  if opts.objectLayers == nil then opts.objectLayers = EMPTY_TABLE end
 
   -- Return the mutated options instead of a new table
-  return options
+  return opts
 end
+
+--
+-- Object Processing Helpers
+--
 
 -- ! Helper: Create Default Object Sprite
 -- Creates a sprite from a Tiled object, with parallax support
-local function createDefaultObjectSprite(object, layerOptions)
+local function _createDefaultObjectSprite(object, layerOptions)
   -- Initialize parallax values and object properties
   local parallaxX, parallaxY = 1, 1
   local parallaxOriginX, parallaxOriginY = 0, 0
@@ -240,18 +259,18 @@ local function createDefaultObjectSprite(object, layerOptions)
   -- Try to load the image
   local img = nil
   local success, errorMsg = pcall(function()
-    img = getImageCached(imagePath)
+    img = _getImageCached(imagePath)
   end)
 
   --#DEBUG START
   if not success or not img then
-    Log.warn("[createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
+    Log.warn("[_createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
   end
   --#DEBUG END
 
   -- Retain image if successfully loaded
   if img then
-    retain(imagePath, img)
+    _retain(imagePath, img)
   end
 
   -- Create appropriate sprite type
@@ -284,6 +303,7 @@ local function createDefaultObjectSprite(object, layerOptions)
     --#DEBUG END
     end
   end
+  sprite._retainedImagePath = imagePath
 
   -- Store object properties on sprite
   sprite.objectProps = objectProperties
@@ -292,7 +312,7 @@ end
 
 -- ! Helper: Process Object Layer
 -- Converts Tiled object layer into sprites
-local function processObjectLayer(self, layer, options, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
+local function _processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
   local objects = layer.objects or {}
 
   -- Preallocate object layer tables
@@ -302,19 +322,19 @@ local function processObjectLayer(self, layer, options, layerOptions, autoAdd, s
     local sprite = nil
 
     -- Use custom sprite factory if provided (check global first, then layer-specific)
-    if options.spriteFactory and type(options.spriteFactory) == "function" then
-      sprite = options.spriteFactory(object, layer.name, layerOptions)
+    if opts.spriteFactory and type(opts.spriteFactory) == "function" then
+      sprite = opts.spriteFactory(object, layer.name, layerOptions)
     elseif layerOptions.spriteFactory and type(layerOptions.spriteFactory) == "function" then
       sprite = layerOptions.spriteFactory(object, layer.name, layerOptions)
     else
       -- Default sprite creation
-      sprite = createDefaultObjectSprite(object, layerOptions)
+      sprite = _createDefaultObjectSprite(object, layerOptions)
     end
 
     if sprite then
       -- Calculate object position in world pixels (top-left or centered based on anchor)
       local positionX, positionY = object.x or 0, object.y or 0
-      if options.anchor == "center" then
+      if opts.anchor == "center" then
         positionX += (object.width  or 0) * 0.5
         positionY += (object.height or 0) * 0.5
       end
@@ -332,7 +352,7 @@ local function processObjectLayer(self, layer, options, layerOptions, autoAdd, s
       end
 
       -- Set z-index if specified
-      local zIndex = layerOptions.zIndex or options.zIndices[layer.name] or 0
+      local zIndex = layerOptions.zIndex or opts.zIndices[layer.name] or 0
       sprite:setZIndex(zIndex)
 
       -- Set visibility
@@ -343,7 +363,7 @@ local function processObjectLayer(self, layer, options, layerOptions, autoAdd, s
 
       -- Add collision if requested
       if layerOptions.collidable == true then
-        sprite:setTag(layerOptions.tag or 2) -- Different from wall sprites (tag 1)
+        sprite:setTag(layerOptions.tag or OBJECT_TAG) -- Different from wall sprites (tag 1)
         sprite:setCollideRect(0, 0, sprite:getSize())
 
         if layerOptions.spriteGroup then
@@ -354,7 +374,7 @@ local function processObjectLayer(self, layer, options, layerOptions, autoAdd, s
           sprite:setCollidesWithGroups(layerOptions.collidesWithGroups)
         end
 
-        sprite.collisionResponse = layerOptions.collisionResponse or options.collisionResponse
+        sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
       end
 
       tableInsert(layerSprites, sprite)
@@ -378,9 +398,13 @@ local function processObjectLayer(self, layer, options, layerOptions, autoAdd, s
   return layerSprites
 end
 
+--
+-- Parallax System Helpers
+--
+
 -- ! Helper: Create Parallax Update Function
 -- Creates an update function for parallax sprites (hoisted to avoid per-sprite function creation)
-local function createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter, anchor, mapPixelWidth, mapPixelHeight)
+local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter, anchor, mapPixelWidth, mapPixelHeight)
   return function(self)
     local cameraX, cameraY = cameraGetter()
 
@@ -399,71 +423,24 @@ local function createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parall
 end
 
 --------------------------------------------------------------------------------
--- ! Class Definition
+-- ! Class Definition and Initialize
 --------------------------------------------------------------------------------
 
 class("RoxyTilemap").extends(Object)
 
---------------------------------------------------------------------------------
--- Isometric helpers (shared by iso/staggered leaves)
---------------------------------------------------------------------------------
-
--- ! Shared: Isometric Draw Offsets
--- Per-tile draw offsets so diamonds align with Tiled.
-function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, img)
-  local imageWidth, imageHeight = img:getSize()
-  local offsetX = (tileWidth - imageWidth) * 0.5
-  local offsetY = (tileHeight - imageHeight)
-  return offsetX, offsetY
-end
-
--- ! Shared: Begin Manual Draw
--- Temporarily zero draw offset when doing manual placement.
-function RoxyTilemap._beginManualDraw()
-  local offsetX, offsetY = getDrawOffset()
-  if offsetX ~= 0 or offsetY ~= 0 then
-    setDrawOffset(0, 0)
-  end
-  return offsetX, offsetY
-end
-
--- ! Shared: End Manual Draw
--- Restore draw offset after manual placement.
-function RoxyTilemap._endManualDraw(offsetX, offsetY)
-  if offsetX ~= 0 or offsetY ~= 0 then
-    setDrawOffset(offsetX, offsetY)
-  end
-end
-
--- ! Shared: Get Valid Layer
--- Returns a layer if it exists and is drawable
-function RoxyTilemap._getValidLayer(layerName)
-  if not layerName or not self.layers then return nil end
-
-  local layerData = self.layers[layerName]
-  if not layerData or not layerData.tilemap or layerData.visible == false then
-    return nil
-  end
-
-  return layerData
-end
-
---------------------------------------------------------------------------------
--- ! Initialize
---------------------------------------------------------------------------------
-
 --[[
   jsonPath: string - Path to Tiled JSON map
-  options:  table  - Configuration options (see validateOptions)
-  scene:    table? - Optional scene object with addSprite method
+  opts:   table  - Configuration opts (see _validateOptions)
+  scene:  table? - Optional scene object with addSprite method
 ]]
-function RoxyTilemap:init(jsonPath, options, scene)
-  options = validateOptions(options)
+function RoxyTilemap:init(jsonPath, opts, scene)
+  opts = _validateOptions(opts)
+  self._opts = opts
 
   self.scene = scene
   self._retainedPaths = {}
 
-  local autoAdd = options.wrapInSprites and (options.autoAddSprites ~= false)
+  local autoAdd = opts.wrapInSprites and (opts.autoAddSprites ~= false)
   local sceneHasAdd = scene and type(scene) == "table" and type(scene.addSprite) == "function" or false
 
   --#DEBUG START
@@ -509,21 +486,28 @@ function RoxyTilemap:init(jsonPath, options, scene)
   tableSort(gidRanges, function(rangeA, rangeB) return rangeA.first < rangeB.first end)
 
   -- Helper: Find tileset for a given GID
-  local function tilesetForGid(gid)
-    for index = #gidRanges, 1, -1 do
-      local range = gidRanges[index]
-      if gid >= range.first then
-        if gid <= range.last then
-          return range.tileset
-        end
-        break
+  -- Use binary search over sorted gidRanges (firstgid ascending)
+  local function _tilesetForGid(gid)
+    local lo, hi = 1, #gidRanges
+    local candidate = nil
+    while lo <= hi do
+      local mid = floor((lo + hi) * 0.5)
+      local range = gidRanges[mid]
+      if gid < range.first then
+        hi = mid - 1
+      else
+        candidate = range
+        lo = mid + 1
       end
+    end
+    if candidate and gid <= candidate.last then
+      return candidate.tileset
     end
     return nil
   end
 
   -- Apply camera bounds if requested
-  if options.cameraBounds then
+  if opts.cameraBounds then
     setCameraBounds({
       x1 = 0,
       y1 = 0,
@@ -539,38 +523,68 @@ function RoxyTilemap:init(jsonPath, options, scene)
   -- Build tileset lookup (for loading imageTables)
   local tilesets = {}
   for _, tileset in ipairs(mapData.tilesets or {}) do
-    local normalizedPath = normalizeImagePath(tileset.image)
+    local normalizedPath = _normalizeImagePath(tileset.image)
     if not normalizedPath then
       Log.warn("[RoxyTilemap:init] Skipping tileset '" .. tostring(tileset.name) .. "' due to invalid image path") --#DEBUG
       goto continueTileset
     end
 
-    tileset.imagePath = normalizedPath -- Store normalized path
-    tileset.imageTable = getImagetable(normalizedPath)
-    retain(normalizedPath, tileset.imageTable)
-    tilesets[tileset.name] = tileset
+    tileset.imagePath  = normalizedPath
+    tileset.imageTable = _getImagetable(normalizedPath)
+    _retain(normalizedPath, tileset.imageTable)
 
+    -- Precompute once per tileset
+    local maxImageHeight = 0
+    local imageCount = tileset.imageTable and tileset.imageTable:getLength() or 0
+    for index = 1, imageCount do
+      local img = tileset.imageTable:getImage(index)
+      if img then
+        local _, height = img:getSize()
+        if height and height > maxImageHeight then
+          maxImageHeight = height
+        end
+      end
+    end
+    tileset.maxImageHeight = maxImageHeight
+    tileset.imageCount     = imageCount
+
+    tilesets[tileset.name] = tileset
     ::continueTileset::
   end
   self.tilesets = tilesets
 
+  -- Assert/early-out if no usable tilesets were loaded
+  --#DEBUG START
+  Log.assert(next(self.tilesets) ~= nil, "[RoxyTilemap:init] No tilesets were loaded; check map JSON and image paths")
+  --#DEBUG END
+  if not next(self.tilesets) then
+    Log.error("[RoxyTilemap:init] No tilesets were loaded; aborting init") --#DEBUG
+    self.layers, self.sprites, self.objectSprites = {}, {}, {}
+    self.tilesets, self.objectLayers = nil, nil
+    self.worldWidth, self.worldHeight = 0, 0
+    return
+  end
+
   -- Build layers
   self.layers = {}
   local newSprites = {}
-  local processAllLayers = next(options.layers) == nil -- Process all if none specified
+  local processAllLayers = next(opts.layers) == nil -- Process all if none specified
 
   for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "tilelayer" and (processAllLayers or options.layers[layer.name]) then
-      local layerOptions = (options.layerOptions and options.layerOptions[layer.name]) or {}
+    if layer.type == "tilelayer" and (processAllLayers or opts.layers[layer.name]) then
+      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
       local data = layer.data or {}
 
       -- Find first nonzero GID and cache the tileset
+      -- We break early for the first non-empty tile to avoid O(n) on dense layers
+      -- For very sparse/empty layers the scan is still O(n); consider precomputing a
+      -- layer->tileset mapping at export time in Tiled for true O(1)
       local usedTileset = nil
       for index = 1, #data do
         local rawGid = data[index]
         local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
         if gid ~= 0 then
-          usedTileset = tilesetForGid(gid)
+          usedTileset = _tilesetForGid(gid)
           break
         end
       end
@@ -610,7 +624,7 @@ function RoxyTilemap:init(jsonPath, options, scene)
         for index = 1, #data do
           local rawGid = data[index]
           local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
-          -- Use cached usedTileset instead of calling tilesetForGid for each tile
+          -- Use cached usedTileset instead of calling _tilesetForGid for each tile
           indices[index] = (gid ~= 0) and (gid - firstgid + 1) or 0
         end
         tilemap:setTiles(indices, layer.width)
@@ -626,25 +640,16 @@ function RoxyTilemap:init(jsonPath, options, scene)
         local mapPixelHeight = mapHeight * tileHeight
 
         -- Calculate maximum image height for this layer's tileset
-        local maxImageHeight = 0
         local imageTable = usedTileset.imageTable
-        local imageCount = imageTable and imageTable:getLength() or 0
-        for index = 1, imageCount do
-          local img = imageTable:getImage(index)
-          if img then
-            local _, height = img:getSize()
-            if height and height > maxImageHeight then
-              maxImageHeight = height
-            end
-          end
-        end
+        local imageCount = usedTileset.imageCount or 0
+        local maxImageHeight = usedTileset.maxImageHeight or 0
 
         -- Create layer data structure
         local layerData = {
           name = layer.name,
           tilemap = tilemap,
           tiledId = layer.id,
-          anchor = options.anchor,
+          anchor = opts.anchor,
           imagePath = usedTileset.imagePath,
           imageTable = imageTable,
           imageCount = imageCount,
@@ -655,12 +660,13 @@ function RoxyTilemap:init(jsonPath, options, scene)
           tilesFlat  = tiles,
           tilesStride = stride or layer.width,
           maxImageHeight = maxImageHeight,
-          zIndex = (layerOptions.zIndex or options.zIndices[layer.name] or 0),
+          zIndex = (layerOptions.zIndex or opts.zIndices[layer.name] or 0),
           visible = (layerOptions.visible ~= false),
           mapWidth = mapWidth,
           mapHeight = mapHeight,
           mapPixelWidth = mapPixelWidth,
           mapPixelHeight = mapPixelHeight,
+          layerOptions = layerOptions,
           _imageCache = {},
           _offsetCache = {},
         }
@@ -669,7 +675,7 @@ function RoxyTilemap:init(jsonPath, options, scene)
         local offsetX = tonumber(layer.offsetx) or 0
         local offsetY = tonumber(layer.offsety) or 0
         local originX, originY
-        if options.anchor == "topLeft" then
+        if opts.anchor == "topLeft" then
           originX, originY = offsetX, offsetY
         else
           originX = (mapPixelWidth  * 0.5) + offsetX
@@ -680,19 +686,19 @@ function RoxyTilemap:init(jsonPath, options, scene)
 
         local parallaxX = tonumber(layer.parallaxx) or 1
         local parallaxY = tonumber(layer.parallaxy) or 1
-        local parallaxOriginX = options.parallaxOriginX or mapParallaxOriginX
-        local parallaxOriginY = options.parallaxOriginY or mapParallaxOriginY
+        local parallaxOriginX = opts.parallaxOriginX or mapParallaxOriginX
+        local parallaxOriginY = opts.parallaxOriginY or mapParallaxOriginY
         layerData.parallaxx = parallaxX
         layerData.parallaxy = parallaxY
         layerData.parallaxoriginx = parallaxOriginX
         layerData.parallaxoriginy = parallaxOriginY
 
         -- Wrap in sprite if requested
-        if options.wrapInSprites then
+        if opts.wrapInSprites then
           local sprite = newSprite()
           sprite:setTilemap(tilemap)
 
-          if options.anchor == "topLeft" then
+          if opts.anchor == "topLeft" then
             sprite:setCenter(0, 0)
           else
             sprite:setCenter(0.5, 0.5)
@@ -711,12 +717,12 @@ function RoxyTilemap:init(jsonPath, options, scene)
             -- Use consistent pivot calculation like projection classes
             local worldX, worldY = originX, originY
 
-            sprite.update = createParallaxUpdate(
+            sprite.update = _createParallaxUpdate(
               worldX, worldY,
               parallaxX, parallaxY,
               parallaxOriginX, parallaxOriginY,
               roundFn, cameraGetter,
-              options.anchor, mapPixelWidth, mapPixelHeight
+              opts.anchor, mapPixelWidth, mapPixelHeight
             )
           else
             sprite:moveTo(originX, originY)
@@ -739,12 +745,13 @@ function RoxyTilemap:init(jsonPath, options, scene)
         -- Add collision sprites if layer is collidable
         if layerOptions.collidable == true then
           local emptyIDs = layerOptions.emptyIDs or {}
-          local wallGroup = layerOptions.wallSpriteGroup or options.wallSpriteGroup
-          local layerCollidesWithGroups = layerOptions.wallCollidesWithGroups or options.wallCollidesWithGroups
+          local wallGroup = layerOptions.wallSpriteGroup or opts.wallSpriteGroup
+          local layerCollidesWithGroups = layerOptions.wallCollidesWithGroups or opts.wallCollidesWithGroups
 
           local collisionSprites = addWallSprites(tilemap, emptyIDs)
           for _, sprite in ipairs(collisionSprites) do
-            sprite:setTag(1)
+            -- Use const for tag instead of magic number
+            sprite:setTag(WALL_TAG)
             sprite:setCollideRect(0, 0, sprite:getSize())
 
             if wallGroup then
@@ -755,7 +762,8 @@ function RoxyTilemap:init(jsonPath, options, scene)
               sprite:setCollidesWithGroups(layerCollidesWithGroups)
             end
 
-            sprite.collisionResponse = layerOptions.collisionResponse or options.collisionResponse
+            -- Default collisionResponse from layerOptions or global, not hard-coded
+            sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
           end
           layerData.collisionSprites = collisionSprites
         end
@@ -770,11 +778,11 @@ function RoxyTilemap:init(jsonPath, options, scene)
   -- Process object layers
   local objectSprites = {}
   for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "objectgroup" and (processAllLayers or options.objectLayers[layer.name]) then
-      local layerOptions = (options.layerOptions and options.layerOptions[layer.name]) or {}
+    if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
+      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
 
-      -- Pass newSprites to processObjectLayer for direct insertion
-      local sprites = processObjectLayer(self, layer, options, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
+      -- Pass newSprites to _processObjectLayer for direct insertion
+      local sprites = _processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
       objectSprites[layer.name] = sprites
     end
   end
@@ -795,7 +803,38 @@ function RoxyTilemap:init(jsonPath, options, scene)
 end
 
 --------------------------------------------------------------------------------
--- Public Methods
+--  Isometric Rendering Helpers
+--------------------------------------------------------------------------------
+
+-- ! Shared: Isometric Draw Offsets
+-- Per-tile draw offsets so diamonds align with Tiled.
+function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, img)
+  local imageWidth, imageHeight = img:getSize()
+  local offsetX = (tileWidth - imageWidth) * 0.5
+  local offsetY = (tileHeight - imageHeight)
+  return offsetX, offsetY
+end
+
+-- ! Shared: Begin Manual Draw
+-- Temporarily zero draw offset when doing manual placement.
+function RoxyTilemap._beginManualDraw()
+  local offsetX, offsetY = getDrawOffset()
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(0, 0)
+  end
+  return offsetX, offsetY
+end
+
+-- ! Shared: End Manual Draw
+-- Restore draw offset after manual placement.
+function RoxyTilemap._endManualDraw(offsetX, offsetY)
+  if offsetX ~= 0 or offsetY ~= 0 then
+    setDrawOffset(offsetX, offsetY)
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Core Data Access Methods
 --------------------------------------------------------------------------------
 
 -- ! Get Tilemap
@@ -809,6 +848,17 @@ end
 function RoxyTilemap:getSprite(name)
   return self.layers[name] and self.layers[name].sprite
 end
+
+-- ! Get World Size
+-- Returns the pixel dimensions of the tilemap, based on the first tile layer
+-- This is cached at init-time and available even if cameraBounds is false
+function RoxyTilemap:getWorldSize()
+  return self.worldWidth, self.worldHeight
+end
+
+--------------------------------------------------------------------------------
+-- Object Layer Management
+--------------------------------------------------------------------------------
 
 -- ! Get Objects
 -- Returns the raw Tiled object data for the specified object layer
@@ -827,6 +877,10 @@ end
 function RoxyTilemap:getAllSprites()
   return self.sprites or {}
 end
+
+--
+-- Object Sprite Queries
+--
 
 -- ! Find Object Sprite
 -- Finds the first sprite whose Tiled object matches the given predicate function
@@ -885,6 +939,10 @@ function RoxyTilemap:removeObjectLayer(layerName)
   end
 end
 
+--------------------------------------------------------------------------------
+-- Tile Data Access & Manipulation
+--------------------------------------------------------------------------------
+
 -- ! Get Tile At
 -- Returns the tile index at the given tile coordinates (x, y) on the specified layer
 -- Note: Coordinates are in tile units, not pixels
@@ -894,7 +952,7 @@ function RoxyTilemap:getTileAt(name, tileX, tileY)
 end
 
 -- ! For Each Tile
--- Iterates over each tile on the specified layer, calling the provided function.
+-- Iterates over each tile on the specified layer, calling the provided function
 -- Note: Coordinates passed to the function are in tile units.
 function RoxyTilemap:forEachTile(name, fn)
   local tilemap = self:getTilemap(name)
@@ -908,12 +966,9 @@ function RoxyTilemap:forEachTile(name, fn)
   end
 end
 
--- ! Get World Size
--- Returns the pixel dimensions of the tilemap, based on the first tile layer
--- This is cached at init-time and available even if cameraBounds is false
-function RoxyTilemap:getWorldSize()
-  return self.worldWidth, self.worldHeight
-end
+--------------------------------------------------------------------------------
+-- Layer Visibility & Management
+--------------------------------------------------------------------------------
 
 -- ! Hide Layer
 -- Hides a tile layer from rendering (affects both sprites and direct drawing)
@@ -955,7 +1010,7 @@ function RoxyTilemap:removeLayer(name)
 
   -- Release assets that this instance retained
   if layerData.imagePath and self._retainedPaths and self._retainedPaths[layerData.imagePath] then
-    release(layerData.imagePath)
+    _release(layerData.imagePath)
     self._retainedPaths[layerData.imagePath] = nil
   end
 
@@ -998,11 +1053,11 @@ function RoxyTilemap:removeLayer(name)
 end
 
 --------------------------------------------------------------------------------
--- Swap / Set Layer Imagetable and Collisions
+-- Dynamic Layer Modification
 --------------------------------------------------------------------------------
 
 -- ! Set Layer ImageTable
--- Swap the imagetable used by a tile layer at runtime.
+-- Swap the imagetable used by a tile layer at runtime
 -- newImageTableOrPath: a playdate.graphics.imagetable or a string path (Tiled/normalized)
 -- remapFn: optional table or function to remap tile indices (oldIndex --> newIndex)
 --   - If a table, remapFn[oldIndex] = newIndex
@@ -1018,8 +1073,8 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   local newPath, newTable
   if type(newImageTableOrPath) == "string" then
     -- Normalize path like tileset loader does
-    newPath = normalizeImagePath(newImageTableOrPath) or newImageTableOrPath
-    newTable = getImagetable(newPath)
+    newPath = _normalizeImagePath(newImageTableOrPath) or newImageTableOrPath
+    newTable = _getImagetable(newPath)
     if not newTable then
       Log.warn("[RoxyTilemap:setLayerImageTable] Failed to load imagetable: " .. tostring(newPath)) --#DEBUG
       return false
@@ -1071,9 +1126,10 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
 
   -- Recompute maximum image height using the new imagetable
   local maxImageHeight = 0
+  local imageCount = 0
   do
     local imageTable = newTable
-    local imageCount = imageTable and imageTable:getLength() or 0
+    imageCount = imageTable and imageTable:getLength() or 0
     for index = 1, imageCount do
       local img = imageTable:getImage(index)
       if img then
@@ -1090,13 +1146,13 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   -- Update asset retention (if this was a path swap)
   if newPath then
     if not self._retainedPaths[newPath] then
-      retain(newPath, newTable) -- Retain the newly used imagetable path
-      self._retainedPaths[newPath] = true -- Track so we can release on destroy
+      _retain(newPath, newTable) -- Retain the newly used imagetable path
+      self._retainedPaths[newPath] = true -- Track so we can _release on destroy
     end
 
     local oldPath = layerData.imagePath
     if oldPath and oldPath ~= newPath and self._retainedPaths[oldPath] then
-      release(oldPath) -- Only release paths this instance retained
+      _release(oldPath) -- Only _release paths this instance retained
       self._retainedPaths[oldPath] = nil
     end
     layerData.imagePath = newPath
@@ -1123,11 +1179,32 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
 end
 
 -- ! Rebuild Layer Collisions
--- Recreates wall sprites for a tile layer using the provided emptyIDs.
--- Use when a tileset swap changes which tile indices should be passable vs solid.
+-- Recreates wall sprites for a tile layer using the provided emptyIDs
+-- Use when a tileset swap changes which tile indices should be passable vs solid
 function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesWithGroups, collisionResponse)
   local layerData = self.layers and self.layers[name]
   if not layerData or not layerData.tilemap then return end
+
+  -- Pull defaults from stored layer options or global options
+  local layerOptions = (layerData and layerData.layerOptions) or EMPTY_TABLE
+  local global = self._opts or EMPTY_TABLE
+
+  local resolvedEmptyIDs = emptyIDs or layerOptions.emptyIDs or {}
+  local resolvedWallGroup =
+    (wallGroup ~= nil and wallGroup)
+    or layerOptions.wallSpriteGroup
+    or global.wallSpriteGroup
+
+  local resolvedCollidesWithGroups =
+    (collidesWithGroups ~= nil and collidesWithGroups)
+    or layerOptions.wallCollidesWithGroups
+    or global.wallCollidesWithGroups
+
+  local resolvedResponse =
+    (collisionResponse ~= nil and collisionResponse)
+    or layerOptions.collisionResponse
+    or global.collisionResponse
+    or "overlap"
 
   -- Remove previous collision sprites
   if layerData.collisionSprites then
@@ -1138,55 +1215,34 @@ function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesW
   end
 
   -- Build new collision sprites from current tile indices
-  local collisionSprites = addWallSprites(layerData.tilemap, emptyIDs or {})
+  local collisionSprites = addWallSprites(layerData.tilemap, resolvedEmptyIDs)
 
   -- Configure sprites with collision properties
   for _, sprite in ipairs(collisionSprites) do
-    sprite:setTag(1)
+    -- Use const for tag, apply resolved defaults
+    sprite:setTag(WALL_TAG)
     sprite:setCollideRect(0, 0, sprite:getSize())
 
-    if wallGroup then
-      sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
+    if resolvedWallGroup then
+      sprite:setGroups(type(resolvedWallGroup) == "table" and resolvedWallGroup or { resolvedWallGroup })
     end
 
-    if collidesWithGroups and type(collidesWithGroups) == "table" and #collidesWithGroups > 0 then
-      sprite:setCollidesWithGroups(collidesWithGroups)
+    if resolvedCollidesWithGroups and type(resolvedCollidesWithGroups) == "table" and #resolvedCollidesWithGroups > 0 then
+      sprite:setCollidesWithGroups(resolvedCollidesWithGroups)
     end
 
-    sprite.collisionResponse = collisionResponse or "overlap"
+    sprite.collisionResponse = resolvedResponse
   end
 
   layerData.collisionSprites = collisionSprites
 end
 
 --------------------------------------------------------------------------------
--- Projection Methods (abstract -- implemented by subclasses)
---------------------------------------------------------------------------------
-
--- ! World to Screen (abstract method)
--- Converts world coordinates to screen coordinates for the given layer
-function RoxyTilemap:worldToScreen(worldX, worldY, layer)
-  Log.error("[RoxyTilemap:worldToScreen] Abstract method - must be implemented by projection subclass")
-end
-
--- ! Screen to World (abstract method)
--- Converts screen coordinates to world coordinates for the given layer
-function RoxyTilemap:screenToWorld(screenX, screenY, layer)
-  Log.error("[RoxyTilemap:screenToWorld] Abstract method - must be implemented by projection subclass")
-end
-
--- ! Set Tile At (abstract method)
--- Sets a tile at the given coordinates and optionally updates the display sprite
-function RoxyTilemap:setTileAt(name, tileX, tileY, tileIndex, updateSprite)
-  Log.error("[RoxyTilemap:setTileAt] Abstract method - must be implemented by projection subclass")
-end
-
---------------------------------------------------------------------------------
--- Origin helpers
+-- Layer Origin Management
 --------------------------------------------------------------------------------
 
 -- ! Set Layer Origin
--- Updates the origin for a single layer and keeps any display sprite in sync.
+-- Updates the origin for a single layer and keeps any display sprite in sync
 function RoxyTilemap:setLayerOrigin(name, originX, originY)
   local layerData = self.layers and self.layers[name]
   if not layerData then return false end
@@ -1206,7 +1262,7 @@ function RoxyTilemap:setLayerOrigin(name, originX, originY)
     -- If this layer was using a parallax update closure, rebuild it with the new origin
     if sprite.update and sprite.setUpdatesEnabled then
       -- Recreate the cached updater using the helper
-      sprite.update = createParallaxUpdate(
+      sprite.update = _createParallaxUpdate(
         layerData.originX, layerData.originY,
         parallaxX, parallaxY,
         parallaxOriginX, parallaxOriginY,
@@ -1235,7 +1291,7 @@ function RoxyTilemap:setOriginForAllLayers(originX, originY)
 end
 
 --------------------------------------------------------------------------------
--- Culling Utilities
+-- Culling & Visibility Utilities
 --------------------------------------------------------------------------------
 
 -- ! Get Screen Bounds In World Space
@@ -1295,7 +1351,44 @@ function RoxyTilemap:getVisibleTileBounds(layer, extraMargin)
 end
 
 --------------------------------------------------------------------------------
--- Drawing (abstract methods -- implemented by projection subclasses)
+-- Coordinate Projection (Abstract Methods)
+-- Methods that must be implemented by projection-specific subclasses
+--------------------------------------------------------------------------------
+
+-- ! Shared: Get Valid Layer
+-- Returns a layer if it exists and is drawable
+function RoxyTilemap:_getValidLayer(layerName)
+  if not layerName or not self.layers then return nil end
+
+  local layerData = self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then
+    return nil
+  end
+
+  return layerData
+end
+
+-- ! World to Screen
+-- Converts world coordinates to screen coordinates for the given layer
+function RoxyTilemap:worldToScreen(worldX, worldY, layer)
+  Log.error("[RoxyTilemap:worldToScreen] Abstract method - must be implemented by projection subclass")
+end
+
+-- ! Screen to World
+-- Converts screen coordinates to world coordinates for the given layer
+function RoxyTilemap:screenToWorld(screenX, screenY, layer)
+  Log.error("[RoxyTilemap:screenToWorld] Abstract method - must be implemented by projection subclass")
+end
+
+-- ! Set Tile At
+-- Sets a tile at the given coordinates and optionally updates the display sprite
+function RoxyTilemap:setTileAt(name, tileX, tileY, tileIndex, updateSprite)
+  Log.error("[RoxyTilemap:setTileAt] Abstract method - must be implemented by projection subclass")
+end
+
+--------------------------------------------------------------------------------
+-- Drawing (Abstract Methods)
+-- Must be implemented by projection-specific subclasses
 --------------------------------------------------------------------------------
 
 -- ! Draw
@@ -1372,14 +1465,14 @@ function RoxyTilemap:destroy()
   -- Clean up tilesets retained at initialization
   for _, tileset in pairs(self.tilesets or {}) do
     if tileset.imagePath then
-      release(tileset.imagePath)
+      _release(tileset.imagePath)
     end
   end
 
   -- Release any imagetable paths retained via swaps
   if self._retainedPaths then
     for path, _ in pairs(self._retainedPaths) do
-      release(path)
+      _release(path)
     end
     self._retainedPaths = nil
   end

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -175,7 +175,7 @@ local function _validateOptions(opts)
 
   -- Only create layerOptions table if it doesn't exist
   if not opts.layerOptions then
-    opts.layerOptions = EMPTY_TABLE
+    opts.layerOptions = {}
   end
 
   local layerOptions = opts.layerOptions
@@ -185,7 +185,7 @@ local function _validateOptions(opts)
     if layerConfig.emptyIDs ~= nil then
       if type(layerConfig.emptyIDs) ~= "table" then
         Log.warn("[_validateOptions] layerOptions['" .. layerName .. "'].emptyIDs must be a table") --#DEBUG
-        layerConfig.emptyIDs = EMPTY_TABLE
+        layerConfig.emptyIDs = {}
       else
         for index, identifier in ipairs(layerConfig.emptyIDs) do
           if type(identifier) ~= "number" then
@@ -198,14 +198,14 @@ local function _validateOptions(opts)
   end
 
   -- Set defaults directly on options
-  if opts.layers == nil then opts.layers = EMPTY_TABLE end
+  if opts.layers == nil then opts.layers = {} end
   if opts.wrapInSprites == nil then opts.wrapInSprites = true end
-  if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = EMPTY_TABLE end
+  if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = {} end
   if opts.cameraBounds == nil then opts.cameraBounds = false end
   if opts.anchor == nil or opts.anchor ~= "topLeft" then opts.anchor = "center" end
   if opts.collisionResponse == nil then opts.collisionResponse = "overlap" end
-  if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = EMPTY_TABLE end
-  if opts.objectLayers == nil then opts.objectLayers = EMPTY_TABLE end
+  if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = {} end
+  if opts.objectLayers == nil then opts.objectLayers = {} end
 
   -- Return the mutated options instead of a new table
   return opts
@@ -257,16 +257,10 @@ local function _createDefaultObjectSprite(object, layerOptions)
   end
 
   -- Try to load the image
-  local img = nil
-  local success, errorMsg = pcall(function()
-    img = _getImageCached(imagePath)
-  end)
-
-  --#DEBUG START
-  if not success or not img then
-    Log.warn("[_createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath))
+  local img = _getImageCached(imagePath)
+  if not img then
+    Log.warn("[_createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath)) --#DEBUG
   end
-  --#DEBUG END
 
   -- Retain image if successfully loaded
   if img then
@@ -404,7 +398,7 @@ end
 
 -- ! Helper: Create Parallax Update Function
 -- Creates an update function for parallax sprites (hoisted to avoid per-sprite function creation)
-local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter, anchor, mapPixelWidth, mapPixelHeight)
+local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter)
   return function(self)
     local cameraX, cameraY = cameraGetter()
 
@@ -451,9 +445,9 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   --#DEBUG END
 
   -- Load the map JSON
-  local mapData, error = loadJSON(jsonPath)
+  local mapData, err = loadJSON(jsonPath)
   if not mapData then
-    Log.error("[RoxyTilemap:init] " .. (error or "unknown error")) --#DEBUG
+    Log.error("[RoxyTilemap:init] " .. (err or "unknown error")) --#DEBUG
     self.layers, self.sprites, self.tilesets, self.objectLayers, self.objectSprites = {}, {}, nil, nil, {}
     self.worldWidth, self.worldHeight = 0, 0
     return
@@ -721,8 +715,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
               worldX, worldY,
               parallaxX, parallaxY,
               parallaxOriginX, parallaxOriginY,
-              roundFn, cameraGetter,
-              opts.anchor, mapPixelWidth, mapPixelHeight
+              roundFn, cameraGetter
             )
           else
             sprite:moveTo(originX, originY)
@@ -779,7 +772,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   local objectSprites = {}
   for _, layer in ipairs(mapData.layers or {}) do
     if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
-      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
+      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or EMPTY_TABLE
 
       -- Pass newSprites to _processObjectLayer for direct insertion
       local sprites = _processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
@@ -928,6 +921,10 @@ end
 function RoxyTilemap:removeObjectLayer(layerName)
   local sprites = self:getObjectSprites(layerName)
   for _, sprite in ipairs(sprites) do
+    if sprite._retainedImagePath then
+      _release(sprite._retainedImagePath)
+      sprite._retainedImagePath = nil
+    end
     if self.scene and self.scene.removeSprite then
       self.scene:removeSprite(sprite)
     else
@@ -1266,8 +1263,7 @@ function RoxyTilemap:setLayerOrigin(name, originX, originY)
         layerData.originX, layerData.originY,
         parallaxX, parallaxY,
         parallaxOriginX, parallaxOriginY,
-        round, getCameraPosition,
-        layerData.anchor, layerData.mapPixelWidth, layerData.mapPixelHeight
+        round, getCameraPosition
       )
       -- Ensure we do not double-apply draw offset
       sprite:setIgnoresDrawOffset(true)
@@ -1454,6 +1450,10 @@ function RoxyTilemap:destroy()
   -- Remove object sprites
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
+      if sprite._retainedImagePath then
+        _release(sprite._retainedImagePath)
+        sprite._retainedImagePath = nil
+      end
       if self.scene and self.scene.removeSprite then
         self.scene:removeSprite(sprite)
       else

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -1,0 +1,467 @@
+// core/tilemaps/roxy_tileRenderer.c
+
+#include "roxy_tileRenderer.h"
+#include "../../utilities/roxy_math.h"
+#include <string.h>
+#include <math.h>
+
+static PlaydateAPI* pd = NULL;
+
+void roxy_tileRenderer_setPlaydateAPI(PlaydateAPI* playdate)
+{
+    pd = playdate;
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+static void* pd_alloc(size_t sz)
+{
+    return pd->system->realloc(NULL, sz);
+}
+
+static void pd_free(void* p)
+{
+    pd->system->realloc(p, 0);
+}
+
+static inline int indexFromRowColumn(const RoxyTileRendererC* tileRenderer, int columnZeroBased, int rowZeroBased)
+{
+    // 0-based row/column
+    return rowZeroBased * tileRenderer->mapWidth + columnZeroBased;
+}
+
+static inline int16_t safeOffsetX(const RoxyTileRendererC* tileRenderer, int tileIndex)
+{
+    if (tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
+    return tileRenderer->offsetX[tileIndex];
+}
+
+static inline int16_t safeOffsetY(const RoxyTileRendererC* tileRenderer, int tileIndex)
+{
+    if (tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
+    return tileRenderer->offsetY[tileIndex];
+}
+
+// Only for staggered-y
+static inline int rowShiftX_for_row0(const RoxyTileRendererC* tileRenderer, int rowZeroBased)
+{
+    if (tileRenderer->isIsometric) return 0;
+
+    int rowIsOdd = (rowZeroBased & 1);
+    int shouldShift = tileRenderer->staggerIndexOdd ? rowIsOdd : !rowIsOdd;
+
+    if (!shouldShift) return 0;
+
+    return tileRenderer->staggerDirectionRight ? tileRenderer->halfTileWidth : -tileRenderer->halfTileWidth;
+}
+
+// -----------------------------------------------------------------------------
+// lifetime
+// -----------------------------------------------------------------------------
+
+// ! Free Renderer
+static void roxy_tileRenderer_free(RoxyTileRendererC* tileRenderer)
+{
+    if (!tileRenderer || !tileRenderer->alive) return;
+    tileRenderer->alive = 0;
+
+    if (tileRenderer->imageTableUserData) {
+        pd->lua->releaseObject(tileRenderer->imageTableUserData);
+        tileRenderer->imageTableUserData = NULL;
+    }
+
+    if (tileRenderer->offsetX) {
+        pd_free(tileRenderer->offsetX);
+        tileRenderer->offsetX = NULL;
+    }
+
+    if (tileRenderer->offsetY) {
+        pd_free(tileRenderer->offsetY);
+        tileRenderer->offsetY = NULL;
+    }
+
+    if (tileRenderer->tiles) {
+        pd_free(tileRenderer->tiles);
+        tileRenderer->tiles = NULL;
+    }
+}
+
+// ! New Tile Renderer
+static int roxy_tileRenderer_newobject(lua_State* L)
+{
+    if (!pd) return 0;
+
+    const int argumentCount = pd->lua->getArgCount();
+    if (argumentCount < 12) {
+        pd->system->logToConsole("RoxyTileRendererC.new: expected >= 12 args, got %d", argumentCount);
+        return 0;
+    }
+
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd_alloc(sizeof(RoxyTileRendererC));
+    if (!tileRenderer) return 0;
+    memset(tileRenderer, 0, sizeof(*tileRenderer));
+    tileRenderer->alive = 1;
+
+    tileRenderer->isIsometric           = pd->lua->getArgInt(1);
+    tileRenderer->staggerIndexOdd       = pd->lua->getArgInt(2);
+    tileRenderer->staggerDirectionRight = pd->lua->getArgInt(3);
+    tileRenderer->mapWidth              = pd->lua->getArgInt(4);
+    tileRenderer->mapHeight             = pd->lua->getArgInt(5);
+    tileRenderer->tileWidth             = pd->lua->getArgInt(6);
+    tileRenderer->tileHeight            = pd->lua->getArgInt(7);
+    tileRenderer->halfTileWidth         = pd->lua->getArgInt(8);
+    tileRenderer->halfTileHeight        = pd->lua->getArgInt(9);
+    tileRenderer->maxImageHeight        = pd->lua->getArgInt(10);
+
+    // Imagetable
+    LuaUDObject* userDataObject = NULL;
+    tileRenderer->imageTable = pd->lua->getArgObject(11, "playdate.graphics.imagetable", &userDataObject);
+    if (!tileRenderer->imageTable || !userDataObject) {
+        pd->system->logToConsole("RoxyTileRendererC.new: imagetable is nil/invalid");
+        pd_free(tileRenderer);
+        return 0;
+    }
+    tileRenderer->imageTableUserData = pd->lua->retainObject(userDataObject);
+    tileRenderer->imageCount = pd->lua->getArgInt(12);
+
+    // Precompute draw offsets
+    tileRenderer->offsetX = (int16_t*)pd_alloc(sizeof(int16_t) * (tileRenderer->imageCount + 1));
+    tileRenderer->offsetY = (int16_t*)pd_alloc(sizeof(int16_t) * (tileRenderer->imageCount + 1));
+    if (!tileRenderer->offsetX || !tileRenderer->offsetY) {
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
+    tileRenderer->offsetX[0] = tileRenderer->offsetY[0] = 0;
+
+    for (int i = 1; i <= tileRenderer->imageCount; ++i) {
+        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, i - 1);
+        if (!cell) { tileRenderer->offsetX[i] = 0; tileRenderer->offsetY[i] = 0; continue; }
+        int imageWidth = 0, imageHeight = 0;
+        pd->graphics->getBitmapData(cell, &imageWidth, &imageHeight, NULL, NULL, NULL);
+        const int16_t offsetX = (int16_t)((tileRenderer->tileWidth  - imageWidth) / 2);
+        const int16_t offsetY = (int16_t)((tileRenderer->tileHeight - imageHeight));
+        tileRenderer->offsetX[i] = offsetX;
+        tileRenderer->offsetY[i] = offsetY;
+    }
+
+    // Tiles blob (optional)
+    const int tilesCount = tileRenderer->mapWidth * tileRenderer->mapHeight;
+    tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
+    if (!tileRenderer->tiles) {
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
+    memset(tileRenderer->tiles, 0, sizeof(int32_t) * tilesCount);
+
+    if (argumentCount >= 13 && !pd->lua->argIsNil(13)) {
+        size_t bytesLength = 0;
+        const char* bytes = pd->lua->getArgBytes(13, &bytesLength);
+        tileRenderer->tilesCountBytes = (int)bytesLength;
+        if (bytes && bytesLength > 0) {
+            if ((int)bytesLength == tilesCount * 2) {
+                // 16-bit packed
+                for (int i = 0; i < tilesCount; ++i) {
+                    uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
+                    tileRenderer->tiles[i] = (int32_t)value;
+                }
+            } else if ((int)bytesLength == tilesCount * 4) {
+                // 32-bit little endian
+                for (int i = 0; i < tilesCount; ++i) {
+                    const uint8_t* pointer = (const uint8_t*)bytes + 4*i;
+                    tileRenderer->tiles[i] = (int32_t)(pointer[0] | (pointer[1]<<8) | (pointer[2]<<16) | (pointer[3]<<24));
+                }
+            } else {
+                pd->system->logToConsole("RoxyTileRendererC.new: tiles blob size %d doesn't match 2*%d or 4*%d",
+                                       (int)bytesLength, tilesCount, tilesCount);
+            }
+        }
+    }
+
+    pd->lua->pushObject(tileRenderer, "RoxyTileRendererC", 0);
+    return 1;
+}
+
+// ! Garbage Collection (__gc)
+static int roxy_tileRenderer_gc(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (tileRenderer) {
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+    }
+    return 0;
+}
+
+// ! Update Tiles Bytes
+// lua: self:updateTilesBytes(bytes)
+// bytes length must be mapWidth*mapHeight*(2 or 4)
+static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (!tileRenderer || !tileRenderer->alive) return 0;
+
+    size_t bytesLength = 0;
+    const char* bytes = pd->lua->getArgBytes(2, &bytesLength);
+    if (!bytes || bytesLength == 0) return 0;
+
+    const int tilesCount = tileRenderer->mapWidth * tileRenderer->mapHeight;
+    if ((int)bytesLength != tilesCount * 2 && (int)bytesLength != tilesCount * 4) {
+        pd->system->logToConsole("updateTilesBytes: bad size %d (expected %d or %d)",
+                                 (int)bytesLength, tilesCount*2, tilesCount*4);
+        return 0;
+    }
+
+    if (!tileRenderer->tiles) {
+        tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
+        if (!tileRenderer->tiles) return 0;
+    }
+
+    tileRenderer->tilesCountBytes = (int)bytesLength;
+    if ((int)bytesLength == tilesCount * 2) {
+        for (int i = 0; i < tilesCount; ++i) {
+            uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
+            tileRenderer->tiles[i] = (int32_t)value;
+        }
+    } else {
+        for (int i = 0; i < tilesCount; ++i) {
+            const uint8_t* pointer = (const uint8_t*)bytes + 4*i;
+            tileRenderer->tiles[i] = (int32_t)(pointer[0] | (pointer[1]<<8) | (pointer[2]<<16) | (pointer[3]<<24));
+        }
+    }
+    return 0;
+}
+
+// ! Set Tile At
+// lua: self:setTileAt(x, y, tileIndex) -- 1-based x/y like Lua
+static int roxy_tileRenderer_setTileAt(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+
+    int x = pd->lua->getArgInt(2);
+    int y = pd->lua->getArgInt(3);
+    int tileIndex = pd->lua->getArgInt(4);
+
+    x = roxy_math_clampi(x, 1, tileRenderer->mapWidth);
+    y = roxy_math_clampi(y, 1, tileRenderer->mapHeight);
+
+    tileRenderer->tiles[indexFromRowColumn(tileRenderer, x-1, y-1)] = tileIndex;
+
+    return 0;
+}
+
+// ! Draw Cell
+// core draw for a single tile (shared)
+static inline void drawCell(const RoxyTileRendererC* tr, int tileIndex, int sx, int sy)
+{
+    if (tileIndex <= 0 || tileIndex > tr->imageCount) return;
+    LCDBitmap* cell = pd->graphics->getTableBitmap(tr->imageTable, tileIndex - 1);
+    if (!cell) return;
+
+    const int dx = sx + safeOffsetX(tr, tileIndex);
+    const int dy = sy + safeOffsetY(tr, tileIndex);
+
+    pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
+}
+
+// ! Draw Rows
+// lua: self:drawRows(minRow, maxRow, minCol, maxCol,
+//                    originX, originY,
+//                    parallaxX, parallaxY,
+//                    parallaxOriginX, parallaxOriginY,
+//                    cameraX, cameraY)
+static int roxy_tileRenderer_drawRows(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+
+    int minRow = pd->lua->getArgInt(2);
+    int maxRow = pd->lua->getArgInt(3);
+    int minColumn = pd->lua->getArgInt(4);
+    int maxColumn = pd->lua->getArgInt(5);
+
+    int originX = pd->lua->getArgInt(6);
+    int originY = pd->lua->getArgInt(7);
+
+    float parallaxX = pd->lua->getArgFloat(8);
+    float parallaxY = pd->lua->getArgFloat(9);
+
+    int parallaxOriginX = pd->lua->getArgInt(10);
+    int parallaxOriginY = pd->lua->getArgInt(11);
+
+    int cameraX = pd->lua->getArgInt(12);
+    int cameraY = pd->lua->getArgInt(13);
+
+    minRow = roxy_math_clampi(minRow, 1, tileRenderer->mapHeight);
+    maxRow = roxy_math_clampi(maxRow, 1, tileRenderer->mapHeight);
+    minColumn = roxy_math_clampi(minColumn, 1, tileRenderer->mapWidth);
+    maxColumn = roxy_math_clampi(maxColumn, 1, tileRenderer->mapWidth);
+    if (minRow > maxRow || minColumn > maxColumn) return 0;
+
+    const float pivotAdjustX = parallaxOriginX * (1.f - parallaxX);
+    const float pivotAdjustY = parallaxOriginY * (1.f - parallaxY);
+
+    if (!tileRenderer->isIsometric) {
+        // staggered-y (rows step by halfTileHeight, X steps full tileWidth + row shift)
+        for (int tileY = minRow; tileY <= maxRow; ++tileY) {
+            const int rowZeroBased = tileY - 1;
+            const int rowShift = rowShiftX_for_row0(tileRenderer, rowZeroBased);
+
+            const int baseX = roxy_math_roundInt(originX + rowShift + pivotAdjustX - cameraX * parallaxX);
+            const int baseY = roxy_math_roundInt(originY + rowZeroBased * tileRenderer->halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+
+            int screenX = baseX + (minColumn - 1) * tileRenderer->tileWidth;
+            const int rowIndexBase = rowZeroBased * tileRenderer->mapWidth + (minColumn - 1);
+
+            for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
+                const int currentTileIndex = tileRenderer->tiles[tileIndex];
+                if (currentTileIndex > 0) drawCell(tileRenderer, currentTileIndex, screenX, baseY);
+                screenX += tileRenderer->tileWidth;
+            }
+        }
+    } else {
+        // Isometric
+        for (int tileY = minRow; tileY <= maxRow; ++tileY) {
+            const int rowZeroBased = tileY - 1;
+            const int rowIndexBase = rowZeroBased * tileRenderer->mapWidth + (minColumn - 1);
+            for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
+                const int columnZeroBased = tileX - 1;
+                const float worldX = (float)columnZeroBased;
+                const float worldY = (float)rowZeroBased;
+
+                const int isoX = roxy_math_roundInt(originX + (worldX - worldY) * tileRenderer->halfTileWidth + pivotAdjustX - cameraX * parallaxX);
+                const int isoY = roxy_math_roundInt(originY + (worldX + worldY) * tileRenderer->halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+
+                const int currentTileIndex = tileRenderer->tiles[tileIndex];
+                if (currentTileIndex > 0) drawCell(tileRenderer, currentTileIndex, isoX, isoY);
+            }
+        }
+    }
+    return 0;
+}
+
+// ! Render to Buffer
+// lua: self:renderToBuffer(targetBitmap, offsetX, offsetY, bufferWidth, bufferHeight)
+// Draws the layer in layer-local coords into target bitmap. If target is nil,
+// draws into the current context.
+static int roxy_tileRenderer_renderToBuffer(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+
+    LCDBitmap* targetBitmap = pd->lua->getBitmap(2);  // May be NULL
+    const int offsetX = pd->lua->getArgInt(3);
+    const int offsetY = pd->lua->getArgInt(4);
+    const int bufferWidth = pd->lua->getArgInt(5);
+    const int bufferHeight = pd->lua->getArgInt(6);
+
+    int contextPushed = 0;
+    if (targetBitmap) {
+        pd->graphics->pushContext(targetBitmap);
+        contextPushed = 1;
+    }
+
+    // Compute conservative row/column bounds
+    if (!tileRenderer->isIsometric) {
+        // staggered-y
+        const int overdrawRows = (int)ceilf(fmaxf(0.f, (float)(tileRenderer->maxImageHeight - tileRenderer->tileHeight)) /
+                                          fmaxf(1.f, (float)tileRenderer->halfTileHeight)) + 1;
+
+        int minRowZeroBased = (int)floorf((float)(-offsetY - tileRenderer->maxImageHeight) /
+                                        (float)tileRenderer->halfTileHeight) - 1 - overdrawRows;
+        int maxRowZeroBased = (int)ceilf ((float)(bufferHeight - offsetY) /
+                                        (float)tileRenderer->halfTileHeight) + 1 + overdrawRows;
+        minRowZeroBased = roxy_math_clampi(minRowZeroBased, 0, tileRenderer->mapHeight - 1);
+        maxRowZeroBased = roxy_math_clampi(maxRowZeroBased, 0, tileRenderer->mapHeight - 1);
+
+        for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
+            const int baseX = rowShiftX_for_row0(tileRenderer, rowZeroBased) + offsetX;
+            const int baseY = rowZeroBased * tileRenderer->halfTileHeight + offsetY;
+
+            int minColumnZeroBased = (int)floorf((float)(-tileRenderer->tileWidth - baseX) / (float)tileRenderer->tileWidth) - 1;
+            int maxColumnZeroBased = (int)floorf((float)(bufferWidth - 1 - baseX) / (float)tileRenderer->tileWidth) + 1;
+            minColumnZeroBased = roxy_math_clampi(minColumnZeroBased, 0, tileRenderer->mapWidth - 1);
+            maxColumnZeroBased = roxy_math_clampi(maxColumnZeroBased, 0, tileRenderer->mapWidth - 1);
+
+            int drawX = baseX + minColumnZeroBased * tileRenderer->tileWidth;
+            int tileIndex = rowZeroBased * tileRenderer->mapWidth + minColumnZeroBased;
+            for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased, ++tileIndex) {
+                const int currentTileIndex = tileRenderer->tiles[tileIndex];
+                if (currentTileIndex > 0) {
+                    const int dx = drawX + safeOffsetX(tileRenderer, currentTileIndex);
+                    const int dy = baseY + safeOffsetY(tileRenderer, currentTileIndex);
+                    if (dx < bufferWidth && dy < bufferHeight && dx > -tileRenderer->tileWidth && dy > -tileRenderer->tileHeight) {
+                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                        if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
+                    }
+                }
+                drawX += tileRenderer->tileWidth;
+            }
+        }
+    } else {
+        // Isometric
+        // Conservative world bounds — these are broad but safe for a stub
+        const int overdrawRows = (int)ceilf(fmaxf(0.f, (float)(tileRenderer->maxImageHeight - tileRenderer->tileHeight)) / fmaxf(1.f, (float)tileRenderer->halfTileHeight)) + 1;
+
+        const int minColumnZeroBased = roxy_math_clampi(-(bufferWidth / tileRenderer->halfTileWidth) - overdrawRows, 0, tileRenderer->mapWidth  - 1);
+        const int maxColumnZeroBased = roxy_math_clampi((bufferWidth / tileRenderer->halfTileWidth) + overdrawRows, 0, tileRenderer->mapWidth  - 1);
+        const int minRowZeroBased = roxy_math_clampi(-(bufferHeight / tileRenderer->halfTileHeight) - overdrawRows, 0, tileRenderer->mapHeight - 1);
+        const int maxRowZeroBased = roxy_math_clampi((bufferHeight / tileRenderer->halfTileHeight) + overdrawRows, 0, tileRenderer->mapHeight - 1);
+
+        for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
+            for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased) {
+                const int tileIndex = indexFromRowColumn(tileRenderer, columnZeroBased, rowZeroBased);
+                const int currentTileIndex = tileRenderer->tiles[tileIndex];
+                if (currentTileIndex <= 0) continue;
+
+                const float worldX = (float)columnZeroBased;
+                const float worldY = (float)rowZeroBased;
+                const int screenX = roxy_math_roundInt((worldX - worldY) * tileRenderer->halfTileWidth  + offsetX);
+                const int screenY = roxy_math_roundInt((worldX + worldY) * tileRenderer->halfTileHeight + offsetY);
+
+                const int drawX = screenX + safeOffsetX(tileRenderer, currentTileIndex);
+                const int drawY = screenY + safeOffsetY(tileRenderer, currentTileIndex);
+                if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileRenderer->tileWidth && drawY > -tileRenderer->tileHeight) {
+                    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                    if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
+                }
+            }
+        }
+    }
+
+    if (contextPushed) pd->graphics->popContext();
+    return 0;
+}
+
+// ! Destroy
+static int roxy_tileRenderer_destroy(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (tileRenderer) roxy_tileRenderer_free(tileRenderer);
+    return 0;
+}
+
+static const lua_reg roxyTileRendererLib[] = {
+    {    "new",                     roxy_tileRenderer_newobject               },
+    {    "__gc",                    roxy_tileRenderer_gc                      },
+    {    "updateTilesBytes",        roxy_tileRenderer_updateTilesBytes        },
+    {    "setTileAt",               roxy_tileRenderer_setTileAt               },
+    {    "drawRows",                roxy_tileRenderer_drawRows                },
+    {    "renderToBuffer",          roxy_tileRenderer_renderToBuffer          },
+    {    "destroy",                 roxy_tileRenderer_destroy                 },
+    {    NULL, NULL    }
+};
+
+void registerRoxyTileRendererC(PlaydateAPI* playdate)
+{
+    pd = playdate;
+
+    const char* err = NULL;
+    if (!pd->lua->registerClass("RoxyTileRendererC", roxyTileRendererLib, NULL, 0, &err)) {
+        pd->system->logToConsole("%s:%i: registerClass failed, %s", __FILE__, __LINE__, err);
+    }
+}

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -4,6 +4,9 @@
 #include "../../utilities/roxy_math.h"
 #include <string.h>
 #include <math.h>
+#include <limits.h>
+
+#define ROXY_MAGIC 0xA1B2C3D4
 
 static PlaydateAPI* pd = NULL;
 
@@ -18,12 +21,18 @@ void roxy_tileRenderer_setPlaydateAPI(PlaydateAPI* playdate)
 
 static void* pd_alloc(size_t sz)
 {
+    if (!pd || !pd->system) return NULL;
     return pd->system->realloc(NULL, sz);
 }
 
 static void pd_free(void* p)
 {
+    if (!pd || !pd->system) return;
     pd->system->realloc(p, 0);
+}
+
+static inline int roxy_valid(const RoxyTileRendererC* tileRenderer) {
+    return tileRenderer && tileRenderer->magic == ROXY_MAGIC && tileRenderer->alive;
 }
 
 static inline int indexFromRowColumn(const RoxyTileRendererC* tileRenderer, int columnZeroBased, int rowZeroBased)
@@ -34,13 +43,15 @@ static inline int indexFromRowColumn(const RoxyTileRendererC* tileRenderer, int 
 
 static inline int16_t safeOffsetX(const RoxyTileRendererC* tileRenderer, int tileIndex)
 {
-    if (tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
+    // Guard null offset array
+    if (!tileRenderer->offsetX || tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
     return tileRenderer->offsetX[tileIndex];
 }
 
 static inline int16_t safeOffsetY(const RoxyTileRendererC* tileRenderer, int tileIndex)
 {
-    if (tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
+    // Guard null offset array
+    if (!tileRenderer->offsetY || tileIndex < 1 || tileIndex > tileRenderer->imageCount) return 0;
     return tileRenderer->offsetY[tileIndex];
 }
 
@@ -58,7 +69,7 @@ static inline int rowShiftX_for_row0(const RoxyTileRendererC* tileRenderer, int 
 }
 
 // -----------------------------------------------------------------------------
-// lifetime
+// Lifetime
 // -----------------------------------------------------------------------------
 
 // ! Free Renderer
@@ -66,6 +77,10 @@ static void roxy_tileRenderer_free(RoxyTileRendererC* tileRenderer)
 {
     if (!tileRenderer || !tileRenderer->alive) return;
     tileRenderer->alive = 0;
+
+    if (tileRenderer->magic == ROXY_MAGIC) {
+        tileRenderer->magic = 0; // Poison the magic cookie
+    }
 
     if (tileRenderer->imageTableUserData) {
         pd->lua->releaseObject(tileRenderer->imageTableUserData);
@@ -91,7 +106,8 @@ static void roxy_tileRenderer_free(RoxyTileRendererC* tileRenderer)
 // ! New Tile Renderer
 static int roxy_tileRenderer_newobject(lua_State* L)
 {
-    if (!pd) return 0;
+    // Validate subsystem pointers up front
+    if (!pd || !pd->lua || !pd->graphics || !pd->system) return 0;
 
     const int argumentCount = pd->lua->getArgCount();
     if (argumentCount < 12) {
@@ -100,9 +116,10 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     }
 
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd_alloc(sizeof(RoxyTileRendererC));
-    if (!tileRenderer) return 0;
+    if (!tileRenderer) return 0; // Do not call roxy_valid before initialization
     memset(tileRenderer, 0, sizeof(*tileRenderer));
-    tileRenderer->alive = 1;
+    tileRenderer->magic = ROXY_MAGIC; // Initialize magic cookie
+    tileRenderer->alive = 1;          // Mark as alive
 
     tileRenderer->isIsometric           = pd->lua->getArgInt(1);
     tileRenderer->staggerIndexOdd       = pd->lua->getArgInt(2);
@@ -115,6 +132,15 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     tileRenderer->halfTileHeight        = pd->lua->getArgInt(9);
     tileRenderer->maxImageHeight        = pd->lua->getArgInt(10);
 
+    // Validate map size to avoid overflow on multiplication
+    const int mw = tileRenderer->mapWidth;
+    const int mh = tileRenderer->mapHeight;
+    if (mw <= 0 || mh <= 0 || mw > (INT_MAX / (mh > 0 ? mh : 1))) {
+        pd->system->logToConsole("RoxyTileRendererC.new: invalid map size %d x %d", mw, mh);
+        pd_free(tileRenderer);
+        return 0;
+    }
+
     // Imagetable
     LuaUDObject* userDataObject = NULL;
     tileRenderer->imageTable = pd->lua->getArgObject(11, "playdate.graphics.imagetable", &userDataObject);
@@ -125,6 +151,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     }
     tileRenderer->imageTableUserData = pd->lua->retainObject(userDataObject);
     tileRenderer->imageCount = pd->lua->getArgInt(12);
+    if (tileRenderer->imageCount < 0) tileRenderer->imageCount = 0; // Sanitize
 
     // Precompute draw offsets
     tileRenderer->offsetX = (int16_t*)pd_alloc(sizeof(int16_t) * (tileRenderer->imageCount + 1));
@@ -148,7 +175,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     }
 
     // Tiles blob (optional)
-    const int tilesCount = tileRenderer->mapWidth * tileRenderer->mapHeight;
+    const int tilesCount = mw * mh;
     tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
     if (!tileRenderer->tiles) {
         roxy_tileRenderer_free(tileRenderer);
@@ -160,23 +187,25 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     if (argumentCount >= 13 && !pd->lua->argIsNil(13)) {
         size_t bytesLength = 0;
         const char* bytes = pd->lua->getArgBytes(13, &bytesLength);
-        tileRenderer->tilesCountBytes = (int)bytesLength;
         if (bytes && bytesLength > 0) {
             if ((int)bytesLength == tilesCount * 2) {
-                // 16-bit packed
                 for (int i = 0; i < tilesCount; ++i) {
                     uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
-                    tileRenderer->tiles[i] = (int32_t)value;
+                    int v = (int)value;
+                    // Sanitize tile value to avoid out-of-range imagetable lookups
+                    if (v < 0 || v > tileRenderer->imageCount) v = 0;
+                    tileRenderer->tiles[i] = v;
                 }
+                tileRenderer->tilesCountBytes = (int)bytesLength;
             } else if ((int)bytesLength == tilesCount * 4) {
-                // 32-bit little endian
                 for (int i = 0; i < tilesCount; ++i) {
-                    const uint8_t* pointer = (const uint8_t*)bytes + 4*i;
-                    tileRenderer->tiles[i] = (int32_t)(pointer[0] | (pointer[1]<<8) | (pointer[2]<<16) | (pointer[3]<<24));
+                    const uint8_t* p = (const uint8_t*)bytes + 4*i;
+                    int v = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+                    // Sanitize tile value
+                    if (v < 0 || v > tileRenderer->imageCount) v = 0;
+                    tileRenderer->tiles[i] = v;
                 }
-            } else {
-                pd->system->logToConsole("RoxyTileRendererC.new: tiles blob size %d doesn't match 2*%d or 4*%d",
-                                       (int)bytesLength, tilesCount, tilesCount);
+                tileRenderer->tilesCountBytes = (int)bytesLength;
             }
         }
     }
@@ -189,6 +218,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
 static int roxy_tileRenderer_gc(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    // Correct condition; free only if non-null
     if (tileRenderer) {
         roxy_tileRenderer_free(tileRenderer);
         pd_free(tileRenderer);
@@ -202,7 +232,7 @@ static int roxy_tileRenderer_gc(lua_State* L)
 static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
-    if (!tileRenderer || !tileRenderer->alive) return 0;
+    if (!roxy_valid(tileRenderer)) return 0;
 
     size_t bytesLength = 0;
     const char* bytes = pd->lua->getArgBytes(2, &bytesLength);
@@ -220,17 +250,24 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
         if (!tileRenderer->tiles) return 0;
     }
 
-    tileRenderer->tilesCountBytes = (int)bytesLength;
     if ((int)bytesLength == tilesCount * 2) {
         for (int i = 0; i < tilesCount; ++i) {
             uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
-            tileRenderer->tiles[i] = (int32_t)value;
+            int v = (int)value;
+            // Sanitize tile value
+            if (v < 0 || v > tileRenderer->imageCount) v = 0;
+            tileRenderer->tiles[i] = v;
         }
+        tileRenderer->tilesCountBytes = (int)bytesLength; // unchanged
     } else {
         for (int i = 0; i < tilesCount; ++i) {
-            const uint8_t* pointer = (const uint8_t*)bytes + 4*i;
-            tileRenderer->tiles[i] = (int32_t)(pointer[0] | (pointer[1]<<8) | (pointer[2]<<16) | (pointer[3]<<24));
+            const uint8_t* p = (const uint8_t*)bytes + 4*i;
+            int v = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+            // Sanitize tile value
+            if (v < 0 || v > tileRenderer->imageCount) v = 0;
+            tileRenderer->tiles[i] = v;
         }
+        tileRenderer->tilesCountBytes = (int)bytesLength; // unchanged
     }
     return 0;
 }
@@ -240,7 +277,7 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
 static int roxy_tileRenderer_setTileAt(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
-    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+    if (!roxy_valid(tileRenderer) || !tileRenderer->tiles) return 0;
 
     int x = pd->lua->getArgInt(2);
     int y = pd->lua->getArgInt(3);
@@ -249,21 +286,27 @@ static int roxy_tileRenderer_setTileAt(lua_State* L)
     x = roxy_math_clampi(x, 1, tileRenderer->mapWidth);
     y = roxy_math_clampi(y, 1, tileRenderer->mapHeight);
 
-    tileRenderer->tiles[indexFromRowColumn(tileRenderer, x-1, y-1)] = tileIndex;
+    // Sanitize tileIndex to prevent OOB imagetable lookups
+    if (tileIndex < 0 || tileIndex > tileRenderer->imageCount) tileIndex = 0;
 
+    tileRenderer->tiles[indexFromRowColumn(tileRenderer, x-1, y-1)] = tileIndex;
     return 0;
 }
 
 // ! Draw Cell
 // core draw for a single tile (shared)
-static inline void drawCell(const RoxyTileRendererC* tr, int tileIndex, int sx, int sy)
+static inline void drawCell(const RoxyTileRendererC* tileRenderer, int tileIndex, int sx, int sy)
 {
-    if (tileIndex <= 0 || tileIndex > tr->imageCount) return;
-    LCDBitmap* cell = pd->graphics->getTableBitmap(tr->imageTable, tileIndex - 1);
+    // Guard tileRenderer
+    if (!tileRenderer || tileIndex <= 0 || tileIndex > tileRenderer->imageCount) return;
+    // Extra safety
+    if (!pd || !pd->graphics || !tileRenderer->imageTable) return;
+
+    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, tileIndex - 1);
     if (!cell) return;
 
-    const int dx = sx + safeOffsetX(tr, tileIndex);
-    const int dy = sy + safeOffsetY(tr, tileIndex);
+    const int dx = sx + safeOffsetX(tileRenderer, tileIndex);
+    const int dy = sy + safeOffsetY(tileRenderer, tileIndex);
 
     pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
 }
@@ -277,7 +320,8 @@ static inline void drawCell(const RoxyTileRendererC* tr, int tileIndex, int sx, 
 static int roxy_tileRenderer_drawRows(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
-    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+    if (!roxy_valid(tileRenderer) || !tileRenderer->tiles) return 0;
+    if (!pd || !pd->graphics) return 0;
 
     int minRow = pd->lua->getArgInt(2);
     int maxRow = pd->lua->getArgInt(3);
@@ -351,9 +395,10 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
 static int roxy_tileRenderer_renderToBuffer(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
-    if (!tileRenderer || !tileRenderer->alive || !tileRenderer->tiles) return 0;
+    if (!roxy_valid(tileRenderer) || !tileRenderer->tiles) return 0;
+    if (!pd || !pd->graphics) return 0;
 
-    LCDBitmap* targetBitmap = pd->lua->getBitmap(2);  // May be NULL
+    LCDBitmap* targetBitmap = pd->lua->getBitmap(2); // May be NULL
     const int offsetX = pd->lua->getArgInt(3);
     const int offsetY = pd->lua->getArgInt(4);
     const int bufferWidth = pd->lua->getArgInt(5);
@@ -386,17 +431,21 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
             int maxColumnZeroBased = (int)floorf((float)(bufferWidth - 1 - baseX) / (float)tileRenderer->tileWidth) + 1;
             minColumnZeroBased = roxy_math_clampi(minColumnZeroBased, 0, tileRenderer->mapWidth - 1);
             maxColumnZeroBased = roxy_math_clampi(maxColumnZeroBased, 0, tileRenderer->mapWidth - 1);
+            if (minColumnZeroBased > maxColumnZeroBased) continue; // Handle negative-length window
 
             int drawX = baseX + minColumnZeroBased * tileRenderer->tileWidth;
             int tileIndex = rowZeroBased * tileRenderer->mapWidth + minColumnZeroBased;
             for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased, ++tileIndex) {
                 const int currentTileIndex = tileRenderer->tiles[tileIndex];
                 if (currentTileIndex > 0) {
-                    const int dx = drawX + safeOffsetX(tileRenderer, currentTileIndex);
-                    const int dy = baseY + safeOffsetY(tileRenderer, currentTileIndex);
-                    if (dx < bufferWidth && dy < bufferHeight && dx > -tileRenderer->tileWidth && dy > -tileRenderer->tileHeight) {
-                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
-                        if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
+                    // Ensure index is within imagetable range before touching graphics
+                    if (currentTileIndex <= tileRenderer->imageCount) {
+                        const int dx = drawX + safeOffsetX(tileRenderer, currentTileIndex);
+                        const int dy = baseY + safeOffsetY(tileRenderer, currentTileIndex);
+                        if (dx < bufferWidth && dy < bufferHeight && dx > -tileRenderer->tileWidth && dy > -tileRenderer->tileHeight) {
+                            LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                            if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
+                        }
                     }
                 }
                 drawX += tileRenderer->tileWidth;
@@ -409,25 +458,25 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
 
         const int minColumnZeroBased = roxy_math_clampi(-(bufferWidth / tileRenderer->halfTileWidth) - overdrawRows, 0, tileRenderer->mapWidth  - 1);
         const int maxColumnZeroBased = roxy_math_clampi((bufferWidth / tileRenderer->halfTileWidth) + overdrawRows, 0, tileRenderer->mapWidth  - 1);
-        const int minRowZeroBased = roxy_math_clampi(-(bufferHeight / tileRenderer->halfTileHeight) - overdrawRows, 0, tileRenderer->mapHeight - 1);
-        const int maxRowZeroBased = roxy_math_clampi((bufferHeight / tileRenderer->halfTileHeight) + overdrawRows, 0, tileRenderer->mapHeight - 1);
+        const int minRowZeroBased    = roxy_math_clampi(-(bufferHeight / tileRenderer->halfTileHeight) - overdrawRows, 0, tileRenderer->mapHeight - 1);
+        const int maxRowZeroBased    = roxy_math_clampi((bufferHeight / tileRenderer->halfTileHeight) + overdrawRows, 0, tileRenderer->mapHeight - 1);
 
         for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
             for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased) {
                 const int tileIndex = indexFromRowColumn(tileRenderer, columnZeroBased, rowZeroBased);
                 const int currentTileIndex = tileRenderer->tiles[tileIndex];
-                if (currentTileIndex <= 0) continue;
+                if (currentTileIndex > 0 && currentTileIndex <= tileRenderer->imageCount) {
+                    const float worldX = (float)columnZeroBased;
+                    const float worldY = (float)rowZeroBased;
+                    const int screenX = roxy_math_roundInt((worldX - worldY) * tileRenderer->halfTileWidth  + offsetX);
+                    const int screenY = roxy_math_roundInt((worldX + worldY) * tileRenderer->halfTileHeight + offsetY);
 
-                const float worldX = (float)columnZeroBased;
-                const float worldY = (float)rowZeroBased;
-                const int screenX = roxy_math_roundInt((worldX - worldY) * tileRenderer->halfTileWidth  + offsetX);
-                const int screenY = roxy_math_roundInt((worldX + worldY) * tileRenderer->halfTileHeight + offsetY);
-
-                const int drawX = screenX + safeOffsetX(tileRenderer, currentTileIndex);
-                const int drawY = screenY + safeOffsetY(tileRenderer, currentTileIndex);
-                if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileRenderer->tileWidth && drawY > -tileRenderer->tileHeight) {
-                    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
-                    if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
+                    const int drawX = screenX + safeOffsetX(tileRenderer, currentTileIndex);
+                    const int drawY = screenY + safeOffsetY(tileRenderer, currentTileIndex);
+                    if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileRenderer->tileWidth && drawY > -tileRenderer->tileHeight) {
+                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                        if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
+                    }
                 }
             }
         }
@@ -441,6 +490,7 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
 static int roxy_tileRenderer_destroy(lua_State* L)
 {
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    // Allow idempotent destroy; free only if non-null
     if (tileRenderer) roxy_tileRenderer_free(tileRenderer);
     return 0;
 }

--- a/core/tilemaps/roxy_tileRenderer.h
+++ b/core/tilemaps/roxy_tileRenderer.h
@@ -1,0 +1,38 @@
+#ifndef ROXY_TILERENDERER_H
+#define ROXY_TILERENDERER_H
+
+#include "pd_api.h"
+#include <stdint.h>
+
+typedef struct {
+    // Projection / stagger configuration
+    int isIsometric;            // 1 = isometric, 0 = staggered-y
+    int staggerIndexOdd;        // staggered-y: 1 if "odd", 0 if "even"
+    int staggerDirectionRight;  // staggered-y: 1 if "right", 0 if "left"
+
+    // Map / layer geometry
+    int mapWidth, mapHeight;            // Tiles
+    int tileWidth, tileHeight;          // Pixels
+    int halfTileWidth, halfTileHeight;  // Pixels
+    int maxImageHeight;                 // Pixels (for tall art overdraw)
+
+    // Assets
+    LCDBitmapTable* imageTable;
+    LuaUDObject*    imageTableUserData; // Retained UD to keep it alive
+    int             imageCount;
+
+    // Precomputed per-index offsets (1-based)
+    int16_t* offsetX; // [imageCount + 1]
+    int16_t* offsetY; // [imageCount + 1]
+
+    // Tiles: copied into C memory for speed (row-major, 0-based)
+    int32_t* tiles;           // Length = mapWidth*mapHeight
+    int      tilesCountBytes; // Original byte size, for sanity/debug
+
+    // Lifetime guard
+    int alive;
+} RoxyTileRendererC;
+
+void registerRoxyTileRendererC(PlaydateAPI* playdate);
+
+#endif /* ROXY_TILERENDERER_H */

--- a/core/tilemaps/roxy_tileRenderer.h
+++ b/core/tilemaps/roxy_tileRenderer.h
@@ -30,8 +30,12 @@ typedef struct {
     int      tilesCountBytes; // Original byte size, for sanity/debug
 
     // Lifetime guard
-    int alive;
+    uint32_t magic; // Magic cookie used to validate the instance
+    int alive;      // Alive flag to prevent use after destroy
 } RoxyTileRendererC;
+
+// Expose the API setter so users of the header can call it
+void roxy_tileRenderer_setPlaydateAPI(PlaydateAPI* playdate);
 
 void registerRoxyTileRendererC(PlaydateAPI* playdate);
 

--- a/core/transitions/Cut.lua
+++ b/core/transitions/Cut.lua
@@ -11,7 +11,7 @@ local Transition  <const> = r.Transition
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
 
--- Expose stack-op constants so children don’t need to re-require them
+-- Expose stack-op constants so children don't need to re-require them
 local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
 local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
 local STACK_OP_POP     <const> = Transition.STACK_OP_POP

--- a/roxy.c
+++ b/roxy.c
@@ -7,6 +7,7 @@
 #include "core/sequences/roxy_sequence.h"
 #include "core/animations/roxy_animation.h"
 #include "core/sprites/roxy_particles.h"
+#include "core/tilemaps/roxy_tileRenderer.h"
 
 static PlaydateAPI* pd = NULL;
 static uint32_t previousTime = 0;
@@ -217,6 +218,9 @@ int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg)
 
     // ! Register RoxyParticlesC Class
     registerRoxyParticlesC(pd);
+
+    // ! Register RoxyTileRendererC Class
+    registerRoxyTileRendererC(pd);
 
     return 0;
 }

--- a/roxy.lua
+++ b/roxy.lua
@@ -254,13 +254,14 @@ function pd.update()
   handleInput()
   updateSequences(dt)
 
-  -- Cache list once and length once.
+  -- Active scenes
   local updateList = getUpdateList()
   local updateCount = #updateList
   for i = 1, updateCount do
     updateList[i]:update(dt)
   end
 
+  -- Background scenes
   local bgList = getBackgroundList()
   local bgCount = #bgList
   for i = 1, bgCount do
@@ -278,6 +279,7 @@ function pd.update()
 
   spriteUpdate()
 
+  -- Scene draw methods (run after sprites)
   local list = getDrawList()
   local drawCount = #list
   for i = 1, drawCount do

--- a/utilities/TableBuilder.lua
+++ b/utilities/TableBuilder.lua
@@ -12,7 +12,7 @@ class("TableBuilder").extends(Object)
 -- Constructor: start with one base layer (or empty table)
 -- @param base table?
 function TableBuilder:init(base)
-  -- Layers is an array of tables we’ll merge in order
+  -- Layers is an array of tables we'll merge in order
   self.layers = { base or {} }
 end
 


### PR DESCRIPTION
### Overview
This release brings major performance improvements to tilemap rendering with chunk-based prerendering for staggered, isometric, and orthogonal maps. The tilemap system has been modernized to use cached data structures and native renderers where available, significantly reducing per-frame draw cost. Alongside these improvements, internal helpers and APIs have been standardized, new redraw controls introduced, and stricter validation added to prevent rendering errors. Several changes are breaking and require migration for projects relying on internal fields or direct tile edits.

### Key Changes
- **Core**
  - Clarified scene update vs. draw phases with improved comments
- **Tilemap Performance**
  - Cached tiles, offsets, strides, and max image heights to reduce redundant computations
  - Introduced chunk-based prerendering for staggered-Y, isometric, and orthogonal tilemaps
  - Added dirty tile eviction, ordered rendering, and dynamic fallback paths for non-chunked layers
  - Tuned staggered-Y performance defaults (larger cache, tighter culling margins, preload caches)
  - Unified `RoxyTilemap` base: shared helpers, visibility APIs, cached asset refs
- **Isometric & Staggered**
  - `RoxyIsoTilemap` gains parity with staggered: chunking, cached draws, ordered layers, and `drawVisibleInRect`
  - `RoxyIsoTilemap` now uses native `RoxyTileRendererC` for chunk rendering
  - `RoxyStagTilemap` integrates with native renderer for faster rendering and memory safety
  - Added `forceRedraw(frames)` APIs for both staggered and isometric tilemaps to improve transition and alwaysRedraw behavior
- **Orthogonal**
  - Added optional chunk prerendering, ordered layer rendering, and dirty-chunk eviction
- **Cache**
  - Added `Cache.putAsset` for explicit insertion/replacement
  - Reduced cache miss log noise
- **Refactors**
  - Prefixed internal helpers with `_` to clarify non-public API
  - Simplified option validation, image loading, and parallax sprite lifecycle
  - Standardized layer internals: `maxImageHeight`, `_imageCache`, `_offsetCache`
- **Fixes**
  - Hardened native renderer with guards for memory, bounds, and null subsystems
  - Improved redraw predictability with forced repaint flags in `drawVisible` and `drawVisibleInRect`
  - Improved compatibility with `playdate.graphics.sprite.setAlwaysRedraw(true)`
  - Style: standardized straight quotes in comments

### Breaking Changes ⚠️
- **Tilemaps**
  - **Chunked prerendering behavior**: Layers now rely on prebuilt draw lists for `zIndex` and `visible`. Call `resortLayers()` after changing order/visibility, and `markTilesDirty()` after manual edits.
  - **Iso/Stag native renderers**: `setTileAt` enforces bounds and updates both Lua and native buffers. Direct edits to `tilesFlat` are no longer supported.
  - **World size calculations**: Projection-aware math changes reported `worldWidth`/`worldHeight`, which may affect camera bounds or culling logic.
  - **Layer internals renamed**:
    - `maxImgH` → `maxImageHeight`
    - `_imgCache` → `_imageCache`
    - `_offCache` → `_offsetCache`
- **Parallax Properties**
  - Object layer properties must now use exact keys: `parallaxX`, `parallaxY`, `parallaxOriginX`, `parallaxOriginY`
- **Internal Helpers**
  - Functions like `retain`, `release`, `normalizeImagePath` now prefixed with `_`. External use discouraged.

### Challenges/Notes
- Native renderer integration required synchronization between Lua-side tilemaps and C memory, with stricter validation to prevent crashes.
- Migration requires updating any code that accessed renamed internals, relied on silent tile edits, or used deprecated property keys.