### PR TITLE
[0.14.2] - AssetStore, Tilemap Refactor, and Camera Simplification

### DIFF
--- a/core/modules/AssetStore.lua
+++ b/core/modules/AssetStore.lua
@@ -1,0 +1,96 @@
+-- core/modules/AssetStore.lua
+
+roxy = roxy or {}
+roxy.AssetStore = roxy.AssetStore or {}
+local AssetStore <const> = roxy.AssetStore
+
+local pd        <const> = playdate
+local Graphics  <const> = pd.graphics
+
+local newImage      <const> = Graphics.image.new
+local newImagetable <const> = Graphics.imagetable.new
+
+local r     <const> = roxy
+local Cache <const> = r.Cache
+
+local getCachedAsset    <const> = Cache.getCachedAsset
+local cacheAsset        <const> = Cache.cacheAsset
+local evictAsset        <const> = Cache.evictAsset
+local getIsAssetCached  <const> = Cache.getIsAssetCached
+
+-- Shared reference counts for the entire runtime
+local referenceCount = {}
+
+-- ! Retain Asset
+function AssetStore.retain(path, assetOrThunk)
+  referenceCount[path] = (referenceCount[path] or 0) + 1
+
+  if not getIsAssetCached(path) then
+    if type(assetOrThunk) == "function" then
+      -- Store the thunk so the asset is created on first use
+      cacheAsset(path, assetOrThunk)
+    else
+      -- Store a thunk that returns the concrete asset value
+      local value = assetOrThunk
+      cacheAsset(path, function() return value end)
+    end
+  end
+end
+
+-- ! Release Asset
+function AssetStore.release(path)
+  local count = referenceCount[path]
+  if not count then return end
+  if count <= 1 then
+    evictAsset(path)
+    referenceCount[path] = nil
+  else
+    referenceCount[path] = count - 1
+  end
+end
+
+-- Get Imagetable
+function AssetStore.getImagetable(path)
+  if type(path) ~= "string" or path == "" then
+    Log.warn("[AssetStore.getImagetable] Invalid or missing path: " .. tostring(path)) --#DEBUG
+    return nil
+  end
+
+  local cached = getCachedAsset(path)
+  if cached then
+    -- Realize thunk if needed
+    return (type(cached) == "function") and cached() or cached
+  end
+
+  local loaded = newImagetable(path)
+  if loaded then
+    cacheAsset(path, function() return loaded end)
+  else
+    Log.warn("[AssetStore.getImagetable] Failed to load imagetable: " .. path) --#DEBUG
+  end
+
+  return loaded
+end
+
+-- Get Image (cached)
+function AssetStore.getImageCached(path)
+  if type(path) ~= "string" or path == "" then
+    Log.warn("[AssetStore.getImageCached] Invalid or missing path: " .. tostring(path)) --#DEBUG
+    return nil
+  end
+
+  local cached = getCachedAsset(path)
+  if cached then
+    -- Realize thunk if needed.
+    return (type(cached) == "function") and cached() or cached
+  end
+
+  local loaded = newImage(path)
+  if loaded then
+    cacheAsset(path, function() return loaded end)
+  else
+    Log.warn("[AssetStore.getImageCached] Failed to load image: " .. path) --#DEBUG
+  end
+
+  return loaded
+end

--- a/core/modules/Cache.lua
+++ b/core/modules/Cache.lua
@@ -339,3 +339,6 @@ function Cache.clearCache(bucket)
   bucket.currentSize = 0
   return true
 end
+
+-- Load the Asset Store helper
+import "libraries/roxy/core/modules/AssetStore"

--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -21,6 +21,9 @@ local pi    <const> = math.pi
 local lerp  <const> = roxy.Math.lerp
 local round <const> = roxy.Math.roundInt
 
+local tableRemove <const> = table.remove
+local tableInsert <const> = table.insert
+
 local setDrawOffset <const> = Graphics.setDrawOffset
 
 local redrawBackground <const> = Sprite.redrawBackground
@@ -40,8 +43,22 @@ Camera._velocityX       = 0     -- velocity in x direction
 Camera._velocityY       = 0     -- velocity in y direction
 Camera._lastX           = 0     -- last x position for dirty rect
 Camera._lastY           = 0     -- last y position for dirty rect
+Camera._screenLeft      = 0     -- cached screen left boundary
+Camera._screenTop       = 0     -- cached screen top boundary
+Camera._screenRight     = DISPLAY_WIDTH   -- cached screen right boundary
+Camera._screenBottom    = DISPLAY_HEIGHT  -- cached screen bottom boundary
 Camera._targetX         = 0     -- target x position
 Camera._targetY         = 0     -- target y position
+
+-- Conversion cache for worldToScreen/screenToWorld performance
+-- Added: Small offset-scoped caches with simple FIFO eviction.
+Camera._conversionCache = {
+  -- Each cache keeps entries (map), keys (insertion order), count, and last seen offset.
+  w2s = { lastOffsetX = nil, lastOffsetY = nil, entries = {}, keys = {}, count = 0 }, -- world-to-screen cache
+  s2w = { lastOffsetX = nil, lastOffsetY = nil, entries = {}, keys = {}, count = 0 }  -- screen-to-world cache
+}
+local CONVERSION_CACHE_SIZE <const> = 8  -- Small cache to avoid memory overhead
+
 Camera.target           = nil   -- sprite to follow
 Camera._bounds          = nil   -- { x1, y1, x2, y2 }
 Camera._boundsCache     = nil
@@ -54,9 +71,12 @@ Camera.smoothing        = 0     -- smoothing rate in 1/seconds (0 = instant)
 Camera._shakeAmplitude  = 0     -- Shake intensity (pixels)
 Camera.shakeDuration    = 0     -- Remaining shake time (seconds)
 Camera._shakeFrequency  = 0     -- Shake oscillations per second
+Camera._shakeAngularFreq = 0    -- Cached angular frequency (frequency * 2π)
 Camera._shakeTimer      = 0     -- Tracks elapsed shake time
 Camera._deadZoneWidth   = 0     -- Dead zone width (pixels, 0 = disabled)
 Camera._deadZoneHeight  = 0     -- Dead zone height (pixels, 0 = disabled)
+Camera._deadZoneHalfW   = 0     -- Cached half width for performance
+Camera._deadZoneHalfH   = 0     -- Cached half height for performance
 Camera.friction         = FRICTION_DEFAULT
 
 -- Indicates whether the camera needs an update this frame.
@@ -82,7 +102,7 @@ local function _applyShake(dt)
     Camera._shakeTimer = 0
     return 0, 0
   end
-  local t = Camera._shakeTimer * Camera._shakeFrequency * 2 * pi
+  local t = Camera._shakeTimer * Camera._shakeAngularFreq
   local amplitude = Camera._shakeAmplitude * (1 - Camera._shakeTimer / Camera.shakeDuration) -- Linear decay
   return round(amplitude * sin(t)), round(amplitude * cos(t))
 end
@@ -98,6 +118,17 @@ local function _commitOffset(dt)
     setDrawOffset(-totalOffsetX, -totalOffsetY)
     redrawBackground()
     Camera._lastX, Camera._lastY = totalOffsetX, totalOffsetY
+    -- Update cached screen bounds for isOnScreen performance
+    Camera._screenLeft = totalOffsetX
+    Camera._screenTop = totalOffsetY
+    Camera._screenRight = totalOffsetX + DISPLAY_WIDTH
+    Camera._screenBottom = totalOffsetY + DISPLAY_HEIGHT
+    -- Invalidate conversion caches when offset changes
+    -- Updated: Just bump last offsets; converters will reinit their caches lazily on next call.
+    Camera._conversionCache.w2s.lastOffsetX = nil
+    Camera._conversionCache.w2s.lastOffsetY = nil
+    Camera._conversionCache.s2w.lastOffsetX = nil
+    Camera._conversionCache.s2w.lastOffsetY = nil
     Camera._isActive = true
   else
     Camera._isActive = Camera.shakeDuration > 0 or Camera._velocityX ~= 0 or Camera._velocityY ~= 0 or Camera.target ~= nil
@@ -155,7 +186,7 @@ end
 -- Follows a sprite (or nil to stop).
 -- Optional smoothing rate controls interpolation speed:
 --   0 = Snap instantly to target each frame
---  >0 = Rate in “per second” at which camera moves toward target.
+--  >0 = Rate in "per second" at which camera moves toward target.
 --       Actual lerp factor per frame is t = min(rate * dt, 1).
 function Camera.setTarget(sprite, smoothing)
   --#DEBUG START
@@ -203,6 +234,8 @@ function Camera.shake(amplitude, duration, frequency)
   Camera._shakeAmplitude = max(amplitude, 0)
   Camera.shakeDuration = max(duration, 0)
   Camera._shakeFrequency = max(frequency, 0)
+  -- Pre-compute angular frequency to avoid multiplication each frame
+  Camera._shakeAngularFreq = Camera._shakeFrequency * 2 * pi
   Camera._shakeTimer = 0
   Camera._isActive = true -- Ensure updates run during shake
 end
@@ -219,6 +252,9 @@ function Camera.setDeadZone(width, height)
   --#DEBUG END
   Camera._deadZoneWidth = max(width, 0)
   Camera._deadZoneHeight = max(height, 0)
+  -- Cache half sizes to avoid division in update loop
+  Camera._deadZoneHalfW = Camera._deadZoneWidth / 2
+  Camera._deadZoneHalfH = Camera._deadZoneHeight / 2
 end
 
 -- ! Set Friction
@@ -281,6 +317,10 @@ function Camera.reset()
   Camera._velocityY       = 0
   Camera._lastX           = 0
   Camera._lastY           = 0
+  Camera._screenLeft      = 0
+  Camera._screenTop       = 0
+  Camera._screenRight     = DISPLAY_WIDTH
+  Camera._screenBottom    = DISPLAY_HEIGHT
   Camera._targetX         = 0
   Camera._targetY         = 0
   Camera.target           = nil
@@ -295,11 +335,27 @@ function Camera.reset()
   Camera._shakeAmplitude  = 0
   Camera.shakeDuration    = 0
   Camera._shakeFrequency  = 0
+  Camera._shakeAngularFreq = 0
   Camera._shakeTimer      = 0
   Camera._deadZoneWidth   = 0
   Camera._deadZoneHeight  = 0
+  Camera._deadZoneHalfW   = 0
+  Camera._deadZoneHalfH   = 0
   Camera.friction         = FRICTION_DEFAULT
   Camera._updateFunc      = Camera.updateStatic
+
+  -- Clear conversion caches
+  -- Updated: Clear entries, keys, counts to fully reset caches.
+  Camera._conversionCache.w2s.lastOffsetX = nil
+  Camera._conversionCache.w2s.lastOffsetY = nil
+  Camera._conversionCache.w2s.entries = {}
+  Camera._conversionCache.w2s.keys = {}
+  Camera._conversionCache.w2s.count = 0
+  Camera._conversionCache.s2w.lastOffsetX = nil
+  Camera._conversionCache.s2w.lastOffsetY = nil
+  Camera._conversionCache.s2w.entries = {}
+  Camera._conversionCache.s2w.keys = {}
+  Camera._conversionCache.s2w.count = 0
 
   -- Immediate screen‑space reset
   setDrawOffset(0, 0)
@@ -343,15 +399,13 @@ function Camera.updateFollow(dt)
   if Camera._deadZoneWidth > 0 and Camera._deadZoneHeight > 0 then
     local dx = desiredX - Camera._targetX
     local dy = desiredY - Camera._targetY
-    local halfW = Camera._deadZoneWidth / 2
-    local halfH = Camera._deadZoneHeight / 2
-    if abs(dx) > halfW then
-      desiredX = desiredX - (dx - (dx > 0 and halfW or -halfW))
+    if abs(dx) > Camera._deadZoneHalfW then
+      desiredX = desiredX - (dx - (dx > 0 and Camera._deadZoneHalfW or -Camera._deadZoneHalfW))
     else
       -- desiredX = Camera._targetX
     end
-    if abs(dy) > halfH then
-      desiredY = desiredY - (dy - (dy > 0 and halfH or -halfH))
+    if abs(dy) > Camera._deadZoneHalfH then
+      desiredY = desiredY - (dy - (dy > 0 and Camera._deadZoneHalfH or -Camera._deadZoneHalfH))
     else
       -- desiredY = Camera._targetY
     end
@@ -371,10 +425,6 @@ function Camera.updateFollow(dt)
     local t = min(Camera.smoothing * dt, 1)
     Camera.x = lerp(Camera.x, Camera._targetX, t)
     Camera.y = lerp(Camera.y, Camera._targetY, t)
-
-    -- Snap to nearest pixel
-    Camera.x = round(Camera.x)
-    Camera.y = round(Camera.y)
   else
     Camera.x, Camera.y = Camera._targetX, Camera._targetY
   end
@@ -383,10 +433,6 @@ function Camera.updateFollow(dt)
   if Camera._hasBounds then
     Camera.x = clamp(Camera.x, Camera._minX, Camera._maxX)
     Camera.y = clamp(Camera.y, Camera._minY, Camera._maxY)
-
-    -- Snap to nearest pixel
-    Camera.x = round(Camera.x)
-    Camera.y = round(Camera.y)
   end
 
   if Camera.smoothing > 0
@@ -395,13 +441,11 @@ function Camera.updateFollow(dt)
     and abs(Camera._velocityX or 0) < 0.01
     and abs(Camera._velocityY or 0) < 0.01
   then
-    Camera.x = round(Camera.x)
-    Camera.y = round(Camera.y)
     Camera._targetX = Camera.x
     Camera._targetY = Camera.y
   end
 
-  -- Apply shake and update draw offset
+  -- Apply shake and update draw offset (handles rounding)
   _commitOffset(dt)
 end
 
@@ -434,10 +478,6 @@ function Camera.updateManualPan(dt)
     local t = min(Camera.smoothing * dt, 1)
     Camera.x = lerp(Camera.x, Camera._targetX, t)
     Camera.y = lerp(Camera.y, Camera._targetY, t)
-
-    -- Snap to nearest pixel
-    Camera.x = round(Camera.x)
-    Camera.y = round(Camera.y)
   else
     Camera.x, Camera.y = Camera._targetX, Camera._targetY
   end
@@ -446,13 +486,9 @@ function Camera.updateManualPan(dt)
   if Camera._hasBounds then
     Camera.x = clamp(Camera.x, Camera._minX, Camera._maxX)
     Camera.y = clamp(Camera.y, Camera._minY, Camera._maxY)
-
-    -- Snap to nearest pixel
-    Camera.x = round(Camera.x)
-    Camera.y = round(Camera.y)
   end
 
-  -- Apply shake and update draw offset
+  -- Apply shake and update draw offset (handles rounding)
   _commitOffset(dt)
 end
 
@@ -530,8 +566,46 @@ function Camera.worldToScreen(worldX, worldY)
     Log.warn("worldToScreen received nil coordinate(s)") --#DEBUG
   end
 
-  local screenX = worldX ~= nil and (worldX - Camera._lastX) or 0
-  local screenY = worldY ~= nil and (worldY - Camera._lastY) or 0
+  -- Handle nil coordinates
+  if worldX == nil then worldX = 0 end
+  if worldY == nil then worldY = 0 end
+
+  local cache = Camera._conversionCache.w2s
+  local offsetX, offsetY = Camera._lastX, Camera._lastY
+
+  -- Check if cache is valid for current offset
+  if cache.lastOffsetX ~= offsetX or cache.lastOffsetY ~= offsetY then
+    -- Camera moved, invalidate cache
+    cache.entries = {}
+    cache.keys = {}
+    cache.count = 0
+    cache.lastOffsetX = offsetX
+    cache.lastOffsetY = offsetY
+  end
+
+  -- Create cache key (combine coordinates into single string)
+  local key = worldX .. "," .. worldY
+  local cached = cache.entries[key]
+  if cached then
+    return cached[1], cached[2]
+  end
+
+  -- Compute conversion
+  local screenX = worldX - offsetX
+  local screenY = worldY - offsetY
+
+  -- Store in cache with simple FIFO eviction
+  if cache.count >= CONVERSION_CACHE_SIZE then
+    local oldKey = tableRemove(cache.keys, 1)
+    if oldKey ~= nil then
+      cache.entries[oldKey] = nil
+      cache.count -= 1 -- Uses Playdate SDK augmented assignment
+    end
+  end
+  tableInsert(cache.keys, key)
+  cache.entries[key] = { screenX, screenY }
+  cache.count += 1 -- Uses Playdate SDK augmented assignment
+
   return screenX, screenY
 end
 
@@ -542,18 +616,56 @@ function Camera.screenToWorld(screenX, screenY)
     Log.warn("screenToWorld received nil coordinate(s)") --#DEBUG
   end
 
-  local worldX = screenX ~= nil and (screenX + Camera._lastX) or 0
-  local worldY = screenY ~= nil and (screenY + Camera._lastY) or 0
+  -- Handle nil coordinates
+  if screenX == nil then screenX = 0 end
+  if screenY == nil then screenY = 0 end
+
+  local cache = Camera._conversionCache.s2w
+  local offsetX, offsetY = Camera._lastX, Camera._lastY
+
+  -- Check if cache is valid for current offset
+  if cache.lastOffsetX ~= offsetX or cache.lastOffsetY ~= offsetY then
+    -- Camera moved, invalidate cache
+    cache.entries = {}
+    cache.keys = {}
+    cache.count = 0
+    cache.lastOffsetX = offsetX
+    cache.lastOffsetY = offsetY
+  end
+
+  -- Create cache key (combine coordinates into single string)
+  local key = screenX .. "," .. screenY
+  local cached = cache.entries[key]
+  if cached then
+    return cached[1], cached[2]
+  end
+
+  -- Compute conversion
+  local worldX = screenX + offsetX
+  local worldY = screenY + offsetY
+
+  -- Store in cache with simple FIFO eviction
+  if cache.count >= CONVERSION_CACHE_SIZE then
+    local oldKey = tableRemove(cache.keys, 1)
+    if oldKey ~= nil then
+      cache.entries[oldKey] = nil
+      cache.count -= 1 -- Uses Playdate SDK augmented assignment
+    end
+  end
+  tableInsert(cache.keys, key)
+  cache.entries[key] = { worldX, worldY }
+  cache.count += 1 -- Uses Playdate SDK augmented assignment
+
   return worldX, worldY
 end
 
 -- ! Is On Screen
 -- Returns true if the point (x, y) is within the current screen bounds
 function Camera.isOnScreen(x, y)
-  return x >= Camera._lastX
-     and x <  Camera._lastX + DISPLAY_WIDTH
-     and y >= Camera._lastY
-     and y <  Camera._lastY + DISPLAY_HEIGHT
+  return x >= Camera._screenLeft
+     and x <  Camera._screenRight
+     and y >= Camera._screenTop
+     and y <  Camera._screenBottom
 end
 
 -- Default to static mode

--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -5,7 +5,6 @@ roxy.Camera = roxy.Camera or {}
 local Camera <const> = roxy.Camera
 
 local pd        <const> = playdate
-local Display   <const> = pd.display
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
@@ -28,116 +27,109 @@ local setDrawOffset <const> = Graphics.setDrawOffset
 
 local redrawBackground <const> = Sprite.redrawBackground
 
-local CAMERA_SPEED_DEFAULT <const> = 120  -- Default pan velocity (pixels per second)
-local FRICTION_DEFAULT <const>     = 0.85 -- Default friction factor (0 to 1, higher = slower stop)
+--
+-- Constants
+--
+
+local CAMERA_SPEED_DEFAULT  <const> = 120   -- Default pan velocity (pixels per second)
+local FRICTION_DEFAULT      <const> = 0.85  -- Default friction factor (0 to 1, higher = slower stop)
 
 local DISPLAY_WIDTH   <const> = roxy.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = roxy.Graphics.displayHeight
 local CENTER_X        <const> = roxy.Graphics.displayWidthCenter
 local CENTER_Y        <const> = roxy.Graphics.displayHeightCenter
 
--- Global State
-Camera.x                = 0     -- current x position
-Camera.y                = 0     -- current y position
-Camera._velocityX       = 0     -- velocity in x direction
-Camera._velocityY       = 0     -- velocity in y direction
-Camera._lastX           = 0     -- last x position for dirty rect
-Camera._lastY           = 0     -- last y position for dirty rect
-Camera._screenLeft      = 0     -- cached screen left boundary
-Camera._screenTop       = 0     -- cached screen top boundary
-Camera._screenRight     = DISPLAY_WIDTH   -- cached screen right boundary
-Camera._screenBottom    = DISPLAY_HEIGHT  -- cached screen bottom boundary
-Camera._targetX         = 0     -- target x position
-Camera._targetY         = 0     -- target y position
+--
+-- Public Variables (externally visible state)
+--
 
--- Conversion cache for worldToScreen/screenToWorld performance
--- Added: Small offset-scoped caches with simple FIFO eviction.
-Camera._conversionCache = {
-  -- Each cache keeps entries (map), keys (insertion order), count, and last seen offset.
-  w2s = { lastOffsetX = nil, lastOffsetY = nil, entries = {}, keys = {}, count = 0 }, -- world-to-screen cache
-  s2w = { lastOffsetX = nil, lastOffsetY = nil, entries = {}, keys = {}, count = 0 }  -- screen-to-world cache
-}
-local CONVERSION_CACHE_SIZE <const> = 8  -- Small cache to avoid memory overhead
+Camera.x              = 0   -- Current x position
+Camera.y              = 0   -- Current y position
+Camera.target         = nil -- Sprite to follow
+Camera.smoothing      = 0   -- Smoothing rate in 1/seconds (0 = instant)
+Camera.shakeDuration  = 0   -- Remaining shake time (seconds)
+Camera.friction       = FRICTION_DEFAULT
 
-Camera.target           = nil   -- sprite to follow
-Camera._bounds          = nil   -- { x1, y1, x2, y2 }
-Camera._boundsCache     = nil
-Camera._hasBounds       = false -- whether bounds are active
-Camera._minX            = 0     -- minimum x bound
-Camera._minY            = 0     -- minimum y bound
-Camera._maxX            = 0     -- maximum x bound
-Camera._maxY            = 0     -- maximum y bound
-Camera.smoothing        = 0     -- smoothing rate in 1/seconds (0 = instant)
-Camera._shakeAmplitude  = 0     -- Shake intensity (pixels)
-Camera.shakeDuration    = 0     -- Remaining shake time (seconds)
-Camera._shakeFrequency  = 0     -- Shake oscillations per second
-Camera._shakeAngularFreq = 0    -- Cached angular frequency (frequency * 2π)
-Camera._shakeTimer      = 0     -- Tracks elapsed shake time
-Camera._deadZoneWidth   = 0     -- Dead zone width (pixels, 0 = disabled)
-Camera._deadZoneHeight  = 0     -- Dead zone height (pixels, 0 = disabled)
-Camera._deadZoneHalfW   = 0     -- Cached half width for performance
-Camera._deadZoneHalfH   = 0     -- Cached half height for performance
-Camera.friction         = FRICTION_DEFAULT
+--
+-- Private Variables (internal module state; underscore-reserved)
+--
 
--- Indicates whether the camera needs an update this frame.
--- Remains true while there's an active target, any velocity, or an ongoing shake.
-Camera._isActive = true -- Ensure initial update
+Camera._velocityX         = 0     -- Velocity in x direction
+Camera._velocityY         = 0     -- Velocity in y direction
+Camera._lastX             = 0     -- Last x position for dirty rect
+Camera._lastY             = 0     -- Last y position for dirty rect
+Camera._screenLeft        = 0     -- Cached screen left boundary
+Camera._screenTop         = 0     -- Cached screen top boundary
+Camera._screenRight       = DISPLAY_WIDTH   -- Cached screen right boundary
+Camera._screenBottom      = DISPLAY_HEIGHT  -- Cached screen bottom boundary
+Camera._targetX           = 0     -- Target x position
+Camera._targetY           = 0     -- Target y position
+Camera._bounds            = nil   -- { x1, y1, x2, y2 }
+Camera._hasBounds         = false -- Whether bounds are active
+Camera._minX              = 0     -- Minimum x bound
+Camera._minY              = 0     -- Minimum y bound
+Camera._maxX              = 0     -- Maximum x bound
+Camera._maxY              = 0     -- Maximum y bound
+Camera._shakeAmplitude    = 0     -- Shake intensity (pixels)
+Camera._shakeFrequency    = 0     -- Shake oscillations per second
+Camera._shakeAngularFreq  = 0     -- Cached angular frequency (frequency * 2π)
+Camera._shakeTimer        = 0     -- Tracks elapsed shake time
+Camera._deadZoneWidth     = 0     -- Dead zone width (pixels, 0 = disabled)
+Camera._deadZoneHeight    = 0     -- Dead zone height (pixels, 0 = disabled)
+Camera._deadZoneHalfW     = 0     -- Cached half width for performance
+Camera._deadZoneHalfH     = 0     -- Cached half height for performance
+Camera._isActive          = true  -- Ensure initial update
+Camera._updateFunc        = nil   -- Default to static mode (set after functions defined)
 
--- Default to static mode (must be set after all Camera functions exist!)
-Camera._updateFunc = nil
-
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Helpers
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
--- ! Helper: Shake helper
--- _applyShake(dt) only uses dt to advance the internal shake timer.
--- All offset calculations are based on the timer; dt is not used elsewhere here.
+-- ! Apply Shake
+-- Advances the internal shake timer and returns rounded shake offsets (x, y)
+-- Note: dt only advances time; the offset calculation uses the accumulated timer
 local function _applyShake(dt)
   if Camera.shakeDuration <= 0 then return 0, 0 end
-  Camera._shakeTimer = Camera._shakeTimer + dt
+  Camera._shakeTimer += dt
   if Camera._shakeTimer >= Camera.shakeDuration then
     Camera.shakeDuration = 0
     Camera._shakeAmplitude = 0
     Camera._shakeTimer = 0
     return 0, 0
   end
-  local t = Camera._shakeTimer * Camera._shakeAngularFreq
-  local amplitude = Camera._shakeAmplitude * (1 - Camera._shakeTimer / Camera.shakeDuration) -- Linear decay
-  return round(amplitude * sin(t)), round(amplitude * cos(t))
+  local timer = Camera._shakeTimer * Camera._shakeAngularFreq
+  local amplitude = Camera._shakeAmplitude * (1 - Camera._shakeTimer / Camera.shakeDuration)
+  return round(amplitude * sin(timer)), round(amplitude * cos(timer))
 end
 
--- ! Helper: Commit Offset
+-- ! Commit Offset
+-- Rounds the camera position, applies shake, commits draw offset, updates screen bounds
+-- invalidates conversion caches when the offset changes, and maintains _isActive
 local function _commitOffset(dt)
   local newX = round(Camera.x)
   local newY = round(Camera.y)
   local shakeX, shakeY = (Camera.shakeDuration > 0) and _applyShake(dt) or 0, 0
   local totalOffsetX = newX + shakeX
   local totalOffsetY = newY + shakeY
-  if abs(totalOffsetX - Camera._lastX) >= 1 or abs(totalOffsetY - Camera._lastY) >= 1 then
+  local lastX, lastY = Camera._lastX, Camera._lastY
+  if abs(totalOffsetX - lastX) >= 1 or abs(totalOffsetY - lastY) >= 1 then
     setDrawOffset(-totalOffsetX, -totalOffsetY)
     redrawBackground()
-    Camera._lastX, Camera._lastY = totalOffsetX, totalOffsetY
-    -- Update cached screen bounds for isOnScreen performance
+    Camera._lastX = totalOffsetX
+    Camera._lastY = totalOffsetY
     Camera._screenLeft = totalOffsetX
     Camera._screenTop = totalOffsetY
     Camera._screenRight = totalOffsetX + DISPLAY_WIDTH
     Camera._screenBottom = totalOffsetY + DISPLAY_HEIGHT
-    -- Invalidate conversion caches when offset changes
-    -- Updated: Just bump last offsets; converters will reinit their caches lazily on next call.
-    Camera._conversionCache.w2s.lastOffsetX = nil
-    Camera._conversionCache.w2s.lastOffsetY = nil
-    Camera._conversionCache.s2w.lastOffsetX = nil
-    Camera._conversionCache.s2w.lastOffsetY = nil
     Camera._isActive = true
   else
     Camera._isActive = Camera.shakeDuration > 0 or Camera._velocityX ~= 0 or Camera._velocityY ~= 0 or Camera.target ~= nil
   end
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Public API
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Set Position
 -- Sets the camera position to (x, y) instantly
@@ -147,21 +139,24 @@ function Camera.setPosition(x, y)
     Log.error("[Camera.setPosition] Invalid position: expected numbers (x, y)", 2)
   end
   --#DEBUG END
-  Camera.x, Camera.y = x, y
-  Camera._targetX, Camera._targetY = x, y
-  Camera._velocityX, Camera._velocityY = 0, 0
+
+  Camera.x = x
+  Camera.y = y
+  Camera._targetX = x
+  Camera._targetY = y
+  Camera._velocityX = 0
+  Camera._velocityY = 0
   Camera._updateFunc = Camera.updateStatic
-  Camera._isActive = true -- Ensure update runs at least once
+  Camera._isActive = true
 end
 
 -- ! Set Pan Velocity
 -- Sets pan velocity (pixels/second). If vx is nil, uses CAMERA_SPEED_DEFAULT (120).
--- If vy is nil, uses vx. Set vx=0, vy=0 to stop panning.
+-- If vy is nil, uses vx. Set vx=0, vy=0 to stop panning
 function Camera.setPanVelocity(vx, vy)
   --#DEBUG START
   if vx ~= nil and type(vx) ~= "number" then
     Log.error("[Camera.setPanVelocity] Invalid vx: expected a number or nil", 2)
-    return
   end
   --#DEBUG END
 
@@ -172,46 +167,39 @@ function Camera.setPanVelocity(vx, vy)
   --#DEBUG START
   if type(vy) ~= "number" then
     Log.error("[Camera.setPanVelocity] Invalid vy: expected a number or nil", 2)
-    return
   end
   --#DEBUG END
 
   Camera._velocityX = vx
   Camera._velocityY = vy
   Camera._updateFunc = Camera.updateManualPan
-  Camera._isActive = true -- Ensure updates run
+  Camera._isActive = true
 end
 
 -- ! Set Target
--- Follows a sprite (or nil to stop).
+-- Follows a sprite (or nil to stop)
 -- Optional smoothing rate controls interpolation speed:
 --   0 = Snap instantly to target each frame
---  >0 = Rate in "per second" at which camera moves toward target.
---       Actual lerp factor per frame is t = min(rate * dt, 1).
+--  >0 = Rate in "per second" at which camera moves toward target (t = min(rate * dt, 1))
 function Camera.setTarget(sprite, smoothing)
   --#DEBUG START
   if sprite and not sprite.getPosition then
     Log.error("[Camera.setTarget] Invalid sprite: expected a sprite with getPosition method", 2)
   end
   --#DEBUG END
+
   Camera.target = sprite
   if smoothing ~= nil then
     Camera.smoothing = max(smoothing, 0)
   end
-  if sprite then
-    Camera._updateFunc = Camera.updateFollow
-  else
-    Camera._updateFunc = Camera.updateStatic -- Default to static when no target
-  end
+
+  -- Default to static when no target
+  Camera._updateFunc = sprite and Camera.updateFollow or Camera.updateStatic
   Camera._isActive = true
 end
 
 -- ! Set Smoothing
--- Sets the global smoothing rate for interpolation:
---   0 = Camera jumps immediately to its desired position
---  >0 = Interpolation rate (1/seconds).
---       Higher values → faster convergence
---       (e.g. rate = 2 means ~50% of gap closed each 1/2s).
+-- Sets the global smoothing rate for interpolation (1/seconds)
 function Camera.setSmoothing(rate)
   --#DEBUG START
   if type(rate) ~= "number" then
@@ -222,48 +210,43 @@ function Camera.setSmoothing(rate)
 end
 
 -- ! Shake
--- Triggers a camera shake effect with amplitude (pixels), duration (seconds), and frequency (oscillations per second).
--- Works in all modes (follow, pan, static).
+-- Triggers a camera shake with amplitude (pixels), duration (seconds), and frequency (oscillations per second)
 function Camera.shake(amplitude, duration, frequency)
   --#DEBUG START
   if type(amplitude) ~= "number" or type(duration) ~= "number" or type(frequency) ~= "number" then
     Log.error("[Camera.shake] Invalid shake parameters: expected numbers (amplitude, duration, frequency)", 2)
-    return
   end
   --#DEBUG END
+
   Camera._shakeAmplitude = max(amplitude, 0)
   Camera.shakeDuration = max(duration, 0)
   Camera._shakeFrequency = max(frequency, 0)
-  -- Pre-compute angular frequency to avoid multiplication each frame
   Camera._shakeAngularFreq = Camera._shakeFrequency * 2 * pi
   Camera._shakeTimer = 0
-  Camera._isActive = true -- Ensure updates run during shake
+  Camera._isActive = true
 end
 
 -- ! Set Dead Zone
--- Sets a dead zone rectangle (width, height in pixels). Camera only moves when sprite exits this zone.
--- Use width=0, height=0 to disable.
+-- Sets a dead zone rectangle (width, height in pixels). Use 0,0 to disable.
 function Camera.setDeadZone(width, height)
   --#DEBUG START
   if type(width) ~= "number" or type(height) ~= "number" then
     Log.error("[Camera.setDeadZone] Invalid dead zone: expected numbers (width, height)", 2)
-    return
   end
   --#DEBUG END
+
   Camera._deadZoneWidth = max(width, 0)
   Camera._deadZoneHeight = max(height, 0)
-  -- Cache half sizes to avoid division in update loop
   Camera._deadZoneHalfW = Camera._deadZoneWidth / 2
   Camera._deadZoneHalfH = Camera._deadZoneHeight / 2
 end
 
 -- ! Set Friction
--- Sets the default friction factor (0–1) applied when no pan input is active.
+-- Sets the default friction factor (0–1) applied when no pan input is active
 function Camera.setFriction(friction)
   --#DEBUG START
   if type(friction) ~= "number" then
     Log.error("[Camera.setFriction] Invalid friction: expected a number", 2)
-    return
   end
   --#DEBUG END
   Camera.friction = clamp(friction, 0, 1)
@@ -272,16 +255,14 @@ end
 -- ! Set Bounds
 -- Clamps the camera to a rectangle {x1, y1, x2, y2}
 function Camera.setBounds(bounds)
-  --#DEBUG START
   if not bounds or type(bounds.x1) ~= "number" or type(bounds.y1) ~= "number" or type(bounds.x2) ~= "number" or type(bounds.y2) ~= "number" then
-    Log.error("[Camera.setBounds] Invalid bounds: expected {x1, y1, x2, y2} with numbers", 2)
+    Log.error("[Camera.setBounds] Invalid bounds: expected {x1, y1, x2, y2} with numbers", 2) --#DEBUG
     Camera._bounds = nil
     Camera._hasBounds = false
     Camera._minX, Camera._minY = 0, 0
     Camera._maxX, Camera._maxY = 0, 0
     return
   end
-  --#DEBUG END
 
   Camera._bounds = bounds
   Camera._hasBounds = true
@@ -289,13 +270,6 @@ function Camera.setBounds(bounds)
   Camera._maxX = max(bounds.x1, bounds.x2)
   Camera._minY = min(bounds.y1, bounds.y2)
   Camera._maxY = max(bounds.y1, bounds.y2)
-
-  -- Cache bounds table for getBounds efficiency
-  Camera._boundsCache = Camera._boundsCache or { x1 = 0, y1 = 0, x2 = 0, y2 = 0 }
-  Camera._boundsCache.x1 = Camera._minX
-  Camera._boundsCache.y1 = Camera._minY
-  Camera._boundsCache.x2 = Camera._maxX
-  Camera._boundsCache.y2 = Camera._maxY
 end
 
 -- ! Clear Bounds
@@ -303,59 +277,46 @@ end
 function Camera.clearBounds()
   Camera._bounds = nil
   Camera._hasBounds = false
-  Camera._minX, Camera._minY = 0, 0
-  Camera._maxX, Camera._maxY = 0, 0
-  Camera._boundsCache = nil
+  Camera._minX = 0
+  Camera._minY = 0
+  Camera._maxX = 0
+  Camera._maxY = 0
 end
 
 -- ! Reset
 -- Resets the camera to its default state
 function Camera.reset()
-  Camera.x                = 0
-  Camera.y                = 0
-  Camera._velocityX       = 0
-  Camera._velocityY       = 0
-  Camera._lastX           = 0
-  Camera._lastY           = 0
-  Camera._screenLeft      = 0
-  Camera._screenTop       = 0
-  Camera._screenRight     = DISPLAY_WIDTH
-  Camera._screenBottom    = DISPLAY_HEIGHT
-  Camera._targetX         = 0
-  Camera._targetY         = 0
-  Camera.target           = nil
-  Camera._bounds          = nil
-  Camera._boundsCache     = nil
-  Camera._hasBounds       = false
-  Camera._minX            = 0
-  Camera._minY            = 0
-  Camera._maxX            = 0
-  Camera._maxY            = 0
-  Camera.smoothing        = 0
-  Camera._shakeAmplitude  = 0
-  Camera.shakeDuration    = 0
-  Camera._shakeFrequency  = 0
-  Camera._shakeAngularFreq = 0
-  Camera._shakeTimer      = 0
-  Camera._deadZoneWidth   = 0
-  Camera._deadZoneHeight  = 0
-  Camera._deadZoneHalfW   = 0
-  Camera._deadZoneHalfH   = 0
-  Camera.friction         = FRICTION_DEFAULT
-  Camera._updateFunc      = Camera.updateStatic
-
-  -- Clear conversion caches
-  -- Updated: Clear entries, keys, counts to fully reset caches.
-  Camera._conversionCache.w2s.lastOffsetX = nil
-  Camera._conversionCache.w2s.lastOffsetY = nil
-  Camera._conversionCache.w2s.entries = {}
-  Camera._conversionCache.w2s.keys = {}
-  Camera._conversionCache.w2s.count = 0
-  Camera._conversionCache.s2w.lastOffsetX = nil
-  Camera._conversionCache.s2w.lastOffsetY = nil
-  Camera._conversionCache.s2w.entries = {}
-  Camera._conversionCache.s2w.keys = {}
-  Camera._conversionCache.s2w.count = 0
+  Camera.x                  = 0
+  Camera.y                  = 0
+  Camera._velocityX         = 0
+  Camera._velocityY         = 0
+  Camera._lastX             = 0
+  Camera._lastY             = 0
+  Camera._screenLeft        = 0
+  Camera._screenTop         = 0
+  Camera._screenRight       = DISPLAY_WIDTH
+  Camera._screenBottom      = DISPLAY_HEIGHT
+  Camera._targetX           = 0
+  Camera._targetY           = 0
+  Camera.target             = nil
+  Camera._bounds            = nil
+  Camera._hasBounds         = false
+  Camera._minX              = 0
+  Camera._minY              = 0
+  Camera._maxX              = 0
+  Camera._maxY              = 0
+  Camera.smoothing          = 0
+  Camera._shakeAmplitude    = 0
+  Camera.shakeDuration      = 0
+  Camera._shakeFrequency    = 0
+  Camera._shakeAngularFreq  = 0
+  Camera._shakeTimer        = 0
+  Camera._deadZoneWidth     = 0
+  Camera._deadZoneHeight    = 0
+  Camera._deadZoneHalfW     = 0
+  Camera._deadZoneHalfH     = 0
+  Camera.friction           = FRICTION_DEFAULT
+  Camera._updateFunc        = Camera.updateStatic
 
   -- Immediate screen‑space reset
   setDrawOffset(0, 0)
@@ -367,15 +328,18 @@ end
 -- ! Update
 -- Dispatches to updateFollow, updateManualPan, or updateStatic based on camera mode
 function Camera.update(dt)
-  -- Only update if active, or if shake in progress
-  if Camera._isActive or Camera.shakeDuration > 0 then
+  Camera._isActive = Camera._isActive or Camera.shakeDuration > 0 or Camera._velocityX ~= 0 or Camera._velocityY ~= 0 or Camera.target ~= nil
+  if Camera._isActive then
     Camera._updateFunc(dt)
   end
 end
 
+--------------------------------------------------------------------------------
+-- Update Modes
+--------------------------------------------------------------------------------
+
 -- ! Update Follow
--- Update camera position following a target sprite
--- Clamps target position before interpolation to ensure smooth boundary stops, and final position for safety.
+-- Follows a target sprite; applies dead zone and optional smoothing; clamps to bounds
 function Camera.updateFollow(dt)
   --#DEBUG START
   if not Camera.target or not Camera.target.getPosition then
@@ -400,18 +364,18 @@ function Camera.updateFollow(dt)
     local dx = desiredX - Camera._targetX
     local dy = desiredY - Camera._targetY
     if abs(dx) > Camera._deadZoneHalfW then
-      desiredX = desiredX - (dx - (dx > 0 and Camera._deadZoneHalfW or -Camera._deadZoneHalfW))
+      desiredX = Camera._targetX + (dx > 0 and Camera._deadZoneHalfW or -Camera._deadZoneHalfW)
     else
-      -- desiredX = Camera._targetX
+      desiredX = Camera._targetX
     end
     if abs(dy) > Camera._deadZoneHalfH then
-      desiredY = desiredY - (dy - (dy > 0 and Camera._deadZoneHalfH or -Camera._deadZoneHalfH))
+      desiredY = Camera._targetY + (dy > 0 and Camera._deadZoneHalfH or -Camera._deadZoneHalfH)
     else
-      -- desiredY = Camera._targetY
+      desiredY = Camera._targetY
     end
   end
-
-  Camera._targetX, Camera._targetY = desiredX, desiredY
+  Camera._targetX = desiredX
+  Camera._targetY = desiredY
 
   -- Clamp target position only if smoothing
   local hasSmoothing = Camera.smoothing > 0
@@ -426,7 +390,8 @@ function Camera.updateFollow(dt)
     Camera.x = lerp(Camera.x, Camera._targetX, t)
     Camera.y = lerp(Camera.y, Camera._targetY, t)
   else
-    Camera.x, Camera.y = Camera._targetX, Camera._targetY
+    Camera.x = Camera._targetX
+    Camera.y = Camera._targetY
   end
 
   -- Clamp final position
@@ -438,32 +403,28 @@ function Camera.updateFollow(dt)
   if Camera.smoothing > 0
     and abs(Camera.x - Camera._targetX) < 0.05
     and abs(Camera.y - Camera._targetY) < 0.05
-    and abs(Camera._velocityX or 0) < 0.01
-    and abs(Camera._velocityY or 0) < 0.01
   then
     Camera._targetX = Camera.x
     Camera._targetY = Camera.y
   end
 
-  -- Apply shake and update draw offset (handles rounding)
   _commitOffset(dt)
 end
 
 -- ! Update Manual Pan
--- Update camera position using pan velocity and friction
--- Clamps target position before interpolation (if smoothing enabled) to avoid boundary tug, and final position for safety.
+-- Integrates pan velocity with optional smoothing; applies friction when idle; clamps to bounds
 function Camera.updateManualPan(dt)
   -- Apply velocity for panning
-  Camera._targetX = Camera._targetX + Camera._velocityX * dt
-  Camera._targetY = Camera._targetY + Camera._velocityY * dt
+  Camera._targetX += Camera._velocityX * dt
+  Camera._targetY += Camera._velocityY * dt
 
-  -- Apply friction when no new input is given
-  if Camera._velocityX == 0 and Camera._velocityY == 0 then
-    Camera._targetX = lerp(Camera._targetX, Camera.x, 1 - Camera.friction)
-    Camera._targetY = lerp(Camera._targetY, Camera.y, 1 - Camera.friction)
-    -- (Uncomment below for snap if necessary)
-    -- if abs(Camera._targetX - Camera.x) < 0.1 then Camera._targetX = Camera.x end
-    -- if abs(Camera._targetY - Camera.y) < 0.1 then Camera._targetY = Camera.y end
+  -- Apply friction to velocity if no new input
+  local hasInput = Camera._velocityX ~= 0 or Camera._velocityY ~= 0
+  if not hasInput then
+    Camera._velocityX *= Camera.friction
+    Camera._velocityY *= Camera.friction
+    if abs(Camera._velocityX) < 0.01 then Camera._velocityX = 0 end
+    if abs(Camera._velocityY) < 0.01 then Camera._velocityY = 0 end
   end
 
   -- Clamp target position only if smoothing
@@ -479,7 +440,8 @@ function Camera.updateManualPan(dt)
     Camera.x = lerp(Camera.x, Camera._targetX, t)
     Camera.y = lerp(Camera.y, Camera._targetY, t)
   else
-    Camera.x, Camera.y = Camera._targetX, Camera._targetY
+    Camera.x = Camera._targetX
+    Camera.y = Camera._targetY
   end
 
   -- Clamp final position
@@ -488,49 +450,41 @@ function Camera.updateManualPan(dt)
     Camera.y = clamp(Camera.y, Camera._minY, Camera._maxY)
   end
 
-  -- Apply shake and update draw offset (handles rounding)
   _commitOffset(dt)
 end
 
 -- ! Update Static
--- Update camera position when static
+-- Holds current draw offset active while shaking or until activity stops
 function Camera.updateStatic(dt)
   if not Camera._isActive then return end
 
   _commitOffset(dt)
 
-  if not (Camera.shakeDuration > 0 or Camera._velocityX ~= 0
-      or Camera._velocityY ~= 0 or Camera.target ~= nil) then
+  if not (Camera.shakeDuration > 0 or Camera._velocityX ~= 0 or Camera._velocityY ~= 0 or Camera.target ~= nil) then
     Camera._isActive = false
   end
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Getters
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
--- ! Get Offset
+-- ! Get Position
 -- Returns the current camera position (x, y)
 function Camera.getPosition()
   return Camera.x, Camera.y
 end
 
 -- ! Get Bounds
--- Returns the current bounds if set, or nil
+-- Returns the current bounds table if set, or nil
 function Camera.getBounds()
   if not Camera._hasBounds then return nil end
-
-  -- Lazily allocate once, then just update fields
-  if not Camera._boundsCache then
-    Camera._boundsCache = { x1 = 0, y1 = 0, x2 = 0, y2 = 0 }
-  end
-
-  local cache = Camera._boundsCache
-  cache.x1 = Camera._minX
-  cache.y1 = Camera._minY
-  cache.x2 = Camera._maxX
-  cache.y2 = Camera._maxY
-  return cache
+  return {
+    x1 = Camera._minX,
+    y1 = Camera._minY,
+    x2 = Camera._maxX,
+    y2 = Camera._maxY
+  }
 end
 
 -- ! Get Bound X1
@@ -559,113 +513,50 @@ function Camera.getDrawOffset()
   return -Camera._lastX, -Camera._lastY
 end
 
+--------------------------------------------------------------------------------
+-- Converters
+--------------------------------------------------------------------------------
+
 -- ! World to Screen Converter
 -- Converts world coordinates to screen coordinates, using the current camera offset
 function Camera.worldToScreen(worldX, worldY)
+  --#DEBUG START
   if worldX == nil or worldY == nil then
-    Log.warn("worldToScreen received nil coordinate(s)") --#DEBUG
+    Log.warn("worldToScreen received nil coordinate(s)")
   end
+  --#DEBUG END
 
-  -- Handle nil coordinates
-  if worldX == nil then worldX = 0 end
-  if worldY == nil then worldY = 0 end
-
-  local cache = Camera._conversionCache.w2s
-  local offsetX, offsetY = Camera._lastX, Camera._lastY
-
-  -- Check if cache is valid for current offset
-  if cache.lastOffsetX ~= offsetX or cache.lastOffsetY ~= offsetY then
-    -- Camera moved, invalidate cache
-    cache.entries = {}
-    cache.keys = {}
-    cache.count = 0
-    cache.lastOffsetX = offsetX
-    cache.lastOffsetY = offsetY
-  end
-
-  -- Create cache key (combine coordinates into single string)
-  local key = worldX .. "," .. worldY
-  local cached = cache.entries[key]
-  if cached then
-    return cached[1], cached[2]
-  end
-
-  -- Compute conversion
-  local screenX = worldX - offsetX
-  local screenY = worldY - offsetY
-
-  -- Store in cache with simple FIFO eviction
-  if cache.count >= CONVERSION_CACHE_SIZE then
-    local oldKey = tableRemove(cache.keys, 1)
-    if oldKey ~= nil then
-      cache.entries[oldKey] = nil
-      cache.count -= 1 -- Uses Playdate SDK augmented assignment
-    end
-  end
-  tableInsert(cache.keys, key)
-  cache.entries[key] = { screenX, screenY }
-  cache.count += 1 -- Uses Playdate SDK augmented assignment
-
-  return screenX, screenY
+  worldX = worldX or 0
+  worldY = worldY or 0
+  return worldX - Camera._lastX, worldY - Camera._lastY
 end
 
 -- ! Screen to World Converter
 -- Converts screen coordinates to world coordinates, using the current camera offset
 function Camera.screenToWorld(screenX, screenY)
+  --#DEBUG START
   if screenX == nil or screenY == nil then
-    Log.warn("screenToWorld received nil coordinate(s)") --#DEBUG
+    Log.warn("screenToWorld received nil coordinate(s)")
   end
+  --#DEBUG END
 
-  -- Handle nil coordinates
-  if screenX == nil then screenX = 0 end
-  if screenY == nil then screenY = 0 end
-
-  local cache = Camera._conversionCache.s2w
-  local offsetX, offsetY = Camera._lastX, Camera._lastY
-
-  -- Check if cache is valid for current offset
-  if cache.lastOffsetX ~= offsetX or cache.lastOffsetY ~= offsetY then
-    -- Camera moved, invalidate cache
-    cache.entries = {}
-    cache.keys = {}
-    cache.count = 0
-    cache.lastOffsetX = offsetX
-    cache.lastOffsetY = offsetY
-  end
-
-  -- Create cache key (combine coordinates into single string)
-  local key = screenX .. "," .. screenY
-  local cached = cache.entries[key]
-  if cached then
-    return cached[1], cached[2]
-  end
-
-  -- Compute conversion
-  local worldX = screenX + offsetX
-  local worldY = screenY + offsetY
-
-  -- Store in cache with simple FIFO eviction
-  if cache.count >= CONVERSION_CACHE_SIZE then
-    local oldKey = tableRemove(cache.keys, 1)
-    if oldKey ~= nil then
-      cache.entries[oldKey] = nil
-      cache.count -= 1 -- Uses Playdate SDK augmented assignment
-    end
-  end
-  tableInsert(cache.keys, key)
-  cache.entries[key] = { worldX, worldY }
-  cache.count += 1 -- Uses Playdate SDK augmented assignment
-
-  return worldX, worldY
+  screenX = screenX or 0
+  screenY = screenY or 0
+  return screenX + Camera._lastX, screenY + Camera._lastY
 end
+
+--------------------------------------------------------------------------------
+-- Visibility
+--------------------------------------------------------------------------------
 
 -- ! Is On Screen
 -- Returns true if the point (x, y) is within the current screen bounds
 function Camera.isOnScreen(x, y)
-  return x >= Camera._screenLeft
-     and x <  Camera._screenRight
-     and y >= Camera._screenTop
-     and y <  Camera._screenBottom
+  local left    = Camera._screenLeft
+  local right   = Camera._screenRight
+  local top     = Camera._screenTop
+  local bottom  = Camera._screenBottom
+  return x >= left and x < right and y >= top and y < bottom
 end
 
 -- Default to static mode

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -31,10 +31,10 @@ local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, paral
     local cameraX, cameraY = Camera.getPosition()
     local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
     local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
-  
+
     local screenX = round(worldX + pivotAdjustX - cameraX * parallaxX)
     local screenY = round(worldY + pivotAdjustY - cameraY * parallaxY)
-  
+
     local currentX, currentY = sprite:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
       sprite:moveTo(screenX, screenY)
@@ -61,6 +61,12 @@ end
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
+
+-- ! Set Scene
+function LayerManager:setScene(scene)
+  self.scene = scene
+  self._sceneHasAdd = scene and type(scene.addSprite) == "function" or false
+end
 
 -- ! Add Layer
 -- Register/replace layer data. Does NOT create a sprite yet.
@@ -140,7 +146,7 @@ end
 function LayerManager:hide(name)
   local layer = self.layers[name]
   if not layer then return end
-  
+
   layer.visible = false
   if layer.sprite then layer.sprite:setVisible(false) end
 end
@@ -149,7 +155,7 @@ end
 function LayerManager:show(name)
   local layer = self.layers[name]
   if not layer then return end
-  
+
   layer.visible = true
   local sprite = self:ensureSprite(name)
   if sprite then sprite:setVisible(true) end
@@ -217,7 +223,7 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
             end
           end
         end
-    
+
       elseif type(remapFn) == "table" then
         for index = 1, #tiles do
           local tileIndex = tiles[index]
@@ -229,7 +235,7 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
           end
         end
       end
-    
+
       layer.tilemap:setTiles(tiles, width)
     end
   end
@@ -267,17 +273,17 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
   local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
   local mapPixelWidth, mapPixelHeight = mapWidthTiles * tileWidth, mapHeightTiles * tileHeight
-  
+
   local cameraX, cameraY = Camera.getPosition()
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local originX, originY = layer.originX or 0, layer.originY or 0
-  
+
   local anchorOffsetX = (layer.anchor == "topLeft") and 0 or 0.5
   local anchorOffsetY = (layer.anchor == "topLeft") and 0 or 0.5
-  
+
   local screenX = round(originX - mapPixelWidth * anchorOffsetX - cameraX * parallaxX)
   local screenY = round(originY - mapPixelHeight * anchorOffsetY - cameraY * parallaxY)
-  
+
   Sprite.addDirtyRect(screenX, screenY, mapPixelWidth, mapPixelHeight)
 
   return true
@@ -288,7 +294,7 @@ end
 function LayerManager:setOrigin(name, x, y)
   local layer = self.layers[name]
   if not layer then return false end
-  
+
   layer.originX, layer.originY = x or 0, y or 0
   local sprite = layer.sprite
   if sprite then
@@ -312,6 +318,24 @@ end
 --------------------------------------------------------------------------------
 -- Cleanup
 --------------------------------------------------------------------------------
+
+-- ! Detach
+function LayerManager:detach()
+  for _, layer in pairs(self.layers) do
+    if layer.sprite then
+      if self.scene and self.scene.removeSprite then
+        self.scene:removeSprite(layer.sprite)
+      else
+        layer.sprite:remove()
+      end
+      layer.sprite = nil
+    end
+    if layer.collisionSprites then
+      for _, sprite in ipairs(layer.collisionSprites) do sprite:remove() end
+      layer.collisionSprites = nil
+    end
+  end
+end
 
 -- ! Destroy
 -- Cleanly remove all layer sprites + collisions and release swap-retained paths

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -1,0 +1,333 @@
+-- core/tilemaps/LayerManager.lua
+
+local pd        <const> = playdate
+local Object    <const> = pd.object
+local Graphics  <const> = pd.graphics
+local Sprite    <const> = Graphics.sprite
+
+local r           <const> = roxy
+local AssetStore  <const> = r.AssetStore
+local Camera      <const> = r.Camera
+
+local round     <const> = r.Math.round
+
+local tableInsert <const> = table.insert
+local tableRemove <const> = table.remove
+
+local newSprite <const> = Sprite.new
+
+local retain    <const> = AssetStore.retain
+local release   <const> = AssetStore.release
+local getTable  <const> = AssetStore.getImagetable
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Helper: Create Parallax Update
+-- Parallax updater (same behavior as in RoxyTilemap)
+local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY)
+  return function(sprite)
+    local cameraX, cameraY = Camera.getPosition()
+    local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+    local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+  
+    local screenX = round(worldX + pivotAdjustX - cameraX * parallaxX)
+    local screenY = round(worldY + pivotAdjustY - cameraY * parallaxY)
+  
+    local currentX, currentY = sprite:getPosition()
+    if screenX ~= currentX or screenY ~= currentY then
+      sprite:moveTo(screenX, screenY)
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+-- ! Class Definition and Initialize
+--------------------------------------------------------------------------------
+
+class("LayerManager").extends(Object)
+
+function LayerManager:init(opts, scene, backingLayersTable, backingSpritesList)
+  self._opts = opts or {}
+  self.scene = scene
+  self.layers = backingLayersTable or {}  -- Shares storage with owner (RoxyTilemap)
+  self._spritesList = backingSpritesList or {} -- Optional external list to append into
+  self._retainedPaths = {} -- Only paths retained by swaps (not tilesets)
+  self._autoAdd = (self._opts.wrapInSprites ~= false) and (self._opts.autoAddSprites ~= false)
+  self._sceneHasAdd = scene and type(scene.addSprite) == "function" or false
+end
+
+--------------------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------------------
+
+-- ! Add Layer
+-- Register/replace layer data. Does NOT create a sprite yet.
+function LayerManager:addLayer(layerData)
+  if layerData.visible == nil then layerData.visible = true end
+  self.layers[layerData.name] = layerData
+end
+
+-- ! Ensure Sprite
+-- Create (if needed) and return the sprite for a layer
+function LayerManager:ensureSprite(name)
+  local layer = self.layers[name]; if not layer then return nil end
+  if layer.sprite or self._opts.wrapInSprites == false then return layer.sprite end
+
+  local sprite = newSprite()
+  sprite:setTilemap(layer.tilemap)
+  if (layer.anchor or self._opts.anchor) == "topLeft" then sprite:setCenter(0, 0) else sprite:setCenter(0.5, 0.5) end
+  sprite:setZIndex(layer.zIndex or 0)
+
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local useParallax = (not layer.layerOptions) or (layer.layerOptions.parallax ~= false)
+  if useParallax and (parallaxX ~= 1 or parallaxY ~= 1) then
+    sprite:setIgnoresDrawOffset(true)
+    sprite:setUpdatesEnabled(true)
+    sprite.update = _createParallaxUpdate(
+      layer.originX or 0, layer.originY or 0,
+      parallaxX, parallaxY,
+      layer.parallaxoriginx or 0, layer.parallaxoriginy or 0
+    )
+  else
+    sprite:moveTo(layer.originX or 0, layer.originY or 0)
+  end
+
+  if self._autoAdd then
+    if self._sceneHasAdd then
+      self.scene:addSprite(sprite)
+    else
+      sprite:add()
+    end
+  end
+  sprite:setVisible(layer.visible ~= false)
+
+  tableInsert(self._spritesList, sprite)
+  layer.sprite = sprite
+  return sprite
+end
+
+-- ! Ensure Sprites for All
+function LayerManager:ensureSpritesForAll()
+  for name, _ in pairs(self.layers) do self:ensureSprite(name) end
+end
+
+--
+-- Lookups
+--
+
+-- ! Get Tilemap
+function LayerManager:getTilemap(name)
+  return self.layers[name] and self.layers[name].tilemap or nil
+end
+
+-- ! Get Sprite
+function LayerManager:getSprite(name)
+  return self.layers[name] and self.layers[name].sprite or nil
+end
+
+-- ! Get All Sprites
+function LayerManager:getAllSprites()
+  return self._spritesList
+end
+
+--
+-- Visibility
+--
+
+-- ! Hide
+function LayerManager:hide(name)
+  local layer = self.layers[name]
+  if not layer then return end
+  
+  layer.visible = false
+  if layer.sprite then layer.sprite:setVisible(false) end
+end
+
+-- ! Show
+function LayerManager:show(name)
+  local layer = self.layers[name]
+  if not layer then return end
+  
+  layer.visible = true
+  local sprite = self:ensureSprite(name)
+  if sprite then sprite:setVisible(true) end
+end
+
+-- ! Remove
+-- Remove layer + sprites + collision sprites + retained paths from swaps
+function LayerManager:remove(name)
+  local layer = self.layers[name]
+  if not layer then return end
+
+  if layer.sprite then
+    local sprite = layer.sprite
+    if self.scene and self.scene.removeSprite then self.scene:removeSprite(sprite) else sprite:remove() end
+    -- remove from external list if present
+    for i = #self._spritesList, 1, -1 do
+      if self._spritesList[i] == sprite then tableRemove(self._spritesList, i); break end
+    end
+    layer.sprite = nil
+  end
+
+  if layer.collisionSprites then
+    for _, collisionSprite in ipairs(layer.collisionSprites) do collisionSprite:remove() end
+    layer.collisionSprites = nil
+  end
+
+  if layer.imagePath and self._retainedPaths[layer.imagePath] then
+    release(layer.imagePath)
+    self._retainedPaths[layer.imagePath] = nil
+  end
+
+  layer.tilemap, layer.imageTable, layer._imageCache, layer._offsetCache = nil, nil, nil, nil
+  self.layers[name] = nil
+end
+
+-- ! Set Image Table
+-- Runtime imagetable swap with index remap and proper retention accounting
+function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
+  local layer = self.layers[name]
+  if not layer or not layer.tilemap then return false end
+
+  local newPath, newTable
+  if type(newImageTableOrPath) == "string" then
+    -- Normalize like RoxyTilemap expects ("assets/images/<base>")
+    local filename = newImageTableOrPath:match("([^/]+)$") or ""
+    local base = filename:gsub("%-table%-%d+%-%d+%.png$", "")
+    newPath = "assets/images/" .. base
+    newTable = getTable(newPath)
+    if not newTable then return false end
+  else
+    newTable = newImageTableOrPath
+    if not newTable then return false end
+  end
+
+  if remapFn then
+    local tiles, width = layer.tilemap:getTiles()
+    if tiles and width then
+      if type(remapFn) == "function" then
+        for index = 1, #tiles do
+          local tileIndex = tiles[index]
+          if tileIndex ~= 0 then
+            local mappedIndex = remapFn(tileIndex)
+            if mappedIndex ~= nil then
+              tiles[index] = mappedIndex
+            end
+          end
+        end
+    
+      elseif type(remapFn) == "table" then
+        for index = 1, #tiles do
+          local tileIndex = tiles[index]
+          if tileIndex ~= 0 then
+            local mappedIndex = remapFn[tileIndex]
+            if mappedIndex ~= nil then
+              tiles[index] = mappedIndex
+            end
+          end
+        end
+      end
+    
+      layer.tilemap:setTiles(tiles, width)
+    end
+  end
+
+  layer.tilemap:setImageTable(newTable)
+  layer.imageTable, layer._imageCache, layer._offsetCache = newTable, {}, {}
+
+  -- recompute image meta
+  local maxHeight, count = 0, newTable and newTable:getLength() or 0
+  for i = 1, count do
+    local img = newTable:getImage(i)
+    if img then local _, height = img:getSize()
+      if height and height > maxHeight then
+        maxHeight = height
+      end
+    end
+  end
+  layer.maxImageHeight, layer.imageCount = maxHeight, count
+
+  -- update retention (for swap paths only)
+  if newPath then
+    if not self._retainedPaths[newPath] then
+      retain(newPath, newTable)
+      self._retainedPaths[newPath] = true
+    end
+    local oldPath = layer.imagePath
+    if oldPath and oldPath ~= newPath and self._retainedPaths[oldPath] then
+      release(oldPath)
+      self._retainedPaths[oldPath] = nil
+    end
+    layer.imagePath = newPath
+  end
+
+  -- Mark layer rect dirty
+  local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
+  local mapWidthTiles, mapHeightTiles = layer.tilemap:getSize()
+  local mapPixelWidth, mapPixelHeight = mapWidthTiles * tileWidth, mapHeightTiles * tileHeight
+  
+  local cameraX, cameraY = Camera.getPosition()
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local originX, originY = layer.originX or 0, layer.originY or 0
+  
+  local anchorOffsetX = (layer.anchor == "topLeft") and 0 or 0.5
+  local anchorOffsetY = (layer.anchor == "topLeft") and 0 or 0.5
+  
+  local screenX = round(originX - mapPixelWidth * anchorOffsetX - cameraX * parallaxX)
+  local screenY = round(originY - mapPixelHeight * anchorOffsetY - cameraY * parallaxY)
+  
+  Sprite.addDirtyRect(screenX, screenY, mapPixelWidth, mapPixelHeight)
+
+  return true
+end
+
+-- ! Set Origin
+-- Keep origin/sprite in sync (parallax-aware)
+function LayerManager:setOrigin(name, x, y)
+  local layer = self.layers[name]
+  if not layer then return false end
+  
+  layer.originX, layer.originY = x or 0, y or 0
+  local sprite = layer.sprite
+  if sprite then
+    local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+    local parallaxOriginX, parallaxOriginY = layer.parallaxoriginx or 0, layer.parallaxoriginy or 0
+    if sprite.update and sprite.setUpdatesEnabled then
+      sprite.update = _createParallaxUpdate(layer.originX, layer.originY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY)
+      sprite:setIgnoresDrawOffset(true); sprite:setUpdatesEnabled(true)
+    else
+      sprite:moveTo(layer.originX, layer.originY)
+    end
+  end
+  return true
+end
+
+-- ! Set Origin for All
+function LayerManager:setOriginForAll(x, y)
+  for name, _ in pairs(self.layers) do self:setOrigin(name, x, y) end
+end
+
+--------------------------------------------------------------------------------
+-- Cleanup
+--------------------------------------------------------------------------------
+
+-- ! Destroy
+-- Cleanly remove all layer sprites + collisions and release swap-retained paths
+function LayerManager:destroy()
+  for _, layer in pairs(self.layers) do
+    if layer.sprite then
+      if self.scene and self.scene.removeSprite then self.scene:removeSprite(layer.sprite) else layer.sprite:remove() end
+      layer.sprite = nil
+    end
+    if layer.collisionSprites then
+      for _, collisionSprite in ipairs(layer.collisionSprites) do collisionSprite:remove() end
+      layer.collisionSprites = nil
+    end
+    layer.tilemap, layer.imageTable, layer._imageCache, layer._offsetCache = nil, nil, nil, nil
+  end
+  for path, _ in pairs(self._retainedPaths) do release(path) end
+  self._retainedPaths = {}
+  self._spritesList = {}
+end

--- a/core/tilemaps/ObjectLayerProcessor.lua
+++ b/core/tilemaps/ObjectLayerProcessor.lua
@@ -1,0 +1,243 @@
+-- core/tilemaps/ObjectLayerProcessor.lua
+
+roxy = roxy or {}
+roxy.ObjectLayerProcessor = roxy.ObjectLayerProcessor or {}
+local ObjectLayerProcessor <const> = roxy.ObjectLayerProcessor
+
+local pd        <const> = playdate
+local Graphics  <const> = pd.graphics
+local Sprite    <const> = Graphics.sprite
+
+local r           <const> = roxy
+local AssetStore  <const> = r.AssetStore
+
+local tableCreate <const> = table.create
+local tableInsert <const> = table.insert
+
+local pushContext <const> = Graphics.pushContext
+local popContext  <const> = Graphics.popContext
+local newImage    <const> = Graphics.image.new
+local setColor    <const> = Graphics.setColor
+local fillRect    <const> = Graphics.fillRect
+
+local newSprite <const> = Sprite.new
+
+local retain          <const> = AssetStore.retain
+local getImageCached  <const> = AssetStore.getImageCached
+
+local IMAGE_PATH_PREFIX <const> = "assets/images/"
+
+local SPRITE_DEFAULT_DIMS <const> = 16
+
+local OBJECT_TAG <const> = 2
+
+local COLOR_BLACK <const> = Graphics.kColorBlack
+
+--------------------------------------------------------------------------------
+-- Create Default Object Sprite
+--------------------------------------------------------------------------------
+
+-- ! Create Default Object Sprite
+function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fallbackParallaxX, fallbackParallaxY)
+  -- Initialize parallax values and object properties
+  local parallaxX, parallaxY = 1, 1
+  local parallaxOriginX, parallaxOriginY = 0, 0
+  local objectProperties = {}
+  
+  if object.properties then
+    for _, property in ipairs(object.properties) do
+      local name = property.name
+      local value = property.value
+      objectProperties[name] = value
+      if name == "parallaxX" then
+        parallaxX = tonumber(value) or 1
+      elseif name == "parallaxY" then
+        parallaxY = tonumber(value) or 1
+      elseif name == "parallaxOriginX" then
+        parallaxOriginX = tonumber(value) or 0
+      elseif name == "parallaxOriginY" then
+        parallaxOriginY = tonumber(value) or 0
+      end
+    end
+  end
+  
+  -- Use layer fallback only if object did not override
+  if parallaxX == 1 and parallaxY == 1 then
+    if fallbackParallaxX then parallaxX = fallbackParallaxX end
+    if fallbackParallaxY then parallaxY = fallbackParallaxY end
+  end
+
+  -- Determine if parallax is needed
+  local hasParallax = parallaxX ~= 1 or parallaxY ~= 1
+
+  -- Determine image path
+  local imagePath = nil
+  if objectProperties.image or objectProperties.sprite then
+    imagePath = IMAGE_PATH_PREFIX .. (objectProperties.image or objectProperties.sprite)
+  else
+    local baseName = object.type or object.name or "default"
+    imagePath = IMAGE_PATH_PREFIX .. baseName
+  end
+
+  -- Try to load the image (optional)
+  local img = getImageCached(imagePath) or nil
+  if img then
+    retain(imagePath, img)
+  end
+
+  -- Create appropriate sprite type
+  local sprite
+  if hasParallax then
+    sprite = RoxyParallaxSprite({
+      view = img,
+      worldX = object.x or 0,
+      worldY = object.y or 0,
+      parallaxX = parallaxX,
+      parallaxY = parallaxY,
+      parallaxOriginX = parallaxOriginX,
+      parallaxOriginY = parallaxOriginY
+    })
+  else
+    sprite = newSprite()
+    if img then
+      sprite:setImage(img)
+    --#DEBUG START
+    else
+      -- Create fallback image for debugging
+      local width = object.width or SPRITE_DEFAULT_DIMS
+      local height = object.height or SPRITE_DEFAULT_DIMS
+      local fallbackImage = newImage(width, height)
+      pushContext(fallbackImage)
+        setColor(COLOR_BLACK)
+        fillRect(0, 0, width, height)
+      popContext()
+      sprite:setImage(fallbackImage)
+    --#DEBUG END
+    end
+  end
+
+  -- Track retained imagePath for cleanup
+  sprite._retainedImagePath = img and imagePath or nil
+
+  -- Store object properties on sprite for reference
+  sprite.objectProps = objectProperties
+  return sprite
+end
+
+--------------------------------------------------------------------------------
+-- Process a single object layer into sprites
+--------------------------------------------------------------------------------
+
+-- ! Process Object Layer
+function ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, outSprites)
+  local objects = layer.objects or {}
+  
+  -- Resolve per-layer parallax once.
+  -- (1) Prefer explicit layerOptions (both camelCase and lowercase accepted),
+  -- (2) then Tiled layer fields (parallaxx/parallaxy),
+  -- (3) default to 1.
+  local optPX = layerOptions.parallaxX or layerOptions.parallaxx
+  local optPY = layerOptions.parallaxY or layerOptions.parallaxy
+  local layerPX = tonumber(layer.parallaxx) or nil
+  local layerPY = tonumber(layer.parallaxy) or nil
+  local resolvedParallaxX = tonumber(optPX) or layerPX or 1
+  local resolvedParallaxY = tonumber(optPY) or layerPY or 1
+  
+  local layerSprites = tableCreate(#objects, 0)
+  
+  for _, object in ipairs(objects) do
+    local sprite = nil
+  
+    if opts.spriteFactory and type(opts.spriteFactory) == "function" then
+      sprite = opts.spriteFactory(object, layer, layerOptions)
+    elseif layerOptions.spriteFactory and type(layerOptions.spriteFactory) == "function" then
+      sprite = layerOptions.spriteFactory(object, layer, layerOptions)
+    else
+      -- Default creation uses resolved layer parallax as a fallback,
+      -- but still allows object.properties to override.
+      sprite = ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, resolvedParallaxX, resolvedParallaxY)
+    end
+
+    if sprite then
+      -- Compute world position (center vs topLeft)
+      local positionX, positionY = object.x or 0, object.y or 0
+      if opts.anchor == "center" then
+        positionX += (object.width  or 0) * 0.5
+        positionY += (object.height or 0) * 0.5
+      end
+
+      if sprite.setWorldPosition then
+        sprite:setWorldPosition(positionX, positionY)
+      else
+        sprite:moveTo(positionX, positionY)
+      end
+
+      -- Z-index & visibility
+      local zIndex = layerOptions.zIndex or (opts.zIndices and opts.zIndices[layer.name]) or 0
+      sprite:setZIndex(zIndex)
+      sprite:setVisible(layerOptions.visible ~= false)
+
+      -- Back-reference to Tiled object
+      sprite.tiledObject = object
+
+      -- Optional collisions for object sprites
+      if layerOptions.collidable == true then
+        sprite:setTag(layerOptions.tag or OBJECT_TAG)
+        sprite:setCollideRect(0, 0, sprite:getSize())
+
+        if layerOptions.spriteGroup then
+          sprite:setGroups(type(layerOptions.spriteGroup) == "table" and layerOptions.spriteGroup or { layerOptions.spriteGroup })
+        end
+        if layerOptions.collidesWithGroups and type(layerOptions.collidesWithGroups) == "table" and #layerOptions.collidesWithGroups > 0 then
+          sprite:setCollidesWithGroups(layerOptions.collidesWithGroups)
+        end
+
+        sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
+      end
+
+      tableInsert(layerSprites, sprite)
+
+      -- Append into global new-sprites list if provided
+      if outSprites then
+        tableInsert(outSprites, sprite)
+      end
+
+      -- Optionally add to display/scene immediately
+      if autoAdd then
+        if sceneHasAdd then
+          scene:addSprite(sprite)
+        else
+          sprite:add()
+        end
+      end
+    end
+  end
+
+  return layerSprites
+end
+
+--------------------------------------------------------------------------------
+-- Process multiple layers by name-set (or all object layers on the map)
+--------------------------------------------------------------------------------
+
+-- ! Process Object Layers
+function ObjectLayerProcessor.processObjectLayers(tilemapInstance, mapData, opts, layersToProcess, autoAdd, scene, sceneHasAdd, outSprites)
+  -- layersToProcess is an optional set: { ["Layer Name"] = true, ... }
+  local objectSprites = tilemapInstance.objectSprites or {}
+  local processedCount = 0
+
+  for _, layer in ipairs(mapData.layers or {}) do
+    if layer.type == "objectgroup" then
+      local shouldProcess = not layersToProcess or layersToProcess[layer.name]
+      if shouldProcess then
+        local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
+        local sprites = ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, outSprites)
+        objectSprites[layer.name] = sprites
+        processedCount += 1
+      end
+    end
+  end
+
+  tilemapInstance.objectSprites = objectSprites
+  return processedCount
+end

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -54,10 +54,7 @@ local DEFAULT_CHUNK_SIZE    <const> = 320 -- Adjusted for iso diamond (e.g., til
 local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
 
--- Cull margins / epsilon
-local TILE_MARGIN          <const> = 1 -- Coarse safety margin for dynamic draw
 local VISIBLE_MARGIN_TILES <const> = 2
-local FLOAT_EPSILON        <const> = 0.000001
 
 local PREFETCH_RINGS  <const> = 1  -- 1 ring beyond visible
 local BUILD_BUDGET    <const> = 2  -- Build at most 2 chunks per frame

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -11,7 +11,6 @@ local Cache   <const> = r.Cache
 local min   <const> = math.min
 local max   <const> = math.max
 local floor <const> = math.floor
-local ceil  <const> = math.ceil
 local round <const> = r.Math.round
 
 local tableInsert <const> = table.insert

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -1,54 +1,39 @@
 -- core/tilemaps/RoxyTilemap.lua
 
+import "libraries/roxy/core/tilemaps/ObjectLayerProcessor"
+import "libraries/roxy/core/tilemaps/LayerManager"
+
 local pd        <const> = playdate
 local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
-local Sprite    <const> = Graphics.sprite
 
 local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
-local Cache       <const> = r.Cache
 local Camera      <const> = r.Camera
 
 local min   <const> = math.min
 local max   <const> = math.max
 local floor <const> = math.floor
 local ceil  <const> = math.ceil
-local round <const> = r.Math.round
 
 local createTable <const> = table.create
 local tableInsert <const> = table.insert
-local tableRemove <const> = table.remove
 local tableSort   <const> = table.sort
 
 local loadJSON <const> = r.JSON.loadJson
 
-local pushContext     <const> = Graphics.pushContext
-local popContext      <const> = Graphics.popContext
 local getDrawOffset   <const> = Graphics.getDrawOffset
 local setDrawOffset   <const> = Graphics.setDrawOffset
-local setColor        <const> = Graphics.setColor
-local newImage        <const> = Graphics.image.new
-local newImagetable   <const> = Graphics.imagetable.new
 local newTilemap      <const> = Graphics.tilemap.new
-local fillRect        <const> = Graphics.fillRect
 local addWallSprites  <const> = Graphics.sprite.addWallSprites
-local newSprite       <const> = Graphics.sprite.new
-
-local addDirtyRect <const> = Sprite.addDirtyRect
 
 local retain          <const> = AssetStore.retain
 local release         <const> = AssetStore.release
 local getImagetable   <const> = AssetStore.getImagetable
-local getImageCached  <const> = AssetStore.getImageCached
-
-local getCachedAsset    <const> = Cache.getCachedAsset
-local cacheAsset        <const> = Cache.cacheAsset
-local evictAsset        <const> = Cache.evictAsset
-local getIsAssetCached  <const> = Cache.getIsAssetCached
 
 local setCameraBounds   <const> = Camera.setBounds
-local getCameraPosition <const> = Camera.getPosition
+
+local ObjectLayerProcessor  <const> = r.ObjectLayerProcessor
 
 local IMAGE_PATH_PREFIX <const> = "assets/images/"
 
@@ -145,187 +130,6 @@ local function _validateOptions(opts)
 end
 
 --
--- Object Processing Helpers
---
-
--- ! Helper: Create Default Object Sprite
--- Creates a sprite from a Tiled object, with parallax support
-local function _createDefaultObjectSprite(object, layerOptions)
-  -- Initialize parallax values and object properties
-  local parallaxX, parallaxY = 1, 1
-  local parallaxOriginX, parallaxOriginY = 0, 0
-  local objectProperties = {}
-
-  -- Parse object properties
-  if object.properties then
-    for _, property in ipairs(object.properties) do
-      local name = property.name
-      local value = property.value
-
-      objectProperties[name] = value
-
-      -- Handle parallax properties
-      if name == "parallaxX" then
-        parallaxX = tonumber(value) or 1
-      elseif name == "parallaxY" then
-        parallaxY = tonumber(value) or 1
-      elseif name == "parallaxOriginX" then
-        parallaxOriginX = tonumber(value) or 0
-      elseif name == "parallaxOriginY" then
-        parallaxOriginY = tonumber(value) or 0
-      end
-    end
-  end
-
-  -- Determine if parallax is needed (single check after parsing)
-  local hasParallax = parallaxX ~= 1 or parallaxY ~= 1
-
-  -- Determine image path
-  local imagePath = nil
-  if objectProperties.image or objectProperties.sprite then
-    imagePath = IMAGE_PATH_PREFIX .. (objectProperties.image or objectProperties.sprite)
-  else
-    local baseName = object.type or object.name or "default"
-    imagePath = IMAGE_PATH_PREFIX .. baseName
-  end
-
-  -- Try to load the image
-  local img = getImageCached(imagePath)
-  if not img then
-    Log.warn("[_createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath)) --#DEBUG
-  end
-
-  -- Retain image if successfully loaded
-  if img then
-    retain(imagePath, img)
-  end
-
-  -- Create appropriate sprite type
-  local sprite
-  if hasParallax then
-    sprite = r.RoxyParallaxSprite({
-      view = img,
-      worldX = object.x or 0,
-      worldY = object.y or 0,
-      parallaxX = parallaxX,
-      parallaxY = parallaxY,
-      parallaxOriginX = parallaxOriginX,
-      parallaxOriginY = parallaxOriginY
-    })
-  else
-    sprite = newSprite()
-    if img then
-      sprite:setImage(img)
-    --#DEBUG START
-    else
-      -- Create fallback image for debugging
-      local width = object.width or SPRITE_DEFAULT_DIMS
-      local height = object.height or SPRITE_DEFAULT_DIMS
-      local fallbackImage = newImage(width, height)
-      pushContext(fallbackImage)
-        setColor(COLOR_BLACK)
-        fillRect(0, 0, width, height)
-      popContext()
-      sprite:setImage(fallbackImage)
-    --#DEBUG END
-    end
-  end
-  sprite._retainedImagePath = imagePath
-
-  -- Store object properties on sprite
-  sprite.objectProps = objectProperties
-  return sprite
-end
-
--- ! Helper: Process Object Layer
--- Converts Tiled object layer into sprites
-local function _processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
-  local objects = layer.objects or {}
-
-  -- Preallocate object layer tables
-  local layerSprites = createTable(#objects, 0)
-
-  for _, object in ipairs(objects) do
-    local sprite = nil
-
-    -- Use custom sprite factory if provided (check global first, then layer-specific)
-    if opts.spriteFactory and type(opts.spriteFactory) == "function" then
-      sprite = opts.spriteFactory(object, layer.name, layerOptions)
-    elseif layerOptions.spriteFactory and type(layerOptions.spriteFactory) == "function" then
-      sprite = layerOptions.spriteFactory(object, layer.name, layerOptions)
-    else
-      -- Default sprite creation
-      sprite = _createDefaultObjectSprite(object, layerOptions)
-    end
-
-    if sprite then
-      -- Calculate object position in world pixels (top-left or centered based on anchor)
-      local positionX, positionY = object.x or 0, object.y or 0
-      if opts.anchor == "center" then
-        positionX += (object.width  or 0) * 0.5
-        positionY += (object.height or 0) * 0.5
-      end
-
-      -- Compute final screen coordinates
-      local screenX, screenY = positionX, positionY
-
-      -- Position the sprite appropriately
-      if sprite.setWorldPosition then
-        -- Parallax-aware sprite
-        sprite:setWorldPosition(screenX, screenY)
-      else
-        -- Normal screen-positioned sprite
-        sprite:moveTo(screenX, screenY)
-      end
-
-      -- Set z-index if specified
-      local zIndex = layerOptions.zIndex or opts.zIndices[layer.name] or 0
-      sprite:setZIndex(zIndex)
-
-      -- Set visibility
-      sprite:setVisible(layerOptions.visible ~= false)
-
-      -- Store object data on sprite for reference
-      sprite.tiledObject = object
-
-      -- Add collision if requested
-      if layerOptions.collidable == true then
-        sprite:setTag(layerOptions.tag or OBJECT_TAG) -- Different from wall sprites (tag 1)
-        sprite:setCollideRect(0, 0, sprite:getSize())
-
-        if layerOptions.spriteGroup then
-          sprite:setGroups(type(layerOptions.spriteGroup) == "table" and layerOptions.spriteGroup or {layerOptions.spriteGroup})
-        end
-
-        if layerOptions.collidesWithGroups and type(layerOptions.collidesWithGroups) == "table" and #layerOptions.collidesWithGroups > 0 then
-          sprite:setCollidesWithGroups(layerOptions.collidesWithGroups)
-        end
-
-        sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
-      end
-
-      tableInsert(layerSprites, sprite)
-
-      -- Directly append sprites to the global list
-      if newSprites then
-        tableInsert(newSprites, sprite)
-      end
-
-      -- Auto-add sprite if requested
-      if autoAdd then
-        if sceneHasAdd then
-          scene:addSprite(sprite)
-        else
-          sprite:add()
-        end
-      end
-    end
-  end
-
-  return layerSprites
-end
-
---
 -- Parallax System Helpers
 --
 
@@ -363,7 +167,6 @@ class("RoxyTilemap").extends(Object)
 function RoxyTilemap:init(jsonPath, opts, scene)
   opts = _validateOptions(opts)
   self._opts = opts
-
   self.scene = scene
   self._retainedPaths = {}
 
@@ -473,7 +276,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
       end
     end
     tileset.maxImageHeight = maxImageHeight
-    tileset.imageCount     = imageCount
+    tileset.imageCount = imageCount
 
     tilesets[tileset.name] = tileset
     ::continueTileset::
@@ -495,6 +298,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   -- Build layers
   self.layers = {}
   local newSprites = {}
+  self.layerManager = LayerManager(self._opts, scene, self.layers, newSprites)
   local processAllLayers = next(opts.layers) == nil -- Process all if none specified
 
   for _, layer in ipairs(mapData.layers or {}) do
@@ -620,53 +424,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         layerData.parallaxoriginx = parallaxOriginX
         layerData.parallaxoriginy = parallaxOriginY
 
-        -- Wrap in sprite if requested
-        if opts.wrapInSprites then
-          local sprite = newSprite()
-          sprite:setTilemap(tilemap)
-
-          if opts.anchor == "topLeft" then
-            sprite:setCenter(0, 0)
-          else
-            sprite:setCenter(0.5, 0.5)
-          end
-
-          sprite:setZIndex(layerData.zIndex)
-
-          local cameraGetter = getCameraPosition
-          local roundFn = round
-          local useParallax = (layerOptions.parallax ~= false)
-
-          if useParallax and (parallaxX ~= 1 or parallaxY ~= 1 or offsetX ~= 0 or offsetY ~= 0) then
-            sprite:setIgnoresDrawOffset(true)
-            sprite:setUpdatesEnabled(true)
-
-            -- Use consistent pivot calculation like projection classes
-            local worldX, worldY = originX, originY
-
-            sprite.update = _createParallaxUpdate(
-              worldX, worldY,
-              parallaxX, parallaxY,
-              parallaxOriginX, parallaxOriginY,
-              roundFn, cameraGetter
-            )
-          else
-            sprite:moveTo(originX, originY)
-          end
-
-          tableInsert(newSprites, sprite)
-          layerData.sprite = sprite
-
-          if autoAdd then
-            if sceneHasAdd then
-              scene:addSprite(sprite)
-            else
-              sprite:add()
-            end
-          end
-
-          sprite:setVisible(layerData.visible)
-        end
+        self.layerManager:addLayer(layerData)
 
         -- Add collision sprites if layer is collidable
         if layerOptions.collidable == true then
@@ -693,32 +451,44 @@ function RoxyTilemap:init(jsonPath, opts, scene)
           end
           layerData.collisionSprites = collisionSprites
         end
-
-        self.layers[layer.name] = layerData
       end
     end
     ::continueLayer::
   end
+  -- Optionally defer sprite creation for layers
+  -- Default behavior remains "create now" unless explicitly deferred
+  if self._opts.wrapInSprites and (self._opts.deferLayerSprites ~= true) then
+    self.layerManager:ensureSpritesForAll()
+  end
   self.sprites = newSprites
 
-  -- Process object layers
-  local objectSprites = {}
-  for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
-      local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or EMPTY_TABLE
+  -- Optional deferral of object-layer processing
+  local shouldDeferObjects = (opts.deferObjectProcessing == true)
 
-      -- Pass newSprites to _processObjectLayer for direct insertion
-      local sprites = _processObjectLayer(self, layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
-      objectSprites[layer.name] = sprites
+  -- Process object layers now unless deferred
+  local objectSprites = {}
+  if not shouldDeferObjects then
+    for _, layer in ipairs(mapData.layers or {}) do
+      if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
+        local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or EMPTY_TABLE
+        local sprites = ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
+        objectSprites[layer.name] = sprites
+      end
     end
   end
   self.objectSprites = objectSprites
 
-  -- Store object layer data for reference
+  -- Keep raw object data for later on-demand processing
   self.objectLayers = {}
   for _, layer in ipairs(mapData.layers or {}) do
     if layer.type == "objectgroup" then
-      self.objectLayers[layer.name] = layer.objects or {}
+      -- Store name, objects, and Tiled per-layer parallax so deferred processing can inherit it
+      self.objectLayers[layer.name] = {
+        name      = layer.name,
+        objects   = layer.objects or {},
+        parallaxx = tonumber(layer.parallaxx),
+        parallaxy = tonumber(layer.parallaxy),
+      }
     end
   end
 
@@ -734,8 +504,8 @@ end
 
 -- ! Shared: Isometric Draw Offsets
 -- Per-tile draw offsets so diamonds align with Tiled.
-function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, img)
-  local imageWidth, imageHeight = img:getSize()
+function RoxyTilemap._isoDrawOffsets(tileWidth, tileHeight, image)
+  local imageWidth, imageHeight = image:getSize()
   local offsetX = (tileWidth - imageWidth) * 0.5
   local offsetY = (tileHeight - imageHeight)
   return offsetX, offsetY
@@ -766,13 +536,13 @@ end
 -- ! Get Tilemap
 -- Returns the Playdate tilemap for the specified layer
 function RoxyTilemap:getTilemap(name)
-  return self.layers[name] and self.layers[name].tilemap
+  return self.layerManager and self.layerManager:getTilemap(name)
 end
 
 -- ! Get Sprite
 -- Returns the display sprite for the specified layer (if wrapInSprites was enabled)
 function RoxyTilemap:getSprite(name)
-  return self.layers[name] and self.layers[name].sprite
+  return self.layerManager and self.layerManager:getSprite(name)
 end
 
 -- ! Get World Size
@@ -785,6 +555,38 @@ end
 --------------------------------------------------------------------------------
 -- Object Layer Management
 --------------------------------------------------------------------------------
+
+-- ! Process Object Layers
+-- Process object layers on-demand, after init
+function RoxyTilemap:processObjectLayers(layersToProcess, autoAdd, scene)
+  local opts = self._opts or {}
+  local useAutoAdd = (autoAdd ~= nil) and autoAdd or (opts.wrapInSprites and (opts.autoAddSprites ~= false))
+  scene = scene or self.scene
+  local sceneHasAdd = scene and type(scene.addSprite) == "function" or false
+
+  -- Build a minimal map-like table so ObjectLayerProcessor can iterate layers
+  local mapLike = { layers = {} }
+  for _, entry in pairs(self.objectLayers or {}) do
+    local shouldProcess = not layersToProcess or layersToProcess[entry.name]
+    if shouldProcess then
+      tableInsert(mapLike.layers, {
+        type      = "objectgroup",
+        name      = entry.name,
+        objects   = entry.objects,
+        parallaxx = entry.parallaxx,
+        parallaxy = entry.parallaxy,
+      })
+    end
+  end
+
+  local outSprites = self.sprites or {}
+
+  -- Correct argument order: self first, then mapLike, then opts, etc.
+  local processed = ObjectLayerProcessor.processObjectLayers(self, mapLike, opts, layersToProcess, useAutoAdd, scene, sceneHasAdd, outSprites)
+
+  self.sprites = outSprites
+  return processed
+end
 
 -- ! Get Objects
 -- Returns the raw Tiled object data for the specified object layer
@@ -801,7 +603,15 @@ end
 -- ! Get All Sprites
 -- Returns all sprites managed by this tilemap (tile layers + objects)
 function RoxyTilemap:getAllSprites()
-  return self.sprites or {}
+  -- Layer sprites + object sprites
+  local list = {}
+  if self.layerManager then
+    for _, sprite in ipairs(self.layerManager:getAllSprites()) do tableInsert(list, sprite) end
+  end
+  for _, objectSprite in pairs(self.objectSprites or {}) do
+    for _, sprite in ipairs(objectSprite) do tableInsert(list, sprite) end
+  end
+  return list
 end
 
 --
@@ -903,83 +713,20 @@ end
 -- ! Hide Layer
 -- Hides a tile layer from rendering (affects both sprites and direct drawing)
 function RoxyTilemap:hideLayer(name)
-  local layerData = self.layers and self.layers[name]
-  if not layerData then return end
-
-  -- Update visibility flag for direct draw
-  layerData.visible = false
-
-  -- Hide sprite if it exists
-  local sprite = layerData.sprite
-  if sprite then
-    sprite:setVisible(false)
-  end
+  if self.layerManager then self.layerManager:hide(name) end
 end
 
 -- ! Show Layer
 -- Shows a previously hidden tile layer
 function RoxyTilemap:showLayer(name)
-  local layerData = self.layers and self.layers[name]
-  if not layerData then return end
-
-  -- Update visibility flag for direct draw
-  layerData.visible = true
-
-  -- Show sprite if it exists
-  local sprite = layerData.sprite
-  if sprite then
-    sprite:setVisible(true)
-  end
+  if self.layerManager then self.layerManager:show(name) end
 end
+
 
 -- ! Remove Layer
 -- Completely removes a tile layer and cleans up all associated resources
 function RoxyTilemap:removeLayer(name)
-  local layerData = self.layers[name]
-  if not layerData then return end
-
-  -- Release assets that this instance retained
-  if layerData.imagePath and self._retainedPaths and self._retainedPaths[layerData.imagePath] then
-    release(layerData.imagePath)
-    self._retainedPaths[layerData.imagePath] = nil
-  end
-
-  -- Remove display sprite and keep scene list in sync
-  if layerData.sprite then
-    local sprite = layerData.sprite
-    if self.scene and self.scene.removeSprite then
-      self.scene:removeSprite(sprite)
-    else
-      sprite:remove()
-    end
-
-    -- Remove from sprite list
-    if self.sprites then
-      for index = #self.sprites, 1, -1 do
-        if self.sprites[index] == sprite then
-          tableRemove(self.sprites, index)
-          break
-        end
-      end
-    end
-    layerData.sprite = nil
-  end
-
-  -- Remove collision sprites
-  if layerData.collisionSprites then
-    for _, sprite in ipairs(layerData.collisionSprites) do
-      sprite:remove()
-    end
-    layerData.collisionSprites = nil
-  end
-
-  -- Clear heavy references
-  layerData.tilemap = nil
-  layerData.imageTable = nil
-  layerData._imageCache = nil
-  layerData._offsetCache = nil
-
-  self.layers[name] = nil
+  if self.layerManager then self.layerManager:remove(name) end
 end
 
 --------------------------------------------------------------------------------
@@ -993,119 +740,7 @@ end
 --   - If a table, remapFn[oldIndex] = newIndex
 --   - If a function, newIndex = remapFn(oldIndex) (return nil to keep oldIndex)
 function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
-  local layerData = self.layers and self.layers[name]
-  if not layerData or not layerData.tilemap then
-    Log.warn("[RoxyTilemap:setLayerImageTable] No layer or tilemap for '" .. tostring(name) .. "'") --#DEBUG
-    return false
-  end
-
-  -- Resolve imagetable from path or direct reference
-  local newPath, newTable
-  if type(newImageTableOrPath) == "string" then
-    -- Normalize path like tileset loader does
-    newPath = _normalizeImagePath(newImageTableOrPath) or newImageTableOrPath
-    newTable = getImagetable(newPath)
-    if not newTable then
-      Log.warn("[RoxyTilemap:setLayerImageTable] Failed to load imagetable: " .. tostring(newPath)) --#DEBUG
-      return false
-    end
-  else
-    newTable = newImageTableOrPath
-    if not newTable then
-      Log.warn("[RoxyTilemap:setLayerImageTable] Expected imagetable or path, got nil") --#DEBUG
-      return false
-    end
-  end
-
-  -- Apply optional remapping of existing tile indices
-  if remapFn then
-    local data, width = layerData.tilemap:getTiles()
-    if data and width then
-      if type(remapFn) == "function" then
-        for index = 1, #data do
-          local tileIndex = data[index]
-          if tileIndex ~= 0 then
-            local mapped = remapFn(tileIndex)
-            if mapped ~= nil then
-              data[index] = mapped -- Allow mapping to 0
-            end
-          end
-        end
-      elseif type(remapFn) == "table" then
-        for index = 1, #data do
-          local tileIndex = data[index]
-          if tileIndex ~= 0 then
-            local mapped = remapFn[tileIndex]
-            if mapped ~= nil then
-              data[index] = mapped -- Allow mapping to 0
-            end
-          end
-        end
-      else
-        Log.warn("[RoxyTilemap:setLayerImageTable] Invalid remapFn; expected table or function") --#DEBUG
-      end
-      layerData.tilemap:setTiles(data, width)
-    end
-  end
-
-  -- Swap the imagetable
-  layerData.tilemap:setImageTable(newTable)
-  layerData.imageTable = newTable
-  layerData._imageCache = {}
-  layerData._offsetCache = {}
-
-  -- Recompute maximum image height using the new imagetable
-  local maxImageHeight = 0
-  local imageCount = 0
-  do
-    local imageTable = newTable
-    imageCount = imageTable and imageTable:getLength() or 0
-    for index = 1, imageCount do
-      local img = imageTable:getImage(index)
-      if img then
-        local _, height = img:getSize()
-        if height and height > maxImageHeight then
-          maxImageHeight = height
-        end
-      end
-    end
-  end
-  layerData.maxImageHeight = maxImageHeight
-  layerData.imageCount = imageCount
-
-  -- Update asset retention (if this was a path swap)
-  if newPath then
-    if not self._retainedPaths[newPath] then
-      retain(newPath, newTable) -- Retain the newly used imagetable path
-      self._retainedPaths[newPath] = true -- Track so we can release on destroy
-    end
-
-    local oldPath = layerData.imagePath
-    if oldPath and oldPath ~= newPath and self._retainedPaths[oldPath] then
-      release(oldPath) -- Only release paths this instance retained
-      self._retainedPaths[oldPath] = nil
-    end
-    layerData.imagePath = newPath
-  end
-
-  -- Force a redraw by marking the layer area as dirty
-  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
-  local mapWidthTiles, mapHeightTiles = layerData.tilemap:getSize()
-  local mapPixelWidth  = mapWidthTiles  * tileWidth
-  local mapPixelHeight = mapHeightTiles * tileHeight
-
-  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
-  local cameraX, cameraY = getCameraPosition()
-  local originX, originY = layerData.originX or 0, layerData.originY or 0
-  local centerX = (layerData.anchor == "topLeft") and 0 or 0.5
-  local centerY = (layerData.anchor == "topLeft") and 0 or 0.5
-
-  local screenX = round(originX - mapPixelWidth * centerX  - cameraX * parallaxX)
-  local screenY = round(originY - mapPixelHeight * centerY - cameraY * parallaxY)
-
-  addDirtyRect(screenX, screenY, mapPixelWidth, mapPixelHeight)
-
-  return true
+  return self.layerManager and self.layerManager:setImageTable(name, newImageTableOrPath, remapFn)
 end
 
 -- ! Rebuild Layer Collisions
@@ -1173,50 +808,14 @@ end
 
 -- ! Set Layer Origin
 -- Updates the origin for a single layer and keeps any display sprite in sync
-function RoxyTilemap:setLayerOrigin(name, originX, originY)
-  local layerData = self.layers and self.layers[name]
-  if not layerData then return false end
-
-  -- Update stored origin used by both sprite and direct draw
-  layerData.originX = originX or 0
-  layerData.originY = originY or 0
-
-  -- Keep existing sprite in sync
-  local sprite = layerData.sprite
-  if sprite then
-    local parallaxX = layerData.parallaxx or 1
-    local parallaxY = layerData.parallaxy or 1
-    local parallaxOriginX = layerData.parallaxoriginx or 0
-    local parallaxOriginY = layerData.parallaxoriginy or 0
-
-    -- If this layer was using a parallax update closure, rebuild it with the new origin
-    if sprite.update and sprite.setUpdatesEnabled then
-      -- Recreate the cached updater using the helper
-      sprite.update = _createParallaxUpdate(
-        layerData.originX, layerData.originY,
-        parallaxX, parallaxY,
-        parallaxOriginX, parallaxOriginY,
-        round, getCameraPosition
-      )
-      -- Ensure we do not double-apply draw offset
-      sprite:setIgnoresDrawOffset(true)
-      sprite:setUpdatesEnabled(true)
-    else
-      -- No parallax updater; just move the sprite to the new origin
-      sprite:moveTo(layerData.originX, layerData.originY)
-    end
-  end
-
-  return true
+function RoxyTilemap:setLayerOrigin(name, x, y)
+  return self.layerManager and self.layerManager:setOrigin(name, x, y)
 end
 
 -- ! Set Origin For All Layers
 -- Convenience method to apply the same origin to every tile layer
-function RoxyTilemap:setOriginForAllLayers(originX, originY)
-  if not self.layers then return end
-  for layerName, _ in pairs(self.layers) do
-    self:setLayerOrigin(layerName, originX, originY)
-  end
+function RoxyTilemap:setOriginForAllLayers(x, y)
+  return self.layerManager and self.layerManager:setOriginForAll(x, y)
 end
 
 --------------------------------------------------------------------------------
@@ -1355,32 +954,13 @@ end
 -- ! Destroy
 -- Cleans up all resources and removes sprites from display
 function RoxyTilemap:destroy()
-  -- Remove layer sprites and collision sprites
-  for _, layerData in pairs(self.layers) do
-    if layerData.sprite then
-      if self.scene and self.scene.removeSprite then
-        self.scene:removeSprite(layerData.sprite)
-      else
-        layerData.sprite:remove()
-      end
-      layerData.sprite = nil
-    end
-
-    if layerData.collisionSprites then
-      for _, sprite in ipairs(layerData.collisionSprites) do
-        sprite:remove()
-      end
-      layerData.collisionSprites = nil
-    end
-
-    -- Clear heavy references
-    layerData.tilemap = nil
-    layerData.imageTable = nil
-    layerData._imageCache = nil
-    layerData._offsetCache = nil
+  -- Manager handles layer sprites, collisions, and swap-retained paths
+  if self.layerManager then
+    self.layerManager:destroy()
+    self.layerManager = nil
   end
 
-  -- Remove object sprites
+  -- Remove object sprites (unchanged from your current logic)
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
       if sprite._retainedImagePath then
@@ -1395,34 +975,23 @@ function RoxyTilemap:destroy()
     end
   end
 
-  -- Clean up tilesets retained at initialization
+  -- Clean up tilesets retained at initialization (unchanged)
   for _, tileset in pairs(self.tilesets or {}) do
     if tileset.imagePath then
       release(tileset.imagePath)
     end
   end
 
-  -- Release any imagetable paths retained via swaps
-  if self._retainedPaths then
-    for path, _ in pairs(self._retainedPaths) do
-      release(path)
-    end
-    self._retainedPaths = nil
-  end
-
-  -- Clear all references
+  -- Clear refs + detach from scene (unchanged)
   self.layers = {}
   self.sprites = {}
   self.objectSprites = {}
   self.tilesets = nil
   self.objectLayers = nil
 
-  -- Detach from scene and let it remove us from its tilemaps list
   if self.scene then
     local scene = self.scene
     self.scene = nil
-    if scene.removeTilemap then
-      scene:removeTilemap(self)
-    end
+    if scene.removeTilemap then scene:removeTilemap(self) end
   end
 end

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -120,6 +120,7 @@ local function _validateOptions(opts)
   if opts.wrapInSprites == nil then opts.wrapInSprites = true end
   if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = {} end
   if opts.cameraBounds == nil then opts.cameraBounds = false end
+  if opts.deferCameraBounds == nil then opts.deferCameraBounds = false end
   if opts.anchor == nil or opts.anchor ~= "topLeft" then opts.anchor = "center" end
   if opts.collisionResponse == nil then opts.collisionResponse = "overlap" end
   if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = {} end
@@ -236,14 +237,23 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     return nil
   end
 
-  -- Apply camera bounds if requested
+  -- Apply (or defer) camera bounds
   if opts.cameraBounds then
-    setCameraBounds({
+    local bounds = {
       x1 = 0,
       y1 = 0,
-      x2 = max(0, self.worldWidth - DISPLAY_WIDTH),
-      y2 = max(0, self.worldHeight - DISPLAY_HEIGHT)
-    })
+      x2 = max(0, self.worldWidth  - DISPLAY_WIDTH),
+      y2 = max(0, self.worldHeight - DISPLAY_HEIGHT),
+    }
+
+    if opts.deferCameraBounds == true then
+      -- store for later, do NOT apply now (Loader scene)
+      self._pendingCameraBounds = bounds
+    else
+      -- apply immediately
+      setCameraBounds(bounds)
+      self._pendingCameraBounds = nil
+    end
   end
 
   -- Get map-level parallax origins
@@ -495,6 +505,39 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   -- Attach to a scene immediately if it supports tilemaps
   if scene and scene.addTilemap then
     scene:addTilemap(self)
+  end
+end
+
+--------------------------------------------------------------------------------
+--  Camera Controls
+--------------------------------------------------------------------------------
+
+-- ! Apply Camera Bounds
+-- Apply the precomputed bounds now (e.g., when a scene enters)
+function RoxyTilemap:applyCameraBounds()
+  local pending = self._pendingCameraBounds
+  if pending then
+    setCameraBounds(pending)
+    self._pendingCameraBounds = nil
+    return true
+  end
+  return false
+end
+
+-- ! Update Camera Bounds
+-- Recompute (in case the display size or map changed) and optionally apply or defer
+function RoxyTilemap:updateCameraBounds(shouldApply)
+  local bounds = {
+    x1 = 0,
+    y1 = 0,
+    x2 = max(0, self.worldWidth  - DISPLAY_WIDTH),
+    y2 = max(0, self.worldHeight - DISPLAY_HEIGHT),
+  }
+  if shouldApply then
+    setCameraBounds(bounds)
+    self._pendingCameraBounds = nil
+  else
+    self._pendingCameraBounds = bounds
   end
 end
 
@@ -950,6 +993,17 @@ end
 --------------------------------------------------------------------------------
 -- Cleanup
 --------------------------------------------------------------------------------
+
+-- ! Detach Sprites
+function RoxyTilemap:detachSprites()
+  if self.layerManager then self.layerManager:detach() end
+  for _, sprites in pairs(self.objectSprites or {}) do
+    for _, sprite in ipairs(sprites) do
+      if self.scene and self.scene.removeSprite then self.scene:removeSprite(sprite) else sprite:remove() end
+    end
+  end
+  self.objectSprites = {}
+end
 
 -- ! Destroy
 -- Cleans up all resources and removes sprites from display

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -5,9 +5,10 @@ local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
-local r       <const> = roxy
-local Cache   <const> = r.Cache
-local Camera  <const> = r.Camera
+local r           <const> = roxy
+local AssetStore  <const> = r.AssetStore
+local Cache       <const> = r.Cache
+local Camera      <const> = r.Camera
 
 local min   <const> = math.min
 local max   <const> = math.max
@@ -35,6 +36,11 @@ local addWallSprites  <const> = Graphics.sprite.addWallSprites
 local newSprite       <const> = Graphics.sprite.new
 
 local addDirtyRect <const> = Sprite.addDirtyRect
+
+local retain          <const> = AssetStore.retain
+local release         <const> = AssetStore.release
+local getImagetable   <const> = AssetStore.getImagetable
+local getImageCached  <const> = AssetStore.getImageCached
 
 local getCachedAsset    <const> = Cache.getCachedAsset
 local cacheAsset        <const> = Cache.cacheAsset
@@ -71,30 +77,6 @@ local referenceCount = {}
 -- Asset Management Helpers
 --
 
--- ! Helper: Retain Asset
--- Note on "thunk" caching.
--- We store either the asset or a thunk (a function returning the asset).
--- Thunks defer allocation until first use, which keeps memory lower when an
--- imagetable/image is referenced but never actually drawn.
-local function _retain(path, tbl)
-  referenceCount[path] = (referenceCount[path] or 0) + 1
-  if not getIsAssetCached(path) then
-    cacheAsset(path, function() return tbl end) -- Thunk
-  end
-end
-
--- ! Helper: Release Asset
-local function _release(path)
-  local count = referenceCount[path]
-  if not count then return end
-  if count <= 1 then
-    evictAsset(path)
-    referenceCount[path] = nil
-  else
-    referenceCount[path] = count - 1
-  end
-end
-
 -- ! Helper: Normalize Image Path
 -- Converts Tiled-exported image paths to Roxy's expected format
 local function _normalizeImagePath(tiledImagePath)
@@ -112,55 +94,6 @@ local function _normalizeImagePath(tiledImagePath)
   end
 
   return IMAGE_PATH_PREFIX .. base
-end
-
--- ! Helper: Get Imagetable
--- Loads or retrieves cached imagetable from path
-local function _getImagetable(path)
-  if type(path) ~= "string" or path == "" then
-    Log.warn("[_getImagetable] Invalid or missing path: " .. tostring(path))
-    return nil
-  end
-
-  local cached = getCachedAsset(path)
-  if cached then
-    local imagetable = (type(cached) == "function") and cached() or cached
-    return imagetable
-  end
-
-  local loaded = newImagetable(path)
-  if loaded then
-    cacheAsset(path, function() return loaded end)
-  else --#DEBUG
-    Log.warn("[_getImagetable] Failed to load imagetable at path: " .. path) --#DEBUG
-  end
-
-  return loaded
-end
-
--- ! Helper: Get Image (cached)
--- Loads or retrieves a cached image from a path
-local function _getImageCached(path)
-  if type(path) ~= "string" or path == "" then
-    Log.warn("[_getImageCached] Invalid or missing path: " .. tostring(path)) --#DEBUG
-    return nil
-  end
-
-  local cached = getCachedAsset(path)
-  if cached then
-    -- Realize thunk if needed
-    local img = (type(cached) == "function") and cached() or cached
-    return img
-  end
-
-  local loaded = newImage(path)
-  if loaded then
-    cacheAsset(path, function() return loaded end)
-  else --#DEBUG
-    Log.warn("[_getImageCached] Failed to load image at path: " .. path) --#DEBUG
-  end
-
-  return loaded
 end
 
 --
@@ -257,14 +190,14 @@ local function _createDefaultObjectSprite(object, layerOptions)
   end
 
   -- Try to load the image
-  local img = _getImageCached(imagePath)
+  local img = getImageCached(imagePath)
   if not img then
     Log.warn("[_createDefaultObjectSprite] Failed to load image at: " .. tostring(imagePath)) --#DEBUG
   end
 
   -- Retain image if successfully loaded
   if img then
-    _retain(imagePath, img)
+    retain(imagePath, img)
   end
 
   -- Create appropriate sprite type
@@ -524,8 +457,8 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     end
 
     tileset.imagePath  = normalizedPath
-    tileset.imageTable = _getImagetable(normalizedPath)
-    _retain(normalizedPath, tileset.imageTable)
+    tileset.imageTable = getImagetable(normalizedPath)
+    retain(normalizedPath, tileset.imageTable)
 
     -- Precompute once per tileset
     local maxImageHeight = 0
@@ -922,7 +855,7 @@ function RoxyTilemap:removeObjectLayer(layerName)
   local sprites = self:getObjectSprites(layerName)
   for _, sprite in ipairs(sprites) do
     if sprite._retainedImagePath then
-      _release(sprite._retainedImagePath)
+      release(sprite._retainedImagePath)
       sprite._retainedImagePath = nil
     end
     if self.scene and self.scene.removeSprite then
@@ -1007,7 +940,7 @@ function RoxyTilemap:removeLayer(name)
 
   -- Release assets that this instance retained
   if layerData.imagePath and self._retainedPaths and self._retainedPaths[layerData.imagePath] then
-    _release(layerData.imagePath)
+    release(layerData.imagePath)
     self._retainedPaths[layerData.imagePath] = nil
   end
 
@@ -1071,7 +1004,7 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   if type(newImageTableOrPath) == "string" then
     -- Normalize path like tileset loader does
     newPath = _normalizeImagePath(newImageTableOrPath) or newImageTableOrPath
-    newTable = _getImagetable(newPath)
+    newTable = getImagetable(newPath)
     if not newTable then
       Log.warn("[RoxyTilemap:setLayerImageTable] Failed to load imagetable: " .. tostring(newPath)) --#DEBUG
       return false
@@ -1143,13 +1076,13 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   -- Update asset retention (if this was a path swap)
   if newPath then
     if not self._retainedPaths[newPath] then
-      _retain(newPath, newTable) -- Retain the newly used imagetable path
-      self._retainedPaths[newPath] = true -- Track so we can _release on destroy
+      retain(newPath, newTable) -- Retain the newly used imagetable path
+      self._retainedPaths[newPath] = true -- Track so we can release on destroy
     end
 
     local oldPath = layerData.imagePath
     if oldPath and oldPath ~= newPath and self._retainedPaths[oldPath] then
-      _release(oldPath) -- Only _release paths this instance retained
+      release(oldPath) -- Only release paths this instance retained
       self._retainedPaths[oldPath] = nil
     end
     layerData.imagePath = newPath
@@ -1451,7 +1384,7 @@ function RoxyTilemap:destroy()
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
       if sprite._retainedImagePath then
-        _release(sprite._retainedImagePath)
+        release(sprite._retainedImagePath)
         sprite._retainedImagePath = nil
       end
       if self.scene and self.scene.removeSprite then
@@ -1465,14 +1398,14 @@ function RoxyTilemap:destroy()
   -- Clean up tilesets retained at initialization
   for _, tileset in pairs(self.tilesets or {}) do
     if tileset.imagePath then
-      _release(tileset.imagePath)
+      release(tileset.imagePath)
     end
   end
 
   -- Release any imagetable paths retained via swaps
   if self._retainedPaths then
     for path, _ in pairs(self._retainedPaths) do
-      _release(path)
+      release(path)
     end
     self._retainedPaths = nil
   end

--- a/utilities/TableBuilder.lua
+++ b/utilities/TableBuilder.lua
@@ -67,9 +67,10 @@ end
 -- Merge all layers in sequence and return the result
 -- @return table
 function TableBuilder:build()
+  local merge = self._merge or mergeImmutable
   local result = self.layers[1]
   for i = 2, #self.layers do
-    result = mergeImmutable(result, self.layers[i])
+    result = merge(result, self.layers[i])
   end
   return result
 end


### PR DESCRIPTION
### Overview
This release focuses on reliability and maintainability across the engine. It introduces a centralized `AssetStore` for consistent asset lifecycle management, refactors tilemap responsibilities into dedicated managers, simplifies `Camera` math (removing unused caches), and adds safer camera-bounds handling for cleaner scene transitions. It also includes targeted fixes and code hygiene improvements.

### Key Changes
- **Assets**
  - Added `AssetStore` for centralized image/imagetable caching with retain/release and lazy-load thunks.
  - Auto-loaded in `Cache.lua` so core modules can use `AssetStore` directly.

- **Tilemaps**
  - Migrated `RoxyTilemap` asset handling to `AssetStore` (removed internal ref-count and loader helpers).
  - Split responsibilities:
    - `LayerManager` now manages tile-layer sprites: creation, visibility, image swaps, and cleanup.
    - `ObjectLayerProcessor` handles object-layer → sprite creation with parallax, collisions, and sprite factories.
  - Added camera-bounds improvements:
    - New `deferCameraBounds` option to delay bounds until objects are ready.
    - New `applyCameraBounds` / `updateCameraBounds` to set or refresh bounds explicitly.
  - Layer sprite management now supports detaching sprites so scenes can use their own `addSprite` workflow and ensure proper cleanup.

- **Camera**
  - Added and then removed `worldToScreen` / `screenToWorld` conversion caches and associated invalidation logic after profiling showed no measurable benefit and added GC pressure.
  - Simplified bounds usage and update routines to rely on direct offset-based math.

- **Fixes & Chore**
  - **fix(tablebuilder):** `TableBuilder:build` now uses `self._merge` when provided, falling back to `mergeImmutable`.
  - **chore(tilemaps):** Removed unused constants/imports (`TILE_MARGIN`, `FLOAT_EPSILON`, and `math.ceil`) to reduce clutter.

### Breaking Changes
- **Tilemap API surface**
  - Removed direct/internal asset helpers from `RoxyTilemap`:
    - `_retain`, `_release`, `_getImagetable`, `_getImageCached`.
  - All asset operations must use `AssetStore.retain`, `AssetStore.release`, `AssetStore.getImagetable`, and `AssetStore.getImageCached`.
  - Methods that previously managed sprites/origins or object-layer processing on `RoxyTilemap` now delegate internally to `LayerManager` / `ObjectLayerProcessor`. Projects that touched `RoxyTilemap.layers` or private helpers must migrate to the public APIs that route through these managers.

### Challenges/Notes
- Initial camera conversion caching was prototyped, but profiling in `roxy-engine-tests` showed no gains and extra GC churn; the caching layer was removed in favor of simpler, predictable math paths.
- Centralizing assets in `AssetStore` reduces duplication across tilemaps and prepares the engine for broader, consistent asset management.
- Deferring and explicitly applying camera bounds prevents initialization-order pitfalls when maps load before dependent objects are spawned.