### PR TITLE
V0.14.3

### DIFF
--- a/core/animations/roxy_animation.c
+++ b/core/animations/roxy_animation.c
@@ -57,6 +57,11 @@ int roxy_animation_update_l(lua_State* L) {
     dt = 0.001f;
   }
 
+  // Ensure frameDuration is not zero or negative to avoid division by zero
+  if (frameDuration <= 0.0f) {
+    frameDuration = 0.001f;  // Clamp to small positive value
+  }
+
   // If the speed is zero, we return without changing the frame.
   if (speed <= 0.0f) {
     pd->lua->pushInt(currentFrame);

--- a/core/physics/RoxyPhysicsBody.lua
+++ b/core/physics/RoxyPhysicsBody.lua
@@ -7,11 +7,11 @@ local abs <const> = math.abs
 
 local FLOOR_LIMIT <const> = 0.7 --  normal.y  < -FLOOR_LIMIT  --> floor
 local CEIL_LIMIT  <const> = 0.7 --  normal.y  >  CEIL_LIMIT   --> ceiling
-local WALL_LIMIT <const> = 0.7 -- |normal.x| >  WALL_LIMIT  --> wall
+local WALL_LIMIT <const> = 0.7  -- |normal.x| >  WALL_LIMIT   --> wall
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Class Definition & Init
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 class("RoxyPhysicsBody").extends(Object)
 
@@ -24,20 +24,48 @@ function RoxyPhysicsBody:init(owner, opts)
   self.ay = opts.gravity or 200
   self.onGround = false
   self.onCollision = opts.onCollision -- Optional user function
+
+  -- Collision flags
+  self.enableCollisions = (opts.enableCollisions ~= false)
+  self.autoSetCollideRect = (opts.autoSetCollideRect == true)
+
+  -- Clear ay each frame by default when gravity is zero (top-down mode).
+  -- You can override explicitly via opts.clearAyEachFrame = true/false.
+  if opts.clearAyEachFrame ~= nil then
+    self.clearAyEachFrame = opts.clearAyEachFrame
+  else
+    self.clearAyEachFrame = (opts.gravity == 0)
+  end
+
+  -- Optionally set a collide rect to the sprite size if requested and missing
+  if self.enableCollisions and self.autoSetCollideRect and self._hasInvalidCollideRect(owner) then
+    local width, height = owner:getSize()
+    if width and height and width > 0 and height > 0 then
+      owner:setCollideRect(0, 0, width, height)
+    end
+  end
+end
+
+-- ! Has Invalid Collide Rectangle
+-- Helper to detect an invalid collide rect (nil or zero width/height)
+function RoxyPhysicsBody:_hasInvalidCollideRect(sprite)
+  local rect = sprite:getCollideRect()
+  if not rect then return true end
+  -- Playdate rect provides .width and .height
+  if rect.width == 0 or rect.height == 0 then return true end
+  return false
 end
 
 function RoxyPhysicsBody:update(dt)
-  -- (1) Integrate acceleration
+  -- Integrate acceleration
   self.vx = self.vx + self.ax * dt
   self.vy = self.vy + self.ay * dt
 
-  -- Optional polish: Apply friction if on ground and no acceleration
-  -- (Set self.friction elsewhere as needed)
+  -- Apply friction if on ground and no acceleration
   if self.onGround and self.friction then
     if abs(self.vx) > 0 then
       local sign = self.vx > 0 and 1 or -1
       local frictionForce = self.friction * dt * sign
-      -- Only zero out or reduce velocity, not reverse it
       if abs(frictionForce) > abs(self.vx) then
         self.vx = 0
       else
@@ -46,40 +74,56 @@ function RoxyPhysicsBody:update(dt)
     end
   end
 
-  -- (2) Try to move
+  -- Compute target position
   local sprite = self.owner
   local targetX, targetY = sprite.x + self.vx * dt, sprite.y + self.vy * dt
-  local _, _, collisions = sprite:moveWithCollisions(targetX, targetY)
 
   self.onGround = false
 
-  -- (3) Resolve collisions
-  for _, collision in ipairs(collisions) do
-    local nx, ny = collision.normal.x, collision.normal.y
+  -- Move: collisions if enabled and collide rect valid; else simple moveTo
+  local useCollisions = self.enableCollisions and (not self:_hasInvalidCollideRect(sprite))
+  if useCollisions then
+    local _, _, collisions = sprite:moveWithCollisions(targetX, targetY)
 
-    -- Prefer axis with largest absolute value (dominant axis)
-    if abs(ny) > abs(nx) then
-      if ny < -FLOOR_LIMIT then -- Floor
-        self.vy = 0
-        self.onGround = true
-      elseif ny > CEIL_LIMIT then -- Ceiling
-        self.vy = 0
+    -- Resolve collisions
+    for _, collision in ipairs(collisions) do
+      local nx, ny = collision.normal.x, collision.normal.y
+
+      -- Prefer axis with largest absolute value (dominant axis)
+      if abs(ny) > abs(nx) then
+        if ny < -FLOOR_LIMIT then -- Floor
+          self.vy = 0
+          self.onGround = true
+        elseif ny > CEIL_LIMIT then -- Ceiling
+          self.vy = 0
+        end
+      else
+        if abs(nx) > WALL_LIMIT then -- Wall
+          self.vx = 0
+        end
       end
-    else
-      if abs(nx) > WALL_LIMIT then -- Wall
-        self.vx = 0
+
+      -- Clamp residual velocity to avoid micro-jitter
+      if abs(self.vx) < 0.01 then self.vx = 0 end
+      if abs(self.vy) < 0.01 then self.vy = 0 end
+
+      if self.onCollision then
+        self:onCollision(collision)
       end
     end
-
-    -- Clamp residual velocity to avoid micro-jitter
+  else
+    -- No-collision path
+    sprite:moveTo(targetX, targetY)
+    -- Clamp here too so tiny velocities actually settle
     if abs(self.vx) < 0.01 then self.vx = 0 end
     if abs(self.vy) < 0.01 then self.vy = 0 end
-
-    if self.onCollision then
-      self:onCollision(collision)
-    end
   end
 
   -- Zero ax so you treat acceleration as an instant "force" per input frame
   self.ax = 0
+
+  -- Also clear ay if we’re in top-down/no-gravity mode so forces don’t accumulate.
+  if self.clearAyEachFrame then
+    self.ay = 0
+  end
 end

--- a/core/sequences/roxy_sequence.c
+++ b/core/sequences/roxy_sequence.c
@@ -146,6 +146,23 @@ static void pingPongLoop(EasingArray* ea, float* newTime, float step)
 // ! Loop Handler
 static const LoopHandler handlers[] = { noLoop, normalLoop, pingPongLoop };
 
+// ! Duplicate String
+// Safe String Duplication Helper
+static char* duplicateString(const char* source)
+{
+    if (!source) return NULL;
+
+    size_t len = strlen(source);
+    char* copy = sys->realloc(NULL, len + 1);
+    if (!copy) {
+        sys->logToConsole("Roxy ERROR: [duplicateString] Memory allocation failed for string copy.");
+        return NULL;
+    }
+
+    memcpy(copy, source, len + 1); // Copy including null terminator
+    return copy;
+}
+
 // ----------------------------------------
 //  Object Lifecycle
 // ----------------------------------------
@@ -169,6 +186,7 @@ static int easingArray_newobject(lua_State* L)
         return 0;
     }
 
+    ea->name                = NULL; // Initialize to NULL
     ea->currentTime         = 0.0f;
     ea->completed           = 0;
     ea->totalDuration       = 0.0f;
@@ -187,8 +205,15 @@ static int easingArray_gc(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (ea) {
+        // Free segments array
         if (ea->segments)
             sys->realloc(ea->segments, 0);
+
+        // Free name string
+        if (ea->name)
+            sys->realloc((void*)ea->name, 0);
+
+        // Free the EasingArray itself
         sys->realloc(ea, 0);
     }
     return 0;
@@ -263,9 +288,38 @@ static int easingArray_setName(lua_State* L)
         return 1;
     }
 
-    ea->name = lua->getArgString(2);
+    const char* newName = lua->getArgString(2);
+
+    // Free existing name if it exists
+    if (ea->name) {
+        sys->realloc((void*)ea->name, 0);
+        ea->name = NULL;
+    }
+
+    // Duplicate the new name
+    if (newName) {
+        ea->name = duplicateString(newName);
+        if (!ea->name) {
+            sys->logToConsole("Roxy ERROR: [easingArray_setName] Failed to duplicate name string.");
+            lua->pushBool(0);
+            return 1;
+        }
+    }
 
     lua->pushBool(1);
+    return 1;
+}
+
+// ! Get Name
+static int easingArray_getName(lua_State* L)
+{
+    EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
+    if (!ea || !ea->name) {
+        lua->pushNil();
+        return 1;
+    }
+
+    lua->pushString(ea->name);
     return 1;
 }
 
@@ -728,6 +782,7 @@ static const lua_reg easingArrayLib[] =
     { "__newindex",         easingArray_newindex          },
     { "__len",              easingArray_len               },
     { "setName",            easingArray_setName           },
+    { "getName",            easingArray_getName           },
     { "addEasing",          easingArray_addEasing         },
     { "from",               easingArray_from              },
     { "to",                 easingArray_to                },

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -282,6 +282,7 @@ end
 function RoxySprite:play()
   if self.animation or self.simpleAnim then
     self.isPaused = false
+    self:setUpdatesEnabled(true)  -- Enable engine updates
   end
   return self
 end
@@ -303,6 +304,7 @@ end
 function RoxySprite:pause()
   if self.animation or self.simpleAnim then
     self.isPaused = true
+    self:setUpdatesEnabled(false)  -- Disable engine updates
   end
   return self
 end
@@ -321,6 +323,7 @@ function RoxySprite:replay()
     self.simpleAnim.accumulator  = 0
   end
   self.isPaused = false
+  self:setUpdatesEnabled(true)  -- Enable engine updates
   return self
 end
 
@@ -329,6 +332,7 @@ end
 function RoxySprite:stop()
   if self.animation or self.simpleAnim then
     self.isPaused = true
+    self:setUpdatesEnabled(false)  -- Disable engine updates
     if self.animation then
       self.animation:resetAnimationStart()
     elseif self.simpleAnim then
@@ -436,8 +440,14 @@ end
 function RoxySprite:update()
   if self.isPaused then return end
 
+  -- Cache camera position once for all sprites that need it
+  local camX, camY
+  if not self._ignoresDrawOffset then
+    camX, camY = getPosition()
+  end
+
   -- Skip all animations if sprite is off-screen
-  if not self:isOnScreen() then return end
+  if not self:isOnScreenCached(camX, camY) then return end
 
   local dt = r.deltaTime or 0
 
@@ -541,25 +551,61 @@ end
 
 -- ! Is on Screen
 function RoxySprite:isOnScreen()
+  -- Direct property access instead of method calls
+  local spriteX = self.x
+  local spriteY = self.y
+  local spriteWidth = self.width
+  local spriteHeight = self.height
+
   if self._ignoresDrawOffset then
-    local x, y = self:getPosition()
-    local width, height = self:getSize()
+    -- Screen-space check (simpler case)
     return not (
-      x + width < 0 or x > DISPLAY_WIDTH or
-      y + height < 0 or y > DISPLAY_HEIGHT
+      spriteX + spriteWidth < 0 or spriteX > DISPLAY_WIDTH or
+      spriteY + spriteHeight < 0 or spriteY > DISPLAY_HEIGHT
     )
   else
-    -- Original world-space check
-    local spriteX, spriteY = self:getPosition()
-    local spriteWidth, spriteHeight = self:getSize()
-    local centerX, centerY = self:getCenter()
+    -- World-space check with camera
+    local centerX = self.centerX
+    local centerY = self.centerY
     local left = spriteX - spriteWidth * centerX
     local top = spriteY - spriteHeight * centerY
     local right = left + spriteWidth
     local bottom = top + spriteHeight
 
-    -- Get camera position (top-left corner)
+    -- Cache camera position once
     local camX, camY = getPosition()
+    return not (
+      right < camX or
+      left > camX + DISPLAY_WIDTH or
+      bottom < camY or
+      top > camY + DISPLAY_HEIGHT
+    )
+  end
+end
+
+-- ! Is on Screen (with cached camera)
+function RoxySprite:isOnScreenCached(camX, camY)
+  -- Direct property access instead of method calls
+  local spriteX = self.x
+  local spriteY = self.y
+  local spriteWidth = self.width
+  local spriteHeight = self.height
+
+  if self._ignoresDrawOffset then
+    -- Screen-space check (simpler case) - camera position irrelevant
+    return not (
+      spriteX + spriteWidth < 0 or spriteX > DISPLAY_WIDTH or
+      spriteY + spriteHeight < 0 or spriteY > DISPLAY_HEIGHT
+    )
+  else
+    -- World-space check with provided camera coordinates
+    local centerX = self.centerX
+    local centerY = self.centerY
+    local left = spriteX - spriteWidth * centerX
+    local top = spriteY - spriteHeight * centerY
+    local right = left + spriteWidth
+    local bottom = top + spriteHeight
+
     return not (
       right < camX or
       left > camX + DISPLAY_WIDTH or

--- a/core/sprites/roxy_particles.c
+++ b/core/sprites/roxy_particles.c
@@ -251,25 +251,40 @@ int roxy_particles_setImageTable_l(lua_State* L)
     ps->imageTable = tbl;
 
     if (tbl) {
-        // count frames (Lua imagetable is 1-based!)
+        // Count frames using 0-based indexing
         int count = 0;
-        while (pd->graphics->getTableBitmap(tbl, count + 1)) ++count;
+        while (pd->graphics->getTableBitmap(tbl, count)) {
+            count++;
+        }
         ps->frameCount = count;
 
-        // frameMode (already validated in Lua)
-        ps->frameMode   = (FrameMode)pd->lua->getArgInt(3);
+        // Validate frameCount to prevent division by zero
+        if (ps->frameCount <= 0) {
+            ps->imageTable = NULL;
+            ps->frameCount = 0;
+            ps->frameMode = FRAME_SEQUENTIAL;
+            ps->staticFrame = 0;
+            ps->shouldLoop = false;
+            return 0;
+        }
 
-        // staticFrame: convert from Lua's 1-based to C's 0-based
-        ps->staticFrame = pd->lua->getArgInt(4) - 1;
+        // frameMode (already validated in Lua)
+        ps->frameMode = (FrameMode)pd->lua->getArgInt(3);
+
+        // staticFrame: convert from Lua's 1-based to C's 0-based, then clamp
+        int luaStaticFrame = pd->lua->getArgInt(4);
+        ps->staticFrame = luaStaticFrame - 1;
+        if (ps->staticFrame < 0) ps->staticFrame = 0;
+        if (ps->staticFrame >= ps->frameCount) ps->staticFrame = ps->frameCount - 1;
 
         // loop flag
-        ps->shouldLoop  = pd->lua->getArgBool(5);
+        ps->shouldLoop = pd->lua->getArgBool(5);
     }
     else {
-        ps->frameCount  = 0;
-        ps->frameMode   = FRAME_SEQUENTIAL;
+        ps->frameCount = 0;
+        ps->frameMode = FRAME_SEQUENTIAL;
         ps->staticFrame = 0;
-        ps->shouldLoop  = false;
+        ps->shouldLoop = false;
     }
 
     return 0;
@@ -285,6 +300,7 @@ int roxy_particles_spawn_l(lua_State* L)
         return 1;
     }
 
+    // [Parameter reading code remains the same...]
     float lifeMin = fmaxf(0.0f, pd->lua->getArgFloat(2));
     float lifeMax = fmaxf(0.0f, pd->lua->getArgFloat(3));
     float speedMin = pd->lua->getArgFloat(4);
@@ -318,21 +334,19 @@ int roxy_particles_spawn_l(lua_State* L)
         return 1;
     }
 
-    // Grab & zero a fresh particle
     RoxyParticle* p = &ps->pool[slot];
     memset(p, 0, sizeof(RoxyParticle));
-    p->alive    = 1;
-    p->age      = 0.0f;
+    p->alive = 1;
+    p->age = 0.0f;
     p->lifetime = rand_range(lifeMin, lifeMax);
 
-    if (ps->imageTable) {
-        p->frameRate  = ps->frameRate;
+    if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
+        p->frameRate = ps->frameRate;
         p->frameTimer = 0.0f;
 
         // Pick the starting frame based on mode
         switch (ps->frameMode) {
           case FRAME_STATIC:
-            // StaticFrame is already 0-based
             p->frame = ps->staticFrame;
             break;
           case FRAME_REVERSE:
@@ -348,8 +362,8 @@ int roxy_particles_spawn_l(lua_State* L)
         }
     }
     else {
-        p->frame      = 0;
-        p->frameRate  = 0.0f;
+        p->frame = 0;
+        p->frameRate = 0.0f;
         p->frameTimer = 0.0f;
     }
 
@@ -376,17 +390,17 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
 {
     RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
     if (!ps || !ps->pool) {
-        pd->lua->pushBool(0);
+        pd->lua->pushInt(0);
         return 1;
     }
 
-    int count = pd->lua->getArgInt(2);  // Missing count parameter!
+    int count = pd->lua->getArgInt(2);
     if (count <= 0) {
-        pd->lua->pushBool(0);
+        pd->lua->pushInt(0);
         return 1;
     }
 
-    float lifeMin = fmaxf(0.0f, pd->lua->getArgFloat(3));   // Shifted indices
+    float lifeMin = fmaxf(0.0f, pd->lua->getArgFloat(3));
     float lifeMax = fmaxf(0.0f, pd->lua->getArgFloat(4));
     float speedMin = pd->lua->getArgFloat(5);
     float speedMax = pd->lua->getArgFloat(6);
@@ -411,7 +425,7 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
     float lifeRange = lifeMax - lifeMin;
     float speedRange = speedMax - speedMin;
     float sizeRange = sizeMax - sizeMin;
-    float angleRange = nAngMax - nAngMin;  // Use normalized angles
+    float angleRange = nAngMax - nAngMin;
 
     int spawned = 0;
 
@@ -428,15 +442,15 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
             break;  // No more free slots
         }
 
-        // Initialize particle (same logic as original spawn)
+        // Initialize particle
         RoxyParticle* p = &ps->pool[slot];
         memset(p, 0, sizeof(RoxyParticle));
         p->alive = 1;
         p->age = 0.0f;
         p->lifetime = lifeMin + rnd01() * lifeRange;
 
-        // Frame initialization (same logic as original spawn)
-        if (ps->imageTable) {
+        // Frame initialization with SAFETY CHECK
+        if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
             p->frameRate = ps->frameRate;
             p->frameTimer = 0.0f;
 
@@ -448,7 +462,7 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
                 p->frame = ps->frameCount - 1;
                 break;
               case FRAME_RANDOM:
-                p->frame = rand() % ps->frameCount;
+                p->frame = rand() % ps->frameCount; // Now safe from division by zero
                 break;
               case FRAME_SEQUENTIAL:
               default:
@@ -509,18 +523,21 @@ int roxy_particles_update_l(lua_State* L)
         RoxyParticle* p = &ps->pool[i];
         if (!p->alive) continue;
         hasActiveParticles = 1;
+
         p->age += dt;
         if (p->age >= p->lifetime) {
             p->alive = 0;
             p->age = 0.0f;
             continue;
         }
+
         p->vx += axdt;
         p->vy += aydt;
         p->x += p->vx * dt;
         p->y += p->vy * dt;
 
-        if (p->frameRate > 0.0f) {
+        // FrameCount validation for animation
+        if (p->frameRate > 0.0f && ps->frameCount > 0) {
             p->frameTimer += dt;
             float frameStep = 1.0f / p->frameRate;
             while (p->frameTimer >= frameStep) {
@@ -531,15 +548,15 @@ int roxy_particles_update_l(lua_State* L)
                   case FRAME_SEQUENTIAL:
                     p->frame++;
                     if (p->frame >= ps->frameCount) {
-                      if (ps->shouldLoop)        p->frame = 0;
-                      else /* Clamp at last */   p->frame = ps->frameCount - 1;
+                      if (ps->shouldLoop) p->frame = 0;
+                      else p->frame = ps->frameCount - 1;
                     }
                     break;
                   case FRAME_REVERSE:
                     p->frame--;
                     if (p->frame < 0) {
-                      if (ps->shouldLoop)        p->frame = ps->frameCount - 1;
-                      else /* Clamp at first */  p->frame = 0;
+                      if (ps->shouldLoop) p->frame = ps->frameCount - 1;
+                      else p->frame = 0;
                     }
                     break;
                   case FRAME_RANDOM:
@@ -568,17 +585,22 @@ int roxy_particles_draw_l(lua_State* L)
     int shapeID = pd->lua->getArgInt(3); // 0 = filled circle, etc
     shapeID = roxy_math_clampi(shapeID, 0, 3);
 
-    if (ps->imageTable) {
+    if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
         int frameW = 0, frameH = 0;
-        LCDBitmap *first = pd->graphics->getTableBitmap(ps->imageTable, 1);
+        // Get first frame using 0-based indexing
+        LCDBitmap *first = pd->graphics->getTableBitmap(ps->imageTable, 0);
         if (first) pd->graphics->getBitmapData(first, &frameW, &frameH, NULL, NULL, NULL);
 
         for (int i = 0; i < ps->maxCount; ++i) {
             RoxyParticle* p = &ps->pool[i];
             if (!p->alive) continue;
+
+            // Clamp frame to valid range
             int frame = p->frame;
-            if(frame < 0) frame = 0; // Guard against negatives
+            if (frame < 0) frame = 0;
             if (frame >= ps->frameCount) frame = ps->frameCount - 1;
+
+            // Use 0-based indexing for frame access
             LCDBitmap* bmp = pd->graphics->getTableBitmap(ps->imageTable, frame);
             if (bmp)
                 pd->graphics->drawBitmap(bmp, (int)(p->x - frameW/2), (int)(p->y - frameH/2), kBitmapUnflipped);
@@ -587,13 +609,11 @@ int roxy_particles_draw_l(lua_State* L)
     }
 
     // Decide once: for filled shapes use pattern ptr or solid color
-    // The C‐API fillEllipse/fillRect draw functions take an LCDColor last arg,
-    // which can be a solid‐color enum or a pointer to an 8/16-byte pattern.
     void* fillColorPtr;
     if (ps->hasPattern && (shapeID == 0 || shapeID == 2)) {
-        fillColorPtr = ps->pattern; // pointer to your 8/16 pattern bytes
+        fillColorPtr = ps->pattern;
     } else {
-        fillColorPtr = (void*)(intptr_t)color; // pass solid‐color as integer
+        fillColorPtr = (void*)(intptr_t)color;
     }
 
     for (int i = 0; i < ps->maxCount; ++i) {
@@ -609,7 +629,6 @@ int roxy_particles_draw_l(lua_State* L)
                 pd->graphics->fillEllipse(x - size/2, y - size/2, size, size, 0, 360, (LCDColor)fillColorPtr);
                 break;
             case 1: // Outlined circle
-                // outlines don't support patterns—always solid
                 pd->graphics->drawEllipse(x - size/2, y - size/2, size, size, 1, 0, 360, (LCDColor)(intptr_t)color);
                 break;
             case 2: // Filled square
@@ -618,7 +637,7 @@ int roxy_particles_draw_l(lua_State* L)
             case 3: // Outlined square
                 pd->graphics->drawRect(x - size/2, y - size/2, size, size, (LCDColor)(intptr_t)color);
                 break;
-            default: // Fallback to filled circle
+            default:
                 pd->graphics->fillEllipse(x - size/2, y - size/2, size, size, 0, 360, (LCDColor)fillColorPtr);
                 break;
         }

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -46,6 +46,15 @@ local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+local TilemapHelpers          <const> = r.TilemapHelpers
+local visibleLayerRect        <const> = TilemapHelpers.visibleLayerRect
+local chunkIndicesForRect     <const> = TilemapHelpers.chunkIndicesForRect
+local findFirstAvailableLayer <const> = TilemapHelpers.findFirstAvailableLayer
+local sanitizeTileIndex       <const> = TilemapHelpers.sanitizeTileIndex
+local sanitizeTilesInPlace    <const> = TilemapHelpers.sanitizeTilesInPlace
+local syncNativeTiles         <const> = TilemapHelpers.syncNativeTiles
+local dequeueBestWarmJob      <const> = TilemapHelpers.dequeueBestWarmJob
+
 -- C-side bindings
 local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
 
@@ -63,113 +72,6 @@ local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 
 local COLOR_CLEAR <const> = Graphics.kColorClear
-
---------------------------------------------------------------------------------
--- Helpers
---------------------------------------------------------------------------------
-
--- ! Helper: Visible Layer Rectangle
--- Compute visible layer-space rect
-local function _visibleLayerRect(self, layer)
-  local screenX, screenY = self:worldToScreen(0, 0, layer)
-  -- The screen shows [0..width, 0..height] which corresponds to
-  -- layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
-  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
-end
-
--- ! Helper: Chunk Indices for Rect
--- Which chunk indices intersect a pixel rect?
-local function _chunkIndicesForRect(x, y, width, height, size)
-  local minChunkX = floor(x / size)
-  local maxChunkX = floor((x + width  - 1) / size)
-  local minChunkY = floor(y / size)
-  local maxChunkY = floor((y + height - 1) / size)
-  return minChunkX, maxChunkX, minChunkY, maxChunkY
-end
-
--- ! Helper: Find First Available Layer
-local function _findFirstAvailableLayer(layers)
-  for _, layer in pairs(layers or {}) do
-    if layer.tilemap then return layer end
-  end
-  return nil
-end
-
--- ! Helper: Pack Tiles U16
--- Pack tiles as little-endian uint16 with clamping
-local function _packTilesU16(tiles)
-  if not tiles or #tiles == 0 then return nil end
-  local n = #tiles
-  local format = stringRep("<I2", n)
-  local temp = {}
-  for i = 1, n do
-    local v = tiles[i] or 0
-    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
-    temp[i] = v
-  end
-  return stringPack(format, tableUnpack(temp, 1, n))
-end
-
--- ! Helper: Sanitize a single tile index
--- Returns 0 for out-of-range/invalid, else the original index (1..imageCount)
-local function _sanitizeTileIndex(tileIndex, imageCount)
-  if tileIndex == nil or type(tileIndex) ~= "number" then return 0 end
-  if tileIndex == 0 then return 0 end
-  if tileIndex < 1 or (imageCount and tileIndex > imageCount) then return 0 end
-  return tileIndex
-end
-
--- ! Helper: Sanitize tiles in place
--- Ensures every tile is 0 or in [1..imageCount]
-local function _sanitizeTilesInPlace(tiles, imageCount)
-  if not tiles then return end
-  for i = 1, #tiles do
-    tiles[i] = _sanitizeTileIndex(tiles[i], imageCount)
-  end
-end
-
--- ! Helper: Sync Native Tiles
--- Sync native tiles from current tilesFlat
-local function _syncNativeTiles(layerData)
-  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then return end
-  local blob = _packTilesU16(layerData.tilesFlat)
-  if blob then
-    layerData._nativeRenderer:updateTilesBytes(blob)
-    local selfRef = layerData.ownerTilemap
-    if selfRef then selfRef._frameDirty = true end
-  end
-end
-
--- ! Helper: Warm Score
--- Warm queue prioritization helper (closest chunk to visible center)
-local function _warmScore(self, job)
-  local layerConfig = job.layerConfig
-  local size = layerConfig.size
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerConfig.layer)
-  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
-  local centerX = (minX + maxX) * 0.5
-  local centerY = (minY + maxY) * 0.5
-  local dx = abs(job.chunkX - centerX)
-  local dy = abs(job.chunkY - centerY)
-  return dx + dy -- Manhattan distance is cheap and good enough
-end
-
--- ! Helper: Dequeue Best Warm Job
-local function _dequeueBestWarmJob(self)
-  local queue = self._warmQueue
-  local bestIndex, bestScore
-  for idx = 1, #queue do
-    local score = _warmScore(self, queue[idx])
-    if not bestScore or score < bestScore then
-      bestScore, bestIndex = score, idx
-    end
-  end
-  if not bestIndex then return nil end
-  local job = queue[bestIndex]
-  tableRemove(queue, bestIndex)
-  self._warmSet[job.key] = nil
-  return job
-end
 
 --------------------------------------------------------------------------------
 -- ! Class Definition / Initialize
@@ -249,7 +151,7 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
       -- Create native renderer instance for this layer
       if layerData.imageTable and newTileRenderer_C then
         -- Sanitize tiles once on load so the native blob never sees out-of-range values
-        _sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+        sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
 
         local isIsometric = 1
         local staggerIndexOdd = 0
@@ -278,7 +180,7 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
           nil                       -- Optional tiles blob
         )
         layerData.ownerTilemap = self
-        _syncNativeTiles(layerData)
+        syncNativeTiles(layerData)
       end
     end
   end
@@ -334,10 +236,10 @@ function RoxyIsoTilemap:_primeVisibleChunks()
     local layer = layerConfig.layer
     local size, overlap = layerConfig.size, layerConfig.overlap
 
-    local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+    local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layer)
     visibleX -= overlap; visibleY -= overlap; visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-    local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    local minX, maxX, minY, maxY = chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
     for chunkY = minY, maxY do
       for chunkX = minX, maxX do
         local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
@@ -393,7 +295,7 @@ end
 function RoxyIsoTilemap:_warmSomeChunks()
   local built = 0
   while built < BUILD_BUDGET and #self._warmQueue > 0 do
-    local job = _dequeueBestWarmJob(self) -- Pick closest
+    local job = dequeueBestWarmJob(self) -- Pick closest
     if not job then break end
     if not getIsAssetCached(self._globalChunkBucket, job.key) then
       local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
@@ -442,14 +344,14 @@ end
 function RoxyIsoTilemap:_enqueueRing(layerData, layerConfig)
   local size, overlap = layerConfig.size, layerConfig.overlap
 
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layerData)
   visibleX -= (overlap + size * PREFETCH_RINGS)
   visibleY -= (overlap + size * PREFETCH_RINGS)
   visibleWidth  += 2 * (overlap + size * PREFETCH_RINGS)
   visibleHeight += 2 * (overlap + size * PREFETCH_RINGS)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
 
   -- Skip if ring bounds didn't change
   local last = layerConfig._lastRingBounds
@@ -573,11 +475,11 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   local size, overlap = layerConfig.size, layerConfig.overlap
 
   -- Visible rect in layer coords, padded by overlap.
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+  local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layer)
   visibleX -= overlap; visibleY -= overlap
   visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local minX, maxX, minY, maxY = chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
 
   -- First pass — scan for any missing chunks and enqueue builds.
@@ -702,7 +604,7 @@ function RoxyIsoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     return
   end
 
-  local cleanIndex = _sanitizeTileIndex(tileIndex, layer.imageCount)
+  local cleanIndex = sanitizeTileIndex(tileIndex, layer.imageCount)
 
   layer.tilemap:setTileAtPosition(x, y, cleanIndex)
 
@@ -737,7 +639,7 @@ end
 function RoxyIsoTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
-    targetLayer = _findFirstAvailableLayer(self.layers)
+    targetLayer = findFirstAvailableLayer(self.layers)
     if not targetLayer then return 1 end
   end
 
@@ -768,7 +670,7 @@ function RoxyIsoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, 
   local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
+    chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
   for chunkY = minChunkY, maxChunkY do
     for chunkX = minChunkX, maxChunkX do
       evictAsset(self._globalChunkBucket, layerConfig.keyPrefix .. chunkX .. ":" .. chunkY)

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -31,6 +31,11 @@ local getOrLoadAsset  <const> = Cache.getOrLoadAsset
 local evictAsset      <const> = Cache.evictAsset
 local clearCache      <const> = Cache.clearCache
 
+local TilemapHelpers          <const> = r.TilemapHelpers
+local visibleLayerRect        <const> = TilemapHelpers.visibleLayerRect
+local chunkIndicesForRect     <const> = TilemapHelpers.chunkIndicesForRect
+local findFirstAvailableLayer <const> = TilemapHelpers.findFirstAvailableLayer
+
 -- Default chunk settings
 local DEFAULT_CHUNK_SIZE    <const> = 320
 local DEFAULT_CHUNK_CACHE   <const> = 200
@@ -44,31 +49,6 @@ local COLOR_CLEAR <const> = Graphics.kColorClear
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
-
--- ! Helper: Visible Layer Rectangle
--- Compute visible layer-space rectangle (pixels), factoring parallax/camera.
-local function _visibleLayerRect(self, layerData)
-  local screenX, screenY = self:worldToScreen(0, 0, layerData)
-  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
-end
-
--- ! Helper: Chunk Indices For Rect
--- Which chunk indices intersect a pixel rect?
-local function _chunkIndicesForRect(x, y, width, height, size)
-  local minChunkX = floor(x / size)
-  local maxChunkX = floor((x + width  - 1) / size)
-  local minChunkY = floor(y / size)
-  local maxChunkY = floor((y + height - 1) / size)
-  return minChunkX, maxChunkX, minChunkY, maxChunkY
-end
-
--- ! Helper: Find First Available Layer
-local function _findFirstAvailableLayer(layers)
-  for _, layerData in pairs(layers or {}) do
-    if layerData.tilemap then return layerData end
-  end
-  return nil
-end
 
 -- ! Helper: Render Layer Region To Buffer
 -- Render a rectangular region of the layer directly into the given buffer.
@@ -197,12 +177,12 @@ function RoxyOrthoTilemap:_drawStaticLayerChunked(layerName)
   local size, overlap = cfg.size, cfg.overlap
 
   -- Visible rect in layer coordinates (inflate by overlap)
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layerData)
   visibleX -= overlap; visibleY -= overlap
   visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
 
   -- Top-left screen position of layer pixel (0,0)
   local screenX, screenY = self:worldToScreen(0, 0, layerData)
@@ -309,7 +289,7 @@ end
 function RoxyOrthoTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
-    targetLayer = _findFirstAvailableLayer(self.layers)
+    targetLayer = findFirstAvailableLayer(self.layers)
     if not targetLayer then return 1 end
   end
 
@@ -338,7 +318,7 @@ function RoxyOrthoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth
   local pixelHeight = (tileCountHeight or 1) * tileHeight
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, config.size)
+    chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, config.size)
 
   for chunkY = minChunkY, maxChunkY do
     for chunkX = minChunkX, maxChunkX do

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -46,6 +46,15 @@ local _isoDrawOffsets   <const> = RoxyTilemap._isoDrawOffsets
 local _beginManualDraw  <const> = RoxyTilemap._beginManualDraw
 local _endManualDraw    <const> = RoxyTilemap._endManualDraw
 
+local TilemapHelpers          <const> = r.TilemapHelpers
+local visibleLayerRect        <const> = TilemapHelpers.visibleLayerRect
+local chunkIndicesForRect     <const> = TilemapHelpers.chunkIndicesForRect
+local findFirstAvailableLayer <const> = TilemapHelpers.findFirstAvailableLayer
+local sanitizeTileIndex       <const> = TilemapHelpers.sanitizeTileIndex
+local sanitizeTilesInPlace    <const> = TilemapHelpers.sanitizeTilesInPlace
+local syncNativeTiles         <const> = TilemapHelpers.syncNativeTiles
+local dequeueBestWarmJob      <const> = TilemapHelpers.dequeueBestWarmJob
+
 -- C-side bindings
 local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
 
@@ -91,109 +100,6 @@ local function _rowShiftX_for_row0(self, row0, halfWidth)
   return (direction == "right") and halfWidth or -halfWidth
 end
 
--- ! Helper: Visible Layer Rectangle
--- Compute visible layer-space rect
-local function _visibleLayerRect(self, layer)
-  local screenX, screenY = self:worldToScreen(0, 0, layer)
-  -- The screen shows [0..width, 0..height] which corresponds to
-  -- layer pixels [-screenX..-screenX+width, -screenY..-screenY+height]
-  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
-end
-
--- ! Helper: Chunk Indices for Rect
--- Which chunk indices intersect a pixel rect?
-local function _chunkIndicesForRect(x, y, width, height, size)
-  local minChunkX = floor(x / size)
-  local maxChunkX = floor((x + width  - 1) / size)
-  local minChunkY = floor(y / size)
-  local maxChunkY = floor((y + height - 1) / size)
-  return minChunkX, maxChunkX, minChunkY, maxChunkY
-end
-
--- ! Helper: Find First Available Layer
-local function _findFirstAvailableLayer(layers)
-  for _, layer in pairs(layers or {}) do
-    if layer.tilemap then return layer end
-  end
-  return nil
-end
-
--- ! Helper: Pack Tiles U16
--- Pack tiles as little-endian uint16 with clamping
-local function _packTilesU16(tiles)
-  if not tiles or #tiles == 0 then return nil end
-  local n = #tiles
-  local format = stringRep("<I2", n)
-  local temp = {}
-  for i = 1, n do
-    local v = tiles[i] or 0
-    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
-    temp[i] = v
-  end
-  return stringPack(format, tableUnpack(temp, 1, n))
-end
-
--- ! Helper: Sanitize a single tile index
--- Returns 0 for out-of-range/invalid, else the original index (1..imageCount)
-local function _sanitizeTileIndex(tileIndex, imageCount)
-  if tileIndex == nil or type(tileIndex) ~= "number" then return 0 end
-  if tileIndex == 0 then return 0 end
-  if tileIndex < 1 or (imageCount and tileIndex > imageCount) then return 0 end
-  return tileIndex
-end
-
--- ! Helper: Sanitize tiles in place
--- Ensures every tile is 0 or in [1..imageCount]
-local function _sanitizeTilesInPlace(tiles, imageCount)
-  if not tiles then return end
-  for i = 1, #tiles do
-    tiles[i] = _sanitizeTileIndex(tiles[i], imageCount)
-  end
-end
-
--- ! Helper: Sync Native Tiles
--- Sync native tiles from current tilesFlat
-local function _syncNativeTiles(layerData)
-  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then return end
-  local blob = _packTilesU16(layerData.tilesFlat)
-  if blob then
-    layerData._nativeRenderer:updateTilesBytes(blob)
-    local selfRef = layerData.ownerTilemap
-    if selfRef then selfRef._frameDirty = true end
-  end
-end
-
--- ! Helper: Warm Score
--- Warm queue prioritization helper (closest chunk to visible center)
-local function _warmScore(self, job)
-  local layerConfig = job.layerConfig
-  local size = layerConfig.size
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerConfig.layer)
-  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
-  local centerX = (minX + maxX) * 0.5
-  local centerY = (minY + maxY) * 0.5
-  local dx = abs(job.chunkX - centerX)
-  local dy = abs(job.chunkY - centerY)
-  return dx + dy -- Manhattan distance is cheap and good enough
-end
-
--- ! Helper: Dequeue Best Warm Job
-local function _dequeueBestWarmJob(self)
-  local queue = self._warmQueue
-  local bestIndex, bestScore
-  for idx = 1, #queue do
-    local score = _warmScore(self, queue[idx])
-    if not bestScore or score < bestScore then
-      bestScore, bestIndex = score, idx
-    end
-  end
-  if not bestIndex then return nil end
-  local job = queue[bestIndex]
-  tableRemove(queue, bestIndex)
-  self._warmSet[job.key] = nil
-  return job
-end
-
 --------------------------------------------------------------------------------
 -- ! Class Definition / Initialize
 --------------------------------------------------------------------------------
@@ -205,6 +111,9 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   opts.wrapInSprites = false
   opts.anchor = "topLeft"
   RoxyStagTilemap.super.init(self, jsonPath, opts, scene)
+
+  -- Scratch reused across frames to avoid allocations in _drawStaticLayerChunked
+  self._scratchToDraw = {} -- { {img=..., dx=..., dy=...}, ... }
 
   -- Override world size for staggered-y projection
   local mapWidthTiles   = self.mapWidth  or 0
@@ -274,7 +183,7 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
       -- Create native renderer instance for this layer
       if layerData.imageTable and newTileRenderer_C then
         -- Sanitize tiles once on load so the native blob never sees out-of-range values
-        _sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+        sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
 
         local isIsometric = 0
         local staggerIndexOdd = (self.staggerIndex == "odd") and 1 or 0
@@ -303,7 +212,7 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
           nil                       -- Optional tiles blob
         )
         layerData.ownerTilemap = self
-        _syncNativeTiles(layerData)
+        syncNativeTiles(layerData)
       end
     end
   end
@@ -330,7 +239,8 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
   for layerName, layer in pairs(self.layers) do
     local layerOpts = layerOptions[layerName] or {}
     if layerOpts.preRenderChunked then
-      local halfWidth = layer.halfWidth or floor((layer.tileWidth or DEFAULT_TILE_WIDTH) * 0.5)
+      local tileWidth = layer.tileWidth or 0
+      local halfWidth = layer.halfWidth or floor(tileWidth * 0.5)
 
       local tallOverdraw = 0
       if layer.maxImageHeight and layer.tileHeight then
@@ -338,14 +248,17 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
       end
 
       local overlap = layerOpts.overlapPx or max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+      local size    = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE)
 
       self._staticChunkLayers[layerName] = {
         name      = layerName,
         layer     = layer,
-        size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
+        size      = size,
         overlap   = overlap,
         keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
-        _dirty    = true, -- Per-layer dirty bit
+        _dirty    = true,
+        imageWidth  = size + 2 * overlap,
+        imageHeight = size + 2 * overlap,
       }
     end
   end
@@ -359,10 +272,10 @@ function RoxyStagTilemap:_primeVisibleChunks()
     local layer = layerConfig.layer
     local size, overlap = layerConfig.size, layerConfig.overlap
 
-    local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+    local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layer)
     visibleX -= overlap; visibleY -= overlap; visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-    local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    local minX, maxX, minY, maxY = chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
     for chunkY = minY, maxY do
       for chunkX = minX, maxX do
         local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
@@ -418,7 +331,7 @@ end
 function RoxyStagTilemap:_warmSomeChunks()
   local built = 0
   while built < BUILD_BUDGET and #self._warmQueue > 0 do
-    local job = _dequeueBestWarmJob(self) -- Pick closest
+    local job = dequeueBestWarmJob(self)
     if not job then break end
     if not getIsAssetCached(self._globalChunkBucket, job.key) then
       local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
@@ -431,6 +344,8 @@ function RoxyStagTilemap:_warmSomeChunks()
 
   if built > 0 then
     self._frameDirty = true
+    -- Ensure at least one redraw even if camera is stationary
+    self._forceDrawFrames = max(self._forceDrawFrames or 0, 1)
   end
 end
 
@@ -467,14 +382,14 @@ end
 function RoxyStagTilemap:_enqueueRing(layerData, layerConfig)
   local size, overlap = layerConfig.size, layerConfig.overlap
 
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layerData)
+  local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layerData)
   visibleX -= (overlap + size * PREFETCH_RINGS)
   visibleY -= (overlap + size * PREFETCH_RINGS)
   visibleWidth  += 2 * (overlap + size * PREFETCH_RINGS)
   visibleHeight += 2 * (overlap + size * PREFETCH_RINGS)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+    chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
 
   -- Skip if ring bounds didn't change
   local last = layerConfig._lastRingBounds
@@ -517,7 +432,8 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
-  local function rowShiftX(row0) return (row0 % 2 == 0) and 0 or halfWidth end
+  -- Respect stagger axis/index/direction like the fast path
+  local function rowShiftX(row0) return _rowShiftX_for_row0(self, row0, halfWidth) end
 
   local maxImageHeight = layerData.maxImageHeight or 0
   local overdrawRows = ceil(max(0, maxImageHeight - tileHeight) / max(1, halfHeight)) + 1 -- Safety +1
@@ -594,17 +510,19 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
   local size, overlap = layerConfig.size, layerConfig.overlap
 
   -- Visible rect in layer coords, padded by overlap.
-  local visibleX, visibleY, visibleWidth, visibleHeight = _visibleLayerRect(self, layer)
+  local visibleX, visibleY, visibleWidth, visibleHeight = visibleLayerRect(self, layer)
   visibleX -= overlap; visibleY -= overlap
   visibleWidth += 2 * overlap; visibleHeight += 2 * overlap
 
-  local minX, maxX, minY, maxY = _chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  local minX, maxX, minY, maxY = chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
   local screenX, screenY = self:worldToScreen(0, 0, layer)
 
   -- First pass — scan for any missing chunks and enqueue builds.
   local anyMissing = false
-  local toDraw = {} -- {img, dx, dy, imageWidth, imageHeight}
-  local imageWidth, imageHeight = size + 2 * overlap, size + 2 * overlap
+  local toDraw = self._scratchToDraw
+  local count = 0
+
+  local imageWidth, imageHeight = layerConfig.imageWidth, layerConfig.imageHeight
 
   for chunkY = minY, maxY do
     local rowDeltaY = chunkY * size - overlap + screenY
@@ -614,9 +532,14 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
       if img then
         local dx = chunkX * size - overlap + screenX
         local dy = rowDeltaY
-        -- Offscreen culling
         if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
-          toDraw[#toDraw + 1] = { img = img, dx = dx, dy = dy } -- ints already
+          count += 1
+          local slot = toDraw[count]
+          if slot then
+            slot.img, slot.dx, slot.dy = img, dx, dy
+          else
+            toDraw[count] = { img = img, dx = dx, dy = dy }
+          end
         end
       else
         anyMissing = true
@@ -626,20 +549,20 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
   end
 
   if anyMissing then
-    -- Single-pass fallback — render the layer once (native rows or Lua), not per-miss.
-    -- Clip to screen to be safe.
     setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
       self:drawLayerRows(layerName, nil, nil, nil, nil)
     clearClipRect()
+    -- Trim scratch table length for next frame
+    for i = count + 1, #toDraw do toDraw[i] = nil end
     return
   end
 
-  -- All chunks available — draw them.
-  for index = 1, #toDraw do
-    local element = toDraw[index]
-    -- dx/dy are already integers; removed floor() for tiny win.
-    element.img:draw(element.dx, element.dy)
+  for i = 1, count do
+    local e = toDraw[i]
+    e.img:draw(e.dx, e.dy)
   end
+  -- Trim for next frame
+  for i = count + 1, #toDraw do toDraw[i] = nil end
 end
 
 --
@@ -654,7 +577,9 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
 
   local originX, originY = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
-  local cameraX, cameraY = getCameraPosition()
+
+  local cameraX = self._cameraX ~= nil and self._cameraX or select(1, getCameraPosition())
+  local cameraY = self._cameraY ~= nil and self._cameraY or select(2, getCameraPosition())
 
   local row0 = floor(worldY + FLOAT_EPSILON)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
@@ -679,7 +604,9 @@ function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
 
   local originX, originY = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
-  local cameraX, cameraY = getCameraPosition()
+
+  local cameraX = self._cameraX ~= nil and self._cameraX or select(1, getCameraPosition())
+  local cameraY = self._cameraY ~= nil and self._cameraY or select(2, getCameraPosition())
 
   local parallaxOriginX = layerData.parallaxoriginx or 0
   local parallaxOriginY = layerData.parallaxoriginy or 0
@@ -729,7 +656,7 @@ function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     return
   end
 
-  local cleanIndex = _sanitizeTileIndex(tileIndex, layer.imageCount)
+  local cleanIndex = sanitizeTileIndex(tileIndex, layer.imageCount)
 
   layer.tilemap:setTileAtPosition(x, y, cleanIndex)
 
@@ -764,22 +691,7 @@ end
 function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
   local targetLayer = self.layers and self.layers[layerName]
   if not targetLayer then
-    targetLayer = _findFirstAvailableLayer(self.layers)
-    if not targetLayer then return 1 end
-  end
-
-  local _, mapHeightTiles = targetLayer.tilemap:getSize()
-  local _, worldY = self:screenToWorld(screenX, screenY, targetLayer)
-  local row = floor(worldY + 1)
-  if row < 1 then row = 1 elseif row > mapHeightTiles then row = mapHeightTiles end
-  return row
-end
-
--- ! Get Row From Screen
-function RoxyStagTilemap:getRowFromScreen(screenX, screenY, layerName)
-  local targetLayer = self.layers and self.layers[layerName]
-  if not targetLayer then
-    targetLayer = _findFirstAvailableLayer(self.layers)
+    targetLayer = findFirstAvailableLayer(self.layers)
     if not targetLayer then return 1 end
   end
 
@@ -810,7 +722,7 @@ function RoxyStagTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth,
   local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
-    _chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
+    chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
   for chunkY = minChunkY, maxChunkY do
     for chunkX = minChunkX, maxChunkX do
       evictAsset(self._globalChunkBucket, layerConfig.keyPrefix .. chunkX .. ":" .. chunkY)
@@ -873,6 +785,8 @@ function RoxyStagTilemap:drawVisible()
     self._forceDrawFrames -= 1
   end
 
+  self._cameraX, self._cameraY = cameraX, cameraY
+
   self:_primeVisibleChunks()
 
   local ordered = self._orderedLayers
@@ -887,6 +801,9 @@ function RoxyStagTilemap:drawVisible()
   end
 
   self:_warmSomeChunks()
+
+  -- Clear camera cache after use
+  self._cameraX, self._cameraY = nil, nil
 end
 
 -- ! Draw Visible in Rectangle

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -1,6 +1,7 @@
 -- core/tilemaps/RoxyTilemap.lua
 
 import "libraries/roxy/core/tilemaps/ObjectLayerProcessor"
+import "libraries/roxy/core/tilemaps/TilemapHelpers"
 import "libraries/roxy/core/tilemaps/LayerManager"
 
 local pd        <const> = playdate
@@ -34,6 +35,8 @@ local getImagetable   <const> = AssetStore.getImagetable
 local setCameraBounds   <const> = Camera.setBounds
 
 local ObjectLayerProcessor  <const> = r.ObjectLayerProcessor
+local processObjectLayer    <const> = ObjectLayerProcessor.processObjectLayer
+local processObjectLayers   <const> = ObjectLayerProcessor.processObjectLayers
 
 local IMAGE_PATH_PREFIX <const> = "assets/images/"
 
@@ -481,7 +484,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
     for _, layer in ipairs(mapData.layers or {}) do
       if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
         local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or EMPTY_TABLE
-        local sprites = ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
+        local sprites = processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
         objectSprites[layer.name] = sprites
       end
     end
@@ -625,7 +628,7 @@ function RoxyTilemap:processObjectLayers(layersToProcess, autoAdd, scene)
   local outSprites = self.sprites or {}
 
   -- Correct argument order: self first, then mapLike, then opts, etc.
-  local processed = ObjectLayerProcessor.processObjectLayers(self, mapLike, opts, layersToProcess, useAutoAdd, scene, sceneHasAdd, outSprites)
+  local processed = processObjectLayers(self, mapLike, opts, layersToProcess, useAutoAdd, scene, sceneHasAdd, outSprites)
 
   self.sprites = outSprites
   return processed

--- a/core/tilemaps/TilemapHelpers.lua
+++ b/core/tilemaps/TilemapHelpers.lua
@@ -1,0 +1,121 @@
+-- core/tilemaps/TilemapHelpers.lua
+
+roxy = roxy or {}
+roxy.TilemapHelpers = roxy.TilemapHelpers or {}
+local TilemapHelpers <const> = roxy.TilemapHelpers
+
+local r <const> = roxy
+
+local floor <const> = math.floor
+local abs   <const> = math.abs
+
+local stringRep   <const> = string.rep
+local stringPack  <const> = string.pack
+
+local tableUnpack <const> = table.unpack
+local tableRemove <const> = table.remove
+
+local DISPLAY_WIDTH  <const> = r.Graphics.displayWidth
+local DISPLAY_HEIGHT <const> = r.Graphics.displayHeight
+
+-- ! Visible Layer Rectangle
+-- Compute visible layer-space rect
+function TilemapHelpers.visibleLayerRect(self, layer)
+  local screenX, screenY = self:worldToScreen(0, 0, layer)
+  return floor(-screenX), floor(-screenY), DISPLAY_WIDTH, DISPLAY_HEIGHT
+end
+
+-- ! Chunk Indices for Rect
+-- Which chunk indices intersect a pixel rect?
+function TilemapHelpers.chunkIndicesForRect(x, y, width, height, size)
+  local minChunkX = floor(x / size)
+  local maxChunkX = floor((x + width  - 1) / size)
+  local minChunkY = floor(y / size)
+  local maxChunkY = floor((y + height - 1) / size)
+  return minChunkX, maxChunkX, minChunkY, maxChunkY
+end
+
+-- ! Find First Available Layer
+function TilemapHelpers.findFirstAvailableLayer(layers)
+  for _, layer in pairs(layers or {}) do
+    if layer.tilemap then return layer end
+  end
+  return nil
+end
+
+-- ! Pack Tiles U16
+-- Pack tiles as little-endian uint16 with clamping
+function TilemapHelpers.packTilesU16(tiles)
+  if not tiles or #tiles == 0 then return nil end
+  local n = #tiles
+  local format = stringRep("<I2", n)
+  local temp = {}
+  for i = 1, n do
+    local v = tiles[i] or 0
+    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
+    temp[i] = v
+  end
+  return stringPack(format, tableUnpack(temp, 1, n))
+end
+
+-- ! Sanitize a single tile index
+-- Returns 0 for out-of-range/invalid, else the original index (1..imageCount)
+function TilemapHelpers.sanitizeTileIndex(tileIndex, imageCount)
+  if tileIndex == nil or type(tileIndex) ~= "number" then return 0 end
+  if tileIndex == 0 then return 0 end
+  if tileIndex < 1 or (imageCount and tileIndex > imageCount) then return 0 end
+  return tileIndex
+end
+
+-- ! Sanitize tiles in place
+-- Ensures every tile is 0 or in [1..imageCount]
+function TilemapHelpers.sanitizeTilesInPlace(tiles, imageCount)
+  if not tiles then return end
+  for i = 1, #tiles do
+    tiles[i] = TilemapHelpers.sanitizeTileIndex(tiles[i], imageCount)
+  end
+end
+
+-- ! Sync Native Tiles
+-- Sync native tiles from current tilesFlat
+function TilemapHelpers.syncNativeTiles(layerData)
+  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then
+return end
+  local blob = TilemapHelpers.packTilesU16(layerData.tilesFlat)
+  if blob then
+    layerData._nativeRenderer:updateTilesBytes(blob)
+    local selfRef = layerData.ownerTilemap
+    if selfRef then selfRef._frameDirty = true end
+  end
+end
+
+-- ! Warm Score
+-- Warm queue prioritization helper (closest chunk to visible center)
+function TilemapHelpers.warmScore(self, job)
+  local layerConfig = job.layerConfig
+  local size = layerConfig.size
+  local visibleX, visibleY, visibleWidth, visibleHeight = TilemapHelpers.visibleLayerRect(self, layerConfig.layer)
+  local minX, maxX, minY, maxY = TilemapHelpers.chunkIndicesForRect(visibleX, visibleY,visibleWidth, visibleHeight, size)
+  local centerX = (minX + maxX) * 0.5
+  local centerY = (minY + maxY) * 0.5
+  local dx = abs(job.chunkX - centerX)
+  local dy = abs(job.chunkY - centerY)
+  return dx + dy -- Manhattan distance is cheap and good enough
+end
+
+-- ! Dequeue Best Warm Job
+function TilemapHelpers.dequeueBestWarmJob(self)
+  local queue = self._warmQueue
+  local bestIndex, bestScore
+  for i = 1, #queue do
+    local score = TilemapHelpers.warmScore(self, queue[i])
+    if not bestScore or score < bestScore then
+      bestScore, bestIndex = score, i
+    end
+  end
+  if not bestIndex then return nil end
+  local job = queue[bestIndex]
+  tableRemove(queue, bestIndex)
+  self._warmSet[job.key] = nil
+  return job
+end

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -174,8 +174,14 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     tileRenderer->offsetX[0] = tileRenderer->offsetY[0] = 0;
 
     for (int i = 1; i <= tileRenderer->imageCount; ++i) {
-        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, i - 1);
-        if (!cell) { tileRenderer->offsetX[i] = 0; tileRenderer->offsetY[i] = 0; continue; }
+        // Convert 1-based tile index to 0-based bitmap table index
+        const int bitmapIndex = i - 1;
+        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
+        if (!cell) {
+            tileRenderer->offsetX[i] = 0;
+            tileRenderer->offsetY[i] = 0;
+            continue;
+        }
         int imageWidth = 0, imageHeight = 0;
         pd->graphics->getBitmapData(cell, &imageWidth, &imageHeight, NULL, NULL, NULL);
         const int16_t offsetX = (int16_t)((tileRenderer->tileWidth  - imageWidth) / 2);
@@ -307,12 +313,14 @@ static int roxy_tileRenderer_setTileAt(lua_State* L)
 // core draw for a single tile (shared)
 static inline void drawCell(const RoxyTileRendererC* tileRenderer, int tileIndex, int sx, int sy)
 {
-    // Guard tileRenderer
+    // Guard tileRenderer and validate tileIndex range
     if (!tileRenderer || tileIndex <= 0 || tileIndex > tileRenderer->imageCount) return;
     // Extra safety
     if (!pd || !pd->graphics || !tileRenderer->imageTable) return;
 
-    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, tileIndex - 1);
+    // Convert 1-based tile index to 0-based bitmap table index
+    const int bitmapIndex = tileIndex - 1;
+    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
     if (!cell) return;
 
     const int dx = sx + safeOffsetX(tileRenderer, tileIndex);
@@ -460,7 +468,9 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
                         const int dx = drawX + safeOffsetX(tileRenderer, currentTileIndex);
                         const int dy = baseY + safeOffsetY(tileRenderer, currentTileIndex);
                         if (dx < bufferWidth && dy < bufferHeight && dx > -tileRenderer->tileWidth && dy > -tileRenderer->tileHeight) {
-                            LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                            // Convert 1-based tile index to 0-based bitmap table index
+                            const int bitmapIndex = currentTileIndex - 1;
+                            LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
                             if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
                         }
                     }
@@ -491,7 +501,9 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
                     const int drawX = screenX + safeOffsetX(tileRenderer, currentTileIndex);
                     const int drawY = screenY + safeOffsetY(tileRenderer, currentTileIndex);
                     if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileRenderer->tileWidth && drawY > -tileRenderer->tileHeight) {
-                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, currentTileIndex - 1);
+                        // Convert 1-based tile index to 0-based bitmap table index
+                        const int bitmapIndex = currentTileIndex - 1;
+                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
                         if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
                     }
                 }

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -141,6 +141,16 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         return 0;
     }
 
+    // Validate tile dimensions to prevent division-by-zero
+    if (tileRenderer->tileWidth <= 0 || tileRenderer->tileHeight <= 0 ||
+        tileRenderer->halfTileWidth <= 0 || tileRenderer->halfTileHeight <= 0) {
+        pd->system->logToConsole("RoxyTileRendererC.new: invalid tile dimensions (tileWidth=%d, tileHeight=%d, halfTileWidth=%d, halfTileHeight=%d)",
+                                 tileRenderer->tileWidth, tileRenderer->tileHeight,
+                                 tileRenderer->halfTileWidth, tileRenderer->halfTileHeight);
+        pd_free(tileRenderer);
+        return 0;
+    }
+
     // Imagetable
     LuaUDObject* userDataObject = NULL;
     tileRenderer->imageTable = pd->lua->getArgObject(11, "playdate.graphics.imagetable", &userDataObject);
@@ -403,6 +413,13 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     const int offsetY = pd->lua->getArgInt(4);
     const int bufferWidth = pd->lua->getArgInt(5);
     const int bufferHeight = pd->lua->getArgInt(6);
+
+    // Defensive check to prevent division-by-zero
+    if (tileRenderer->tileWidth <= 0 || tileRenderer->halfTileHeight <= 0 ||
+        tileRenderer->halfTileWidth <= 0) {
+        pd->system->logToConsole("renderToBuffer: invalid tile dimensions, cannot render");
+        return 0;
+    }
 
     int contextPushed = 0;
     if (targetBitmap) {

--- a/utilities/roxy_ease.c
+++ b/utilities/roxy_ease.c
@@ -42,6 +42,12 @@
 
 static PlaydateAPI* pd = NULL;
 
+// Zero-duration early-out macro
+// Returns the start value at t <= 0, else the end value (b + c).
+// This avoids division by zero without mutating 'd' or changing behavior when d>0.
+#define ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d) \
+do { if (__builtin_expect((d) <= 0.0f, 0)) return ((t) <= 0.0f ? (b) : ((b) + (c))); } while (0)
+
 static EaseFunction s_easingFunctions[] = {
     roxy_ease_flat,                 //  0
     roxy_ease_linear,               //  1
@@ -116,22 +122,26 @@ float roxy_ease_evaluate(
     float paramA,
     float paramB
 ){
-    // (1) total counts
-    int normalCount   = sizeof(s_easingFunctions) / sizeof(s_easingFunctions[0]); // e.g. 34
-    int elasticCount  = sizeof(s_elasticFunctions) / sizeof(s_elasticFunctions[0]); // 4
-    int backCount     = sizeof(s_backFunctions) / sizeof(s_backFunctions[0]);       // 4
-    int maxIndex      = normalCount + elasticCount + backCount - 1; // e.g. 41
+    // Early-out for zero/negative duration
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
 
-    // (2) clamp index
+    // Total counts
+    int normalCount = sizeof(s_easingFunctions) / sizeof(s_easingFunctions[0]); // e.g. 34
+    int elasticCount = sizeof(s_elasticFunctions) / sizeof(s_elasticFunctions[0]); // 4
+    int backCount = sizeof(s_backFunctions) / sizeof(s_backFunctions[0]); // 4
+    int maxIndex = normalCount + elasticCount + backCount - 1; // e.g. 41
+
+    // Clamp index
     if (index < 0 || index > maxIndex) {
         index = 1; // default to linear
     }
 
-    // (3) pick which array
-    // normal range e.g. 0..29 and 38..41
+    // Pick which array
+    // Normal range e.g. 0..29 and 38..41
     if ((index < 30) || (index >= 38 && index <= 41)) {
-        // Normal
-        EaseFunction fn = s_easingFunctions[index];
+        // Map bounce 38..41 to physical 30..33
+        int idx = (index >= 38) ? (index - 8) : index; // Fix for bounce indices
+        EaseFunction fn = s_easingFunctions[idx];
         return fn(t, b, c, d);
     }
     else if (index >= 30 && index <= 33) {
@@ -153,18 +163,21 @@ float roxy_ease_evaluate(
 // ! Flat
 float roxy_ease_flat(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return b;
 }
 
 // ! Linear
 float roxy_ease_linear(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return c * t / d + b;
 }
 
 // ! InQuad
 float roxy_ease_in_quad(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return c * t * t + b;
 }
@@ -172,6 +185,7 @@ float roxy_ease_in_quad(float t, float b, float c, float d)
 // ! OutQuad
 float roxy_ease_out_quad(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return -c * t * (t - 2) + b;
 }
@@ -179,6 +193,7 @@ float roxy_ease_out_quad(float t, float b, float c, float d)
 // ! InOutQuad
 float roxy_ease_in_out_quad(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d * 2;
     if (t < 1) {
         return c / 2 * t * t + b;
@@ -191,6 +206,7 @@ float roxy_ease_in_out_quad(float t, float b, float c, float d)
 // ! OutInQuad
 float roxy_ease_out_in_quad(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_quad(t * 2, b, c / 2, d);
     } else {
@@ -201,6 +217,7 @@ float roxy_ease_out_in_quad(float t, float b, float c, float d)
 // ! InCubic
 float roxy_ease_in_cubic(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return c * t * t * t + b;
 }
@@ -208,6 +225,7 @@ float roxy_ease_in_cubic(float t, float b, float c, float d)
 // ! OutCubic
 float roxy_ease_out_cubic(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d - 1;
     return c * (t * t * t + 1) + b;
 }
@@ -215,6 +233,7 @@ float roxy_ease_out_cubic(float t, float b, float c, float d)
 // ! InOutCubic
 float roxy_ease_in_out_cubic(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d * 2;
     if (t < 1) {
         return c / 2 * t * t * t + b;
@@ -227,6 +246,7 @@ float roxy_ease_in_out_cubic(float t, float b, float c, float d)
 // ! OutInCubic
 float roxy_ease_out_in_cubic(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_cubic(t * 2, b, c / 2, d);
     } else {
@@ -237,6 +257,7 @@ float roxy_ease_out_in_cubic(float t, float b, float c, float d)
 // ! InQuart
 float roxy_ease_in_quart(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return c * t * t * t * t + b;
 }
@@ -244,6 +265,7 @@ float roxy_ease_in_quart(float t, float b, float c, float d)
 // ! OutQuart
 float roxy_ease_out_quart(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d - 1;
     return -c * (t * t * t * t - 1) + b;
 }
@@ -251,6 +273,7 @@ float roxy_ease_out_quart(float t, float b, float c, float d)
 // ! InOutQuart
 float roxy_ease_in_out_quart(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d * 2;
     if (t < 1) {
         return c / 2 * t * t * t * t + b;
@@ -263,6 +286,7 @@ float roxy_ease_in_out_quart(float t, float b, float c, float d)
 // ! OutInQuart
 float roxy_ease_out_in_quart(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_quart(t * 2, b, c / 2, d);
     } else {
@@ -273,6 +297,7 @@ float roxy_ease_out_in_quart(float t, float b, float c, float d)
 // ! InQuint
 float roxy_ease_in_quint(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return c * t * t * t * t * t + b;
 }
@@ -280,6 +305,7 @@ float roxy_ease_in_quint(float t, float b, float c, float d)
 // ! OutQuint
 float roxy_ease_out_quint(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d - 1;
     return c * (t * t * t * t * t + 1) + b;
 }
@@ -287,6 +313,7 @@ float roxy_ease_out_quint(float t, float b, float c, float d)
 // ! InOutQuint
 float roxy_ease_in_out_quint(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d * 2;
     if (t < 1) {
         return c / 2 * t * t * t * t * t + b;
@@ -299,6 +326,7 @@ float roxy_ease_in_out_quint(float t, float b, float c, float d)
 // ! OutInQuint
 float roxy_ease_out_in_quint(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_quint(t * 2, b, c / 2, d);
     } else {
@@ -309,24 +337,28 @@ float roxy_ease_out_in_quint(float t, float b, float c, float d)
 // ! InSine
 float roxy_ease_in_sine(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return -c * cosf(t / d * ((float)M_PI / 2)) + c + b;
 }
 
 // ! OutSine
 float roxy_ease_out_sine(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return c * sinf(t / d * ((float)M_PI / 2)) + b;
 }
 
 // ! InOutSine
 float roxy_ease_in_out_sine(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return -c / 2 * (cosf((float)M_PI * t / d) - 1) + b;
 }
 
 // ! OutInSine
 float roxy_ease_out_in_sine(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_sine(t * 2, b, c / 2, d);
     } else {
@@ -337,6 +369,7 @@ float roxy_ease_out_in_sine(float t, float b, float c, float d)
 // ! InExpo
 float roxy_ease_in_expo(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == 0) return b;
     return c * powf(2, 10 * (t / d - 1)) + b - c * 0.001f;
 }
@@ -344,6 +377,7 @@ float roxy_ease_in_expo(float t, float b, float c, float d)
 // ! OutExpo
 float roxy_ease_out_expo(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == d) return b + c;
     return c * 1.001f * (1 - powf(2, -10 * t / d)) + b;
 }
@@ -351,6 +385,7 @@ float roxy_ease_out_expo(float t, float b, float c, float d)
 // ! InOutExpo
 float roxy_ease_in_out_expo(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == 0) return b;
     if (t == d) return b + c;
     t = t / d * 2;
@@ -365,6 +400,7 @@ float roxy_ease_in_out_expo(float t, float b, float c, float d)
 // ! OutInExpo
 float roxy_ease_out_in_expo(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_expo(t * 2, b, c / 2, d);
     } else {
@@ -375,6 +411,7 @@ float roxy_ease_out_in_expo(float t, float b, float c, float d)
 // ! InCirc
 float roxy_ease_in_circ(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     return -c * (sqrtf(1 - t * t) - 1) + b;
 }
@@ -382,6 +419,7 @@ float roxy_ease_in_circ(float t, float b, float c, float d)
 // ! OutCirc
 float roxy_ease_out_circ(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d - 1;
     return c * sqrtf(1 - t * t) + b;
 }
@@ -389,6 +427,7 @@ float roxy_ease_out_circ(float t, float b, float c, float d)
 // ! InOutCirc
 float roxy_ease_in_out_circ(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d * 2;
     if (t < 1) {
         return -c / 2 * (sqrtf(1 - t * t) - 1) + b;
@@ -401,6 +440,7 @@ float roxy_ease_in_out_circ(float t, float b, float c, float d)
 // ! OutInCirc
 float roxy_ease_out_in_circ(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_circ(t * 2, b, c / 2, d);
     } else {
@@ -411,6 +451,7 @@ float roxy_ease_out_in_circ(float t, float b, float c, float d)
 // ! InElastic
 float roxy_ease_in_elastic(float t, float b, float c, float d, float a, float p)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == 0) return b;
     t = t / d;
     if (t == 1) return b + c;
@@ -429,6 +470,7 @@ float roxy_ease_in_elastic(float t, float b, float c, float d, float a, float p)
 // ! OutElastic
 float roxy_ease_out_elastic(float t, float b, float c, float d, float a, float p)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == 0) return b;
     t = t / d;
     if (t == 1) return b + c;
@@ -446,6 +488,7 @@ float roxy_ease_out_elastic(float t, float b, float c, float d, float a, float p
 // ! InOutElastic
 float roxy_ease_in_out_elastic(float t, float b, float c, float d, float a, float p)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t == 0) return b;
     t = t / d * 2;
     if (t == 2) return b + c;
@@ -470,6 +513,7 @@ float roxy_ease_in_out_elastic(float t, float b, float c, float d, float a, floa
 // ! OutInElastic
 float roxy_ease_out_in_elastic(float t, float b, float c, float d, float a, float p)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_elastic(t * 2, b, c / 2, d, a, p);
     } else {
@@ -480,6 +524,7 @@ float roxy_ease_out_in_elastic(float t, float b, float c, float d, float a, floa
 // ! InBack
 float roxy_ease_in_back(float t, float b, float c, float d, float s)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (!s) s = 1.70158f;
     t = t / d;
     return c * t * t * ((s + 1) * t - s) + b;
@@ -488,6 +533,7 @@ float roxy_ease_in_back(float t, float b, float c, float d, float s)
 // ! OutBack
 float roxy_ease_out_back(float t, float b, float c, float d, float s)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (!s) s = 1.70158f;
     t = t / d - 1;
     return c * (t * t * ((s + 1) * t + s) + 1) + b;
@@ -496,6 +542,7 @@ float roxy_ease_out_back(float t, float b, float c, float d, float s)
 // ! InOutBack
 float roxy_ease_in_out_back(float t, float b, float c, float d, float s)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (!s) s = 1.70158f;
     s = s * 1.525f;
     t = t / d * 2;
@@ -510,6 +557,7 @@ float roxy_ease_in_out_back(float t, float b, float c, float d, float s)
 // ! OutInBack
 float roxy_ease_out_in_back(float t, float b, float c, float d, float s)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_back(t * 2, b, c / 2, d, s);
     } else {
@@ -520,6 +568,7 @@ float roxy_ease_out_in_back(float t, float b, float c, float d, float s)
 // ! OutBounce
 float roxy_ease_out_bounce(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     t = t / d;
     if (t < 1 / 2.75f) {
         return c * (7.5625f * t * t) + b;
@@ -538,12 +587,14 @@ float roxy_ease_out_bounce(float t, float b, float c, float d)
 // ! InBounce
 float roxy_ease_in_bounce(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     return c - roxy_ease_out_bounce(d - t, 0, c, d) + b;
 }
 
 // ! InOutBounce
 float roxy_ease_in_out_bounce(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_in_bounce(t * 2, 0, c, d) * 0.5f + b;
     } else {
@@ -554,6 +605,7 @@ float roxy_ease_in_out_bounce(float t, float b, float c, float d)
 // ! OutInBounce
 float roxy_ease_out_in_bounce(float t, float b, float c, float d)
 {
+    ROXY_EASE_EARLY_OUT_ZERO_DUR(t, b, c, d);
     if (t < d / 2) {
         return roxy_ease_out_bounce(t * 2, b, c / 2, d);
     } else {

--- a/utilities/roxy_math.c
+++ b/utilities/roxy_math.c
@@ -99,13 +99,17 @@ float roxy_math_lerp(float min, float max, float t)
 // ! Map
 // Maps a value from one range to another
 float roxy_math_map(float value, float fromLow, float fromHigh, float toLow, float toHigh) {
+    if (fromHigh == fromLow) {
+        /* Guard against division by zero: when the source range is empty,
+           we map everything to the start of the target range. */
+        return toLow;
+    }
     return (value - fromLow) / (fromHigh - fromLow) * (toHigh - toLow) + toLow;
 }
 
 // ----------------------------------------
 // ! Lua-Exposed Functions
 // ----------------------------------------
-
 
 int roxy_math_truncateDecimal_l(lua_State* L)
 {


### PR DESCRIPTION
### Overview
This release strengthens engine stability by guarding against division-by-zero errors across graphics, animations, particles, utilities, and easing functions. It introduces new physics body flags for top-down gameplay, sequence naming support, and consolidates tilemap utilities into a shared `TilemapHelpers` module. Several performance improvements and breaking API adjustments are included.

### Key Changes
- **Physics**
  - Added `enableCollisions` and `autoSetCollideRect` flags for flexible collision handling
  - Introduced `clearAyEachFrame` to support top-down physics (gravity-free)
  - Automatically sets collide rect based on sprite size when missing

- **Sequences**
  - Added `setName` / `getName` APIs for easing arrays with safe string duplication and cleanup
  - Allows descriptive identifiers for debugging and workflow organization

- **Graphics**
  - Defensive validation of tile dimensions to prevent division-by-zero in tile renderer
  - Normalized imagetable indexing to 0-based internally with explicit range validation
  - Early return safeguards for invalid indices in renderer paths

- **Animations**
  - Clamped `frameDuration` to positive values to prevent crashes in updates

- **Particles**
  - Validated imagetable frame counts across spawn/update/draw
  - Converted `spawnMultiple` to return integer count instead of boolean
  - Enforced safe 0-based indexing with clamping to prevent memory errors

- **Sprites**
  - Cached camera position and gated updates for `RoxySprite`
  - Skipped off-screen animations and redundant per-frame work for performance

- **Utilities**
  - Added guards against zero-duration easing and corrected bounce easing index mapping
  - Protected `roxy_math_map` against zero-length ranges

- **Tilemaps**
  - Extracted common utilities into new `TilemapHelpers` module
  - Updated `RoxyTilemap`, `RoxyOrthoTilemap`, `RoxyIsoTilemap`, and `RoxyStagTilemap` to use shared helpers
  - Reduced code duplication, improved readability, and added scratch-table/camera caching optimizations in `RoxyStagTilemap`

### Breaking Changes
- **Particles**
  - `spawnMultiple` now returns integer count instead of boolean
    - Update conditional checks from `if spawnMultiple(...) then` → `if spawnMultiple(...) > 0 then`
  - Imagetable frames are now 0-based internally; invalid `staticFrame` values clamp to valid defaults

- **Utilities**
  - Corrected easing indices 38–41 to map to proper bounce functions
    - Projects relying on old incorrect mapping will see changed behavior
  - Zero/negative duration easing now clamps to stable results instead of crashing

### Challenges/Notes
- Investigating a difficult heap corruption issue that is challenging to reproduce and diagnose. Working through potential fixes to isolate the root cause. The crash has been observed in certain Roxy-based games when the Playdate device samples Lua or C code.