### PR TITLE
[0.14.4] - HeapGuard Integration, Sequencer Refactor, and Particle System Overhaul

### DIFF
--- a/core/modules/Debug.lua
+++ b/core/modules/Debug.lua
@@ -6,6 +6,18 @@ roxy = roxy or {}
 local Debug = roxy.Debug or {}
 roxy.Debug = Debug
 
+local max   <const> = math.max
+local floor <const> = math.floor
+
+local performAfterDelay <const> = pd.timer.performAfterDelay
+
+local c_heapGuardVerifyAll  <const> = roxy.heapGuardVerifyAll
+local c_heapGuardDumpActive <const> = roxy.heapGuardDumpActive
+local c_heapGuardSnap       <const> = roxy.heapGuardSnap
+
+local HG_ON = (type(c_heapGuardVerifyAll) == "function")
+Debug.heapGuardEnabled = HG_ON
+
 local debugCheckingEnabled = false
 local debugChecksActive    = false
 
@@ -15,16 +27,16 @@ Debug.visualDebug = false
 -- Store original Playdate SDK functions for tamper detection
 local debugFunctions = {}
 local function captureOriginalFunctions()
-  debugFunctions.update         = pd.update
-  debugFunctions.crankDocked    = pd.crankDocked
-  debugFunctions.crankUndocked  = pd.crankUndocked
-  debugFunctions.gameWillPause  = pd.gameWillPause
+  debugFunctions.update = pd.update
+  debugFunctions.crankDocked = pd.crankDocked
+  debugFunctions.crankUndocked = pd.crankUndocked
+  debugFunctions.gameWillPause = pd.gameWillPause
   debugFunctions.gameWillResume = pd.gameWillResume
 end
 
--- ----------------------------------------
--- Visual‑debug toggles
--- ----------------------------------------
+--------------------------------------------------------------------------------
+-- Visual‑Debug Toggles
+--------------------------------------------------------------------------------
 
 -- ! Enable Visual Debug
 function Debug.enableVisualDebug()
@@ -46,9 +58,42 @@ function Debug.toggleVisualDebug()
   end)
 end
 
--- ----------------------------------------
--- Debug checking lifecycle
--- ----------------------------------------
+--------------------------------------------------------------------------------
+-- Heap Guard Helpers
+--------------------------------------------------------------------------------
+
+-- ! Heap Guard Verify All
+function Debug.heapGuardVerify()
+  if HG_ON then c_heapGuardVerifyAll() end
+end
+
+-- ! Heap Guard Dump Active
+function Debug.heapGuardDump()
+  if HG_ON then c_heapGuardDumpActive() end
+end
+
+-- ! Heap Guard Snap
+function Debug.heapGuardSnap(tag)
+  if HG_ON then c_heapGuardSnap(tag) end
+end
+
+-- ! Heap Guard Verify For (Frames)
+-- Verify for N frames without touching pd.update
+function Debug.heapGuardVerifyFor(frames)
+  if not HG_ON then return end
+  local n = max(1, floor(frames or 60))
+  local function tick()
+    if n <= 0 then return end
+    c_heapGuardVerifyAll()
+    n = n - 1
+    performAfterDelay(0, tick) -- Schedule next frame
+  end
+  tick()
+end
+
+--------------------------------------------------------------------------------
+-- Debug Checking Lifecycle
+--------------------------------------------------------------------------------
 
 -- ! Enable Debug Checking
 function Debug.enableDebugChecking()
@@ -89,16 +134,16 @@ end
 function Debug.disableDebugChecking()
   if debugCheckingEnabled then
     debugCheckingEnabled = false
-    debugChecksActive    = false
+    debugChecksActive = false
     Log.info("Debug checking disabled.")
   else
     Log.warn("[Debug.disableDebugChecking] Debug checking was not enabled.")
   end
 end
 
--- ----------------------------------------
--- Runtime check Implementation
--- ----------------------------------------
+--------------------------------------------------------------------------------
+-- Runtime Check Implementation
+--------------------------------------------------------------------------------
 
 -- ! Check
 local function check(funcRef, original, name)
@@ -114,11 +159,11 @@ function Debug.runChecks()
     return
   end
   if debugChecksActive then
-    check(pd.update,        debugFunctions.update,        "playdate.update")
-    check(pd.crankDocked,   debugFunctions.crankDocked,   "playdate.crankDocked")
+    check(pd.update, debugFunctions.update, "playdate.update")
+    check(pd.crankDocked, debugFunctions.crankDocked, "playdate.crankDocked")
     check(pd.crankUndocked, debugFunctions.crankUndocked, "playdate.crankUndocked")
     check(pd.gameWillPause, debugFunctions.gameWillPause, "playdate.gameWillPause")
-    check(pd.gameWillResume,debugFunctions.gameWillResume,"playdate.gameWillResume")
+    check(pd.gameWillResume, debugFunctions.gameWillResume, "playdate.gameWillResume")
   end
 end
 

--- a/core/sequences/roxy_sequence.c
+++ b/core/sequences/roxy_sequence.c
@@ -1,4 +1,6 @@
-/*
+// core/sequences/roxy_sequence.c
+
+/**
  *
  * Adapted from Nic Magnier's Sequence library.
  * (https://github.com/NicMagnier/PlaydateSequence)
@@ -8,11 +10,18 @@
 #include "roxy_sequence.h"
 #include "../../utilities/roxy_ease.h"
 #include "../../utilities/roxy_math.h"
+#include "../../utilities/roxy_heapguard.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <limits.h>
 #include <math.h>
 
-static PlaydateAPI* pd                = NULL;
+static PlaydateAPI* pd = NULL;
 static const struct playdate_lua* lua = NULL;
 static const struct playdate_sys* sys = NULL;
+
+static float boundaryTimeForCompletion(const EasingArray* ea);
 
 #define INITIAL_CAPACITY 8
 
@@ -20,67 +29,25 @@ static const float DEFAULT_DURATION    = 0.04f;
 static const int DEFAULT_EASE_FUNCTION = 1; // Linear
 static const int DEFAULT_REPEAT_COUNT  = 1;
 
-// ! Easing Segment Struct
-typedef struct
-{
-    float timestamp;
-    float from;
-    float to;
-    float duration;
-    float endTime;
-    int easeFunction;
-} EasingSegment;
-
-// ! Easing Array Struct
-typedef struct
-{
-    const char* name;
-    int count;
-    int capacity;
-    EasingSegment* segments;
-    float currentTime;
-    int completed;          // 1 = finished, 0 = running
-    float totalDuration;
-    int loopType;
-    float loopCount;
-    float loopCounter;
-    int pingPongHalfCycles; // Tracks half-cycles (forward or backward flip)
-    int isForward;          // 1 = moving forward, 0 = moving backward
-} EasingArray;
-
-typedef void (*LoopHandler)(EasingArray*, float*, float);
-
-// ----------------------------------------
-// Helpers
-// ----------------------------------------
-
-// ! Add Segment Helper Macro
-//  Allocate and initialize a new EasingSegment in the array.
-#define ADD_SEGMENT(ea, ts, fr, t, dur, ef) \
-do { \
-    EasingSegment* seg = ensureCapacityAndInsert(ea); \
-    if (!seg) { \
-        sys->logToConsole("Roxy ERROR: [ADD_SEGMENT] Memory allocation failed resizing EasingArray."); \
-        lua->pushObject(ea, "RoxySequenceC", 0); \
-        return 1; \
-    } \
-    seg->timestamp = (ts); \
-    seg->from = (fr); \
-    seg->to = (t); \
-    seg->duration = (dur); \
-    seg->endTime = (ts) + (dur); \
-    seg->easeFunction = (ef); \
-} while (0)
+/*******************************************//**
+ *  Helpers
+ ***********************************************/
 
 // ! Ensure Capacity and Insert
 static EasingSegment* ensureCapacityAndInsert(EasingArray* ea)
 {
     if (ea->count == ea->capacity) {
         int newCap = ea->capacity * 2;
-        EasingSegment* newPtr = sys->realloc(ea->segments, newCap * sizeof(EasingSegment));
+        // overflow guard
+        if ((size_t)newCap > (SIZE_MAX / sizeof(EasingSegment))) return NULL;
+
+        EasingSegment* newPtr = (EasingSegment*)roxy_realloc(
+            ea->segments, (size_t)newCap * sizeof(EasingSegment));
         if (!newPtr) return NULL;
+
         ea->segments = newPtr;
         ea->capacity = newCap;
+        ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
     }
     // Return pointer to the next slot, but also increment
     EasingSegment* seg = &ea->segments[ea->count];
@@ -103,43 +70,68 @@ static void noLoop(EasingArray* ea, float* newTime, float step)
 // ! Normal Loop
 static void normalLoop(EasingArray* ea, float* newTime, float step)
 {
-    *newTime += step;
-    if (*newTime >= ea->totalDuration) {
-        ea->loopCounter++;
-        if (ea->loopCount > 0 && ea->loopCounter >= ea->loopCount) {
-            *newTime = ea->totalDuration;
-            ea->completed = 1;
-        } else {
-            while (*newTime >= ea->totalDuration) *newTime -= ea->totalDuration;
-        }
-    } else if (*newTime < 0.0f) {
-        while (*newTime < 0.0f) *newTime += ea->totalDuration;
+    ea->completed = 0;
+    if (ea->totalDuration <= 0.0f) { *newTime = 0.0f; ea->completed = 1; return; }
+
+    // Clip the positive step so we exactly consume the remaining budget.
+    float applied = step;
+    if (step > 0.0f && ea->loopCount > 0.0f) {
+        float maxDist = ea->loopCount * ea->totalDuration;
+        float remain  = maxDist - ea->travelAccum;
+        if (remain <= 0.0f) { *newTime = boundaryTimeForCompletion(ea); ea->completed = 1; return; }
+        if (applied > remain) applied = remain;
+    }
+
+    // Apply wrapped motion
+    float t = *newTime + applied;
+    if (t >= ea->totalDuration) {
+        t = fmodf(t, ea->totalDuration);
+    } else if (t < 0.0f) {
+        float q = fmodf(-t, ea->totalDuration);
+        t = (q == 0.0f) ? 0.0f : (ea->totalDuration - q);
+    }
+    *newTime = t;
+
+    if (step > 0.0f) ea->travelAccum += applied;
+    if (ea->loopCount > 0.0f && ea->travelAccum >= ea->loopCount * ea->totalDuration - 1e-6f) {
+        *newTime = boundaryTimeForCompletion(ea);
+        ea->completed = 1;
     }
 }
 
 // ! Ping Pong Loop
 static void pingPongLoop(EasingArray* ea, float* newTime, float step)
 {
-    float dt = step;
-    if (ea->isForward) *newTime += dt;
-    else *newTime -= dt;
-    if (*newTime > ea->totalDuration) {
-        float overshoot = *newTime - ea->totalDuration;
-        *newTime = ea->totalDuration - overshoot;
-        ea->isForward = 0;
-        ea->pingPongHalfCycles++;
-    } else if (*newTime < 0.0f) {
-        float overshoot = -*newTime;
-        *newTime = overshoot;
-        ea->isForward = 1;
-        ea->pingPongHalfCycles++;
+    if (ea->totalDuration <= 0.0f) { *newTime = 0.0f; ea->completed = 1; return; }
+
+    float D = ea->totalDuration;
+    float period = 2.0f * D;
+
+    // Clip the positive step so we exactly consume the remaining ping-pong budget.
+    float applied = step;
+    if (step > 0.0f && ea->loopCount > 0.0f) {
+        float maxDist = ea->loopCount * period; // Distance along the ping-pong path
+        float remain  = maxDist - ea->travelAccum;
+        if (remain <= 0.0f) { *newTime = boundaryTimeForCompletion(ea); ea->completed = 1; return; }
+        if (applied > remain) applied = remain;
     }
-    if (ea->loopCount > 0) {
-        int totalHalfCycles = (int)(ea->loopCount * 2 + 0.5f); // Round up for safety
-        if (ea->pingPongHalfCycles >= totalHalfCycles) {
-            *newTime = (totalHalfCycles & 1) ? ea->totalDuration : 0.0f; // Bitwise odd/even
-            ea->completed = 1;
-        }
+
+    // Unfold current state into a linear "phase" s in [0, 2D)
+    float s = ea->isForward ? *newTime : (period - *newTime);
+    s += applied; // Positive step always advances along the path; negative rewinds
+
+    // Wrap s into [0, 2D)
+    s = fmodf(s, period);
+    if (s < 0.0f) s += period;
+
+    // Fold back to [0, D] and update direction bit
+    if (s <= D) { *newTime = s; ea->isForward = 1; }
+    else        { *newTime = period - s; ea->isForward = 0; }
+
+    if (step > 0.0f) ea->travelAccum += applied;
+    if (ea->loopCount > 0.0f && ea->travelAccum >= ea->loopCount * period - 1e-6f) {
+        *newTime = boundaryTimeForCompletion(ea);
+        ea->completed = 1;
     }
 }
 
@@ -153,48 +145,148 @@ static char* duplicateString(const char* source)
     if (!source) return NULL;
 
     size_t len = strlen(source);
-    char* copy = sys->realloc(NULL, len + 1);
+    char* copy = (char*)roxy_malloc(len + 1);
     if (!copy) {
         sys->logToConsole("Roxy ERROR: [duplicateString] Memory allocation failed for string copy.");
         return NULL;
     }
 
-    memcpy(copy, source, len + 1); // Copy including null terminator
+    roxy_memcpy(copy, source, len + 1); // Includes NULL
+    ROXY_LABEL(copy, "RoxySequenceC.name");
     return copy;
 }
 
-// ----------------------------------------
-//  Object Lifecycle
-// ----------------------------------------
+// ! Evaluate At Time
+// Evaluate value at an absolute time (uses same search logic as getValue)
+static float evalAtTime(const EasingArray* ea, float t)
+{
+    if (!ea || ea->count == 0) return 0.0f;
+
+    float clamped = roxy_math_clamp(t, 0.0f, ea->totalDuration);
+    int last = ea->count - 1;
+    if (clamped >= ea->segments[last].endTime) return ea->segments[last].to;
+
+    const EasingSegment* easing = NULL;
+
+    if (!ea->isSorted) {
+        for (int i = 0; i < ea->count; ++i) {
+            const EasingSegment* seg = &ea->segments[i];
+            if (clamped >= seg->timestamp && clamped <= seg->endTime) { easing = seg; break; }
+        }
+    } else if (ea->count <= 4) {
+        for (int i = 0; i < ea->count; ++i) {
+            const EasingSegment* seg = &ea->segments[i];
+            if (clamped >= seg->timestamp && clamped <= seg->endTime) { easing = seg; break; }
+        }
+    } else {
+        int left = 0, right = last;
+        while (left <= right) {
+            int mid = left + (right - left) / 2;
+            const EasingSegment* seg = &ea->segments[mid];
+            if (clamped >= seg->timestamp && clamped <= seg->endTime) { easing = seg; break; }
+            if (clamped < seg->timestamp) right = mid - 1; else left = mid + 1;
+        }
+    }
+
+    if (!easing)
+        easing = (clamped < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[last];
+
+    if (easing->duration <= 0.0f) return easing->to;
+
+    float timeOffset = clamped - easing->timestamp;
+
+    // Direction-aware evaluation for ping-pong:
+    if (ea->loopType == 2 && !ea->isForward) {
+        float reverseTimeOffset = easing->duration - timeOffset; // Reverse time
+        return roxy_ease_evaluate(
+            easing->easeFunction,
+            reverseTimeOffset,
+            easing->to,                   // Swap endpoints
+            (easing->from - easing->to),
+            easing->duration,
+            0.0f, 0.0f
+        );
+    }
+
+    // Forward (or normal loop/no loop) evaluation
+    return roxy_ease_evaluate(
+        easing->easeFunction,
+        timeOffset,
+        easing->from,
+        (easing->to - easing->from),
+        easing->duration,
+        0.0f, 0.0f
+    );
+}
+
+// Compute the correct boundary time when the sequence is completed.
+// For ping-pong we map fractional half-cycles onto [0, D] <-> [D, 0].
+// For normal loops we finish at frac(loopCount) * D. For "no loop" clamp to end.
+static float boundaryTimeForCompletion(const EasingArray* ea)
+{
+    if (ea->loopType == 2 && ea->loopCount > 0.0f) {
+        float D = ea->totalDuration;
+        float H = ea->loopCount * 2.0f;     // Half-cycles
+        float hf = H - floorf(H);           // Fractional half-cycle
+        int parity = ((int)floorf(H)) & 1;  // 0=fwd, 1=back
+        return (parity == 0) ? (hf * D) : (D - hf * D);
+    }
+    if (ea->loopType == 1 && ea->loopCount > 0.0f && ea->totalDuration > 0.0f) {
+        float D = ea->totalDuration;
+        float loops = ea->loopCount;
+        float whole;
+        float frac = modff(loops, &whole);  // Split into integer + fractional part
+        if (frac <= 1e-6f) return D;        // Exact (or near-exact) integer --> end at D
+        return frac * D;                    // Fractional loops --> partial progress
+    }
+    // No-loop or infinite loops: clamp to end
+    return ea->totalDuration;
+}
+
+/*******************************************//**
+ *  Object Lifecycle
+ ***********************************************/
 
 // ! New Easing Array
 static int easingArray_newobject(lua_State* L)
 {
-    EasingArray* ea = sys->realloc(NULL, sizeof(EasingArray));
+    EasingArray* ea = (EasingArray*)roxy_malloc(sizeof(EasingArray));
     if (!ea) {
-        sys->logToConsole("Roxy ERROR: [easingArray_newobject] Memory allocation failed for EasingArray.");
+        sys->logToConsole("Roxy ERROR: [easingArray_newobject] Allocation failed for EasingArray.");
         return 0;
     }
+    ROXY_LABEL(ea, "RoxySequenceC");
 
     ea->count     = 0;
     ea->capacity  = INITIAL_CAPACITY;
-    ea->segments  = sys->realloc(NULL, sizeof(EasingSegment) * ea->capacity);
 
-    if (!ea->segments) {
-        sys->logToConsole("Roxy ERROR: [easingArray_newobject] Memory allocation failed for EasingArray segments.");
-        sys->realloc(ea, 0);
+    // Overflow guard
+    if ((size_t)ea->capacity > (SIZE_MAX / sizeof(EasingSegment))) {
+        roxy_free(ea);
+        sys->logToConsole("Roxy ERROR: [easingArray_newobject] Capacity overflow.");
         return 0;
     }
+
+    ea->segments  = (EasingSegment*)roxy_malloc((size_t)ea->capacity * sizeof(EasingSegment));
+    if (!ea->segments) {
+        sys->logToConsole("Roxy ERROR: [easingArray_newobject] Allocation failed for EasingArray segments.");
+        roxy_free(ea);
+        return 0;
+    }
+    ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
+    roxy_memset(ea->segments, 0, (size_t)ea->capacity * sizeof(EasingSegment));
 
     ea->name                = NULL; // Initialize to NULL
     ea->currentTime         = 0.0f;
     ea->completed           = 0;
     ea->totalDuration       = 0.0f;
     ea->loopType            = 0;
-    ea->loopCount           = 0;
+    ea->loopCount           = 0.0f;
+    ea->travelAccum         = 0.0f;
     ea->loopCounter         = 0;
     ea->pingPongHalfCycles  = 0;
     ea->isForward           = 1;
+    ea->isSorted            = 1;
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
@@ -205,68 +297,39 @@ static int easingArray_gc(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (ea) {
-        // Free segments array
-        if (ea->segments)
-            sys->realloc(ea->segments, 0);
-
-        // Free name string
-        if (ea->name)
-            sys->realloc((void*)ea->name, 0);
-
-        // Free the EasingArray itself
-        sys->realloc(ea, 0);
+        if (ea->segments) roxy_free(ea->segments);
+        if (ea->name)     roxy_free((void*)ea->name);
+        roxy_free(ea);
     }
     return 0;
 }
 
-// ----------------------------------------
-// Metamethod
-// ----------------------------------------
+/*******************************************//**
+ *  Metamethod
+ ***********************************************/
 
 // ! Easing Array Index
 static int easingArray_index(lua_State* L)
 {
-    // If this is an index into the class's table, return the result
-    if (lua->indexMetatable())
-        return 1;
+    if (lua->indexMetatable()) return 1;
 
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     int idx = lua->getArgInt(2);
-    if (ea && idx > 0 && idx <= ea->count) {
-        EasingSegment* seg = &ea->segments[idx - 1];
-        lua->pushFloat(seg->timestamp);
-        lua->pushFloat(seg->from);
-        lua->pushFloat(seg->to);
-        lua->pushFloat(seg->duration);
-        lua->pushFloat(seg->endTime);
-        lua->pushInt(seg->easeFunction);
-        return 6;
-    }
-    return 0;
-}
-
-// ! Easing Array New Index
-static int easingArray_newindex(lua_State* L)
-{
-    EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    int idx = lua->getArgInt(2);
-    if (!ea || idx <= 0 || idx > ea->count)
-        return 0;
+    if (!ea || idx <= 0 || idx > ea->count) { lua->pushNil(); return 1; }
 
     EasingSegment* seg = &ea->segments[idx - 1];
-    seg->timestamp    = lua->getArgFloat(3);
-    seg->from         = lua->getArgFloat(4);
-    seg->to           = lua->getArgFloat(5);
-    seg->duration     = lua->getArgFloat(6);
-    seg->endTime      = seg->timestamp + seg->duration;
-    seg->easeFunction = lua->getArgInt(7);
-    return 0;
+    lua->pushFloat(seg->timestamp);
+    lua->pushFloat(seg->from);
+    lua->pushFloat(seg->to);
+    lua->pushFloat(seg->duration);
+    lua->pushFloat(seg->endTime);
+    lua->pushInt(seg->easeFunction);
+    return 6;
 }
 
 // ! Easing Array Length
 static int easingArray_len(lua_State* L)
 {
-    // Local caches
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (ea) {
         lua->pushInt(ea->count);
@@ -275,9 +338,42 @@ static int easingArray_len(lua_State* L)
     return 0;
 }
 
-// ----------------------------------------
-// Lua-Exposed Methods
-// ----------------------------------------
+// ! Set Easing At
+// obj:setEasingAt(idx, ts, from, to, dur, ease)
+static int easingArray_setEasingAt(lua_State* L)
+{
+    EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
+    int idx = lua->getArgInt(2);
+    if (!ea || idx <= 0 || idx > ea->count) { lua->pushBool(0); return 1; }
+
+    // NOTE: Modifying a segment in the middle can result in overlapping or
+    // out-of-order segments. It is the user's responsibility to maintain
+    // non-overlapping, ordered segments for consistent results.
+
+    EasingSegment* seg = &ea->segments[idx - 1];
+    seg->timestamp    = lua->getArgFloat(3);
+    seg->from         = lua->getArgFloat(4);
+    seg->to           = lua->getArgFloat(5);
+    seg->duration     = lua->getArgFloat(6);
+    seg->endTime      = seg->timestamp + seg->duration;
+    seg->easeFunction = lua->getArgInt(7);
+
+    // Re-evaluate sortedness and totalDuration
+    ea->isSorted = 1;
+    float maxEnd = 0.0f;
+    for (int i = 0; i < ea->count; ++i) {
+        if (i > 0 && ea->segments[i].timestamp < ea->segments[i-1].timestamp) ea->isSorted = 0;
+        if (ea->segments[i].endTime > maxEnd) maxEnd = ea->segments[i].endTime;
+    }
+    ea->totalDuration = maxEnd;
+
+    lua->pushBool(1);
+    return 1;
+}
+
+/*******************************************//**
+ *  Lua-Exposed Methods
+ ***********************************************/
 
 // ! Set name
 static int easingArray_setName(lua_State* L)
@@ -290,9 +386,8 @@ static int easingArray_setName(lua_State* L)
 
     const char* newName = lua->getArgString(2);
 
-    // Free existing name if it exists
     if (ea->name) {
-        sys->realloc((void*)ea->name, 0);
+        roxy_free((void*)ea->name);
         ea->name = NULL;
     }
 
@@ -318,7 +413,6 @@ static int easingArray_getName(lua_State* L)
         lua->pushNil();
         return 1;
     }
-
     lua->pushString(ea->name);
     return 1;
 }
@@ -327,71 +421,105 @@ static int easingArray_getName(lua_State* L)
 static int easingArray_addEasing(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea) { lua->pushNil(); return 1; }
 
     float timestamp   = lua->getArgFloat(2);
     float from        = lua->getArgFloat(3);
     float to          = lua->getArgFloat(4);
     float duration    = lua->getArgFloat(5);
     int easeFunction  = lua->getArgInt(6);
-    int lastIdx       = ea->count;
 
-    ADD_SEGMENT(ea, timestamp, from, to, duration, easeFunction);
-    if (ea->segments[lastIdx].endTime > ea->totalDuration) {
-        ea->completed = 0;
-        ea->totalDuration = ea->segments[lastIdx].endTime;
-    }
+    if (duration < 0.0f) duration = 0.0f;
+
+    // NOTE: For best performance, add easings in increasing timestamp order.
+    //       Segments should be non-overlapping and in increasing order.
+    //       If you add out-of-order or overlapping segments, lookup falls back
+    //       to linear scan and results may be unpredictable if two segments
+    //       cover the same time.
+    //       It is the caller's responsibility to avoid overlaps for
+    //       consistent animation.
+
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = timestamp;
+    seg->from         = from;
+    seg->to           = to;
+    seg->duration     = duration;
+    seg->endTime      = timestamp + duration;
+    seg->easeFunction = easeFunction;
+
+    ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
+
+    if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
+    ea->completed = 0;
 
     lua->pushBool(1);
     return 1;
 }
 
 // ! From
-// Clear everything and add a "from" segment at time=0
 static int easingArray_from(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea) { lua->pushNil(); return 1; }
 
-    // Clear everything
     ea->count         = 0;
-    ea->currentTime   = 0;
+    ea->currentTime   = 0.0f;
     ea->completed     = 0;
-    ea->totalDuration = 0;
+    ea->totalDuration = 0.0f;
+    ea->isSorted      = 1;
 
-    float fromVal = lua->getArgFloat(2); // default is 0.0
-    ADD_SEGMENT(ea, 0.0f, fromVal, fromVal, 0.0f, 0);
+    float fromVal = lua->getArgFloat(2);
+
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = 0.0f;
+    seg->from         = fromVal;
+    seg->to           = fromVal;
+    seg->duration     = 0.0f;
+    seg->endTime      = 0.0f;
+    seg->easeFunction = 0;
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
 }
 
 // ! To
-// Append a new segment starting at the end of the last segment
 static int easingArray_to(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea || ea->count == 0) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
 
-    float newTo       = lua->getArgFloat(2);
-    float duration    = lua->getArgFloat(3) ?: DEFAULT_DURATION;
-    int easeFunction  = lua->getArgInt(4) ?: DEFAULT_EASE_FUNCTION;
-    int lastIdx       = ea->count - 1;
+    int argc            = lua->getArgCount();
+    float newTo         = lua->getArgFloat(2);
+    float duration      = (argc >= 3) ? lua->getArgFloat(3) : DEFAULT_DURATION;
+    int easeFunction    = (argc >= 4) ? lua->getArgInt(4) : DEFAULT_EASE_FUNCTION;
+
+    if (duration <= 0.0f) duration = DEFAULT_DURATION;
+    if (easeFunction <= 0) easeFunction = DEFAULT_EASE_FUNCTION;
+
+    int lastIdx = ea->count - 1;
     EasingSegment* lastSeg = &ea->segments[lastIdx];
 
-    lastIdx = ea->count; // Point to new slot
-    ADD_SEGMENT(ea, lastSeg->endTime, lastSeg->to, newTo, duration, easeFunction);
+    // Append new segment
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = lastSeg->endTime;
+    seg->from         = lastSeg->to;
+    seg->to           = newTo;
+    seg->duration     = duration;
+    seg->endTime      = seg->timestamp + seg->duration;
+    seg->easeFunction = easeFunction;
+
+    // Appended at end keeps sorted
+    // (timestamp >= previous endTime)
+    ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
+
+    if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     ea->completed = 0;
-    ea->totalDuration = ea->segments[lastIdx].endTime;
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
@@ -401,43 +529,52 @@ static int easingArray_to(lua_State* L)
 static int easingArray_set(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea) { lua->pushNil(); return 1; }
 
     float value = lua->getArgFloat(2);
     float newTimestamp = 0.0f;
-    if (ea->count > 0) {
-        EasingSegment* lastSeg = &ea->segments[ea->count - 1];
-        newTimestamp = lastSeg->endTime;
-    }
+    if (ea->count > 0) newTimestamp = ea->segments[ea->count - 1].endTime;
 
-    int lastIdx = ea->count;
-    ADD_SEGMENT(ea, newTimestamp, value, value, 0, 0);
-    ea->completed = 0;
-    ea->totalDuration = ea->segments[lastIdx].endTime;
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = newTimestamp;
+    seg->from         = value;
+    seg->to           = value;
+    seg->duration     = 0.0f;
+    seg->endTime      = newTimestamp;
+    seg->easeFunction = 0;
+
+    ea->completed     = 0;
+    if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
+    ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
 }
 
 // ! Sleep
-static int easingArray_sleep(lua_State* L) {
+static int easingArray_sleep(lua_State* L)
+{
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea || ea->count == 0) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
 
-    float duration          = lua->getArgFloat(2);
-    int lastIdx             = ea->count - 1;
-    EasingSegment* lastSeg  = &ea->segments[lastIdx];
+    float duration         = lua->getArgFloat(2);
+    EasingSegment* lastSeg = &ea->segments[ea->count - 1];
 
-    lastIdx = ea->count;
-    ADD_SEGMENT(ea, lastSeg->endTime, lastSeg->to, lastSeg->to, duration, 0);
-    ea->completed = 0;
-    ea->totalDuration = ea->segments[lastIdx].endTime;
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = lastSeg->endTime;
+    seg->from         = lastSeg->to;
+    seg->to           = lastSeg->to;
+    seg->duration     = duration;
+    seg->endTime      = seg->timestamp + seg->duration;
+    seg->easeFunction = 0;
+
+    ea->completed     = 0;
+    if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
+    ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
@@ -447,45 +584,54 @@ static int easingArray_sleep(lua_State* L) {
 static int easingArray_setLoopType(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea) { lua->pushNil(); return 1; }
 
-    int loopType = lua->getArgInt(2);  // 0,1,2
-    float loopCount = lua->getArgFloat(3); // 0=infinite
+    int argc = lua->getArgCount();
+    int loopType  = (argc >= 2) ? lua->getArgInt(2) : 0;  // 0,1,2
+    float loopCount = (argc >= 3) ? lua->getArgFloat(3) : 0.0f;  // 0.0f=infinite
 
+    // Clamp loopType to [0,2]
+    if (loopType < 0) loopType = 0;
+    if (loopType > 2) loopType = 2;
     ea->loopType    = loopType;
-    ea->loopCount   = loopCount;
+    ea->loopCount   = (loopCount < 0.0f) ? 0.0f : loopCount;
+    ea->travelAccum = 0.0f;
     ea->loopCounter = 0;
-    ea->isForward   = 1;  // always start forward
+    ea->isForward   = 1;
 
     lua->pushBool(1);
     return 1;
 }
 
 // ! Again
-static int easingArray_again(lua_State* L) {
+static int easingArray_again(lua_State* L)
+{
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea || ea->count == 0) {
-        lua->pushNil();
-        return 1;
+    if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
+
+    long long rc = (long long)lua->getArgInt(2);
+    if (rc <= 0) rc = DEFAULT_REPEAT_COUNT;
+
+    // Needed elements (count + rc) may overflow int; use size_t
+    size_t needed = (size_t)ea->count + (size_t)rc;
+    if (needed < (size_t)ea->count) { // overflow wrap
+        lua->pushNil(); lua->pushString("repeat overflow"); return 2;
     }
 
-    int repeatCount = lua->getArgInt(2);
-    if (repeatCount <= 0) repeatCount = DEFAULT_REPEAT_COUNT;
-
-    int needed = ea->count + repeatCount;
-    if (needed > ea->capacity) {
-        int newCap = ea->capacity * 2;
-        while (newCap < needed) newCap *= 2;
-        EasingSegment* newPtr = sys->realloc(ea->segments, newCap * sizeof(EasingSegment));
-        if (!newPtr) {
-            lua->pushObject(ea, "RoxySequenceC", 0);
-            return 1;
+    if ((int)needed > ea->capacity) {
+        int newCap = ea->capacity;
+        while ((int)needed > newCap) {
+            if (newCap > INT_MAX/2) { lua->pushNil(); lua->pushString("capacity overflow"); return 2; }
+            newCap *= 2;
         }
+        if ((size_t)newCap > SIZE_MAX/sizeof(EasingSegment)) {
+            lua->pushNil(); lua->pushString("size overflow"); return 2;
+        }
+        EasingSegment* newPtr = (EasingSegment*)roxy_realloc(ea->segments, (size_t)newCap * sizeof(EasingSegment));
+        if (!newPtr) { lua->pushNil(); lua->pushString("oom"); return 2; }
         ea->segments = newPtr;
         ea->capacity = newCap;
+        ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
     }
 
     int lastIdx = ea->count - 1;
@@ -496,72 +642,84 @@ static int easingArray_again(lua_State* L) {
     float newDuration   = lastSeg->duration;
     int newEaseFunction = lastSeg->easeFunction;
 
-    for (int r = 0; r < repeatCount; r++) {
-        lastIdx = ea->count;
-        ADD_SEGMENT(ea, newTimestamp, newFrom, newTo, newDuration, newEaseFunction);
-        newTimestamp = ea->segments[lastIdx].endTime;
+    for (int r = 0; r < rc; r++) {
+        EasingSegment* seg = ensureCapacityAndInsert(ea);
+        if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+        seg->timestamp    = newTimestamp;
+        seg->from         = newFrom;
+        seg->to           = newTo;
+        seg->duration     = newDuration;
+        seg->endTime      = seg->timestamp + seg->duration;
+        seg->easeFunction = newEaseFunction;
+
+        newTimestamp = seg->endTime;
+        if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     }
+
     ea->completed = 0;
-    ea->totalDuration = ea->segments[ea->count - 1].endTime;
+    ea->isSorted = 1; // Appends preserve order
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
 }
 
-// ! Reverse (Modify or Append Reversed Segment)
+// ! Reverse
 static int easingArray_reverse(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea || ea->count == 0) {
-        lua->pushNil();
-        return 1;
-    }
+    if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
 
-    int appendNew           = lua->getArgBool(2);
-    int lastIdx             = ea->count - 1;
-    EasingSegment* lastSeg  = &ea->segments[lastIdx];
+    int appendNew          = lua->getArgBool(2);
+    EasingSegment* lastSeg = &ea->segments[ea->count - 1];
 
     if (!appendNew) {
         float elapsed = ea->currentTime - lastSeg->timestamp;
         float temp    = lastSeg->from;
         lastSeg->from = lastSeg->to;
         lastSeg->to   = temp;
-
-        // Mirror time inside the segment
         ea->currentTime = lastSeg->timestamp + (lastSeg->duration - elapsed);
         lua->pushObject(ea, "RoxySequenceC", 0);
         return 1;
     }
 
-    lastIdx = ea->count;
-    ADD_SEGMENT(ea, lastSeg->endTime, lastSeg->to, lastSeg->from, lastSeg->duration, lastSeg->easeFunction);
-    ea->completed = 0;
-    ea->totalDuration = ea->segments[lastIdx].endTime;
+    EasingSegment* seg = ensureCapacityAndInsert(ea);
+    if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
+
+    seg->timestamp    = lastSeg->endTime;
+    seg->from         = lastSeg->to;
+    seg->to           = lastSeg->from;
+    seg->duration     = lastSeg->duration;
+    seg->endTime      = seg->timestamp + seg->duration;
+    seg->easeFunction = lastSeg->easeFunction;
+
+    ea->completed     = 0;
+    if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
+    ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
 
     lua->pushObject(ea, "RoxySequenceC", 0);
     return 1;
 }
 
-// ----------------------------------------
-// Lua-Exposed Methods: Query and Control
-// ----------------------------------------
+/*******************************************//**
+ *  Lua-Exposed Methods: Query and Control
+ ***********************************************/
 
 // ! Get easing data
 static int easingArray_getEasingData(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     int idx = lua->getArgInt(2);
-    if (ea && idx > 0 && idx <= ea->count) {
-        EasingSegment* seg = &ea->segments[idx - 1];
-        lua->pushFloat(seg->timestamp);
-        lua->pushFloat(seg->from);
-        lua->pushFloat(seg->to);
-        lua->pushFloat(seg->duration);
-        lua->pushFloat(seg->endTime);
-        lua->pushInt(seg->easeFunction);
-        return 6;
-    }
-    return 0;
+    if (!ea || idx <= 0 || idx > ea->count) { lua->pushNil(); return 1; }
+
+    EasingSegment* seg = &ea->segments[idx - 1];
+    lua->pushFloat(seg->timestamp);
+    lua->pushFloat(seg->from);
+    lua->pushFloat(seg->to);
+    lua->pushFloat(seg->duration);
+    lua->pushFloat(seg->endTime);
+    lua->pushInt(seg->easeFunction);
+    return 6;
 }
 
 // ! Get current time
@@ -593,132 +751,84 @@ static int easingArray_updateAndGetValue(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (!ea || ea->count == 0) {
-        lua->pushFloat(0.0f); // oldTime
-        lua->pushFloat(0.0f); // newTime
-        lua->pushFloat(0.0f); // newValue
-        lua->pushBool(1);     // completed
+        lua->pushFloat(0.0f); lua->pushFloat(0.0f); lua->pushFloat(0.0f); lua->pushBool(1);
         return 4;
     }
+
     int lastIdx = ea->count - 1;
     float oldTime = ea->currentTime;
+
+    // If already completed, return boundary-correct value (handles fractional loop counts).
     if (ea->completed) {
-        lua->pushFloat(oldTime);                  // oldTime
-        lua->pushFloat(oldTime);                  // newTime
-        lua->pushFloat(ea->segments[lastIdx].to); // newValue
-        lua->pushBool(1);                         // completed
+        float boundaryTime = boundaryTimeForCompletion(ea);
+        float val = evalAtTime(ea, boundaryTime);
+        lua->pushFloat(oldTime);
+        lua->pushFloat(oldTime);
+        lua->pushFloat(val);
+        lua->pushBool(1);
         return 4;
     }
 
-    float step    = lua->getArgFloat(2);
+    float step = lua->getArgFloat(2);
     float newTime = ea->currentTime;
 
-    // (1) Adjust newTime based on loopType
     if (ea->loopType >= 0 && ea->loopType <= 2) {
         handlers[ea->loopType](ea, &newTime, step);
     }
 
-    // (2) Update our time
     ea->currentTime = newTime;
 
-    // (3) Find the segment for this time
+    // If we just completed, also return the boundary-correct value (fraction-aware)
+    if (ea->completed) {
+        float boundaryTime = boundaryTimeForCompletion(ea);
+        float val = evalAtTime(ea, boundaryTime);
+        lua->pushFloat(oldTime);
+        lua->pushFloat(ea->currentTime);
+        lua->pushFloat(val);
+        lua->pushBool(1);
+        return 4;
+    }
+
+    // Use isSorted and fall back to linear if not sorted
     EasingSegment* easing = NULL;
-    if (ea->count <= 4) { // Threshold tuned for Playdate
+    if (!ea->isSorted || ea->count <= 4) {
         for (int i = 0; i < ea->count; i++) {
             EasingSegment* seg = &ea->segments[i];
-            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) {
-                easing = seg;
-                break;
-            }
+            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) { easing = seg; break; }
         }
     } else {
         int left = 0, right = lastIdx;
         while (left <= right) {
             int mid = left + (right - left) / 2;
             EasingSegment* seg = &ea->segments[mid];
-            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) {
-                easing = seg;
-                break;
-            }
-            if (ea->currentTime < seg->timestamp) right = mid - 1;
-            else left = mid + 1;
+            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) { easing = seg; break; }
+            if (ea->currentTime < seg->timestamp) right = mid - 1; else left = mid + 1;
         }
     }
-    if (!easing) {
-        easing = (ea->currentTime < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[lastIdx];
+    if (!easing) easing = (ea->currentTime < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[lastIdx];
+
+    if (easing->duration <= 0.0f) {
+        lua->pushFloat(oldTime);
+        lua->pushFloat(ea->currentTime);
+        lua->pushFloat(easing->to);
+        lua->pushBool(0);
+        return 4;
     }
 
-    // (4) Calculate the “elapsedTime” within that segment
-    float elapsedTime = ea->currentTime - easing->timestamp;
-    if (ea->loopType == 2 && !ea->isForward) {
-        elapsedTime = easing->duration - elapsedTime;
-    }
-
-    // (5) Evaluate the easing
-    float newValue = (easing->easeFunction == 1) ? (ea->isForward ? easing->from + (easing->to - easing->from) * (elapsedTime / easing->duration) : easing->to + (easing->from - easing->to) * (elapsedTime / easing->duration)) : roxy_ease_evaluate(easing->easeFunction, elapsedTime, ea->isForward ? easing->from : easing->to, ea->isForward ? (easing->to - easing->from) : (easing->from - easing->to), easing->duration, 0.0f, 0.0f);
-
-    lua->pushFloat(oldTime);          // Old time
-    lua->pushFloat(ea->currentTime);  // New time
-    lua->pushFloat(newValue);         // New Value
-    lua->pushBool(ea->completed);     // Completed
+    lua->pushFloat(oldTime);
+    lua->pushFloat(ea->currentTime);
+    lua->pushFloat(evalAtTime(ea, ea->currentTime));
+    lua->pushBool(0);
     return 4;
 }
 
-// ! Get value
 static int easingArray_getValue(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
-    if (!ea || ea->count == 0) {
-        lua->pushFloat(0.0f);
-        return 1;
-    }
+    if (!ea || ea->count == 0) { lua->pushFloat(0.0f); return 1; }
 
     float time = lua->getArgFloat(2);
-    float clampedTime = roxy_math_clamp(time, 0.0f, ea->totalDuration);
-    int lastIdx = ea->count - 1;
-
-    if (clampedTime >= ea->segments[lastIdx].endTime) {
-        lua->pushFloat(ea->segments[lastIdx].to);
-        return 1;
-    }
-
-    EasingSegment* easing = NULL;
-    if (ea->count <= 4) { // Threshold tuned for Playdate
-        for (int i = 0; i < ea->count; i++) {
-            EasingSegment* seg = &ea->segments[i];
-            if (clampedTime >= seg->timestamp && clampedTime <= seg->endTime) {
-                easing = seg;
-                break;
-            }
-        }
-    } else {
-        int left = 0, right = lastIdx;
-        while (left <= right) {
-            int mid = left + (right - left) / 2;
-            EasingSegment* seg = &ea->segments[mid];
-            if (clampedTime >= seg->timestamp && clampedTime <= seg->endTime) {
-                easing = seg;
-                break;
-            }
-            if (clampedTime < seg->timestamp) right = mid - 1;
-            else left = mid + 1;
-        }
-    }
-    if (!easing) {
-        easing = (clampedTime < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[lastIdx];
-    }
-
-    float timeOffset = clampedTime - easing->timestamp;
-    float value = roxy_ease_evaluate(
-        easing->easeFunction,
-        timeOffset,
-        easing->from,
-        (easing->to - easing->from),
-        easing->duration,
-        0.0f,
-        0.0f
-    );
-
-    lua->pushFloat(value);
+    lua->pushFloat(evalAtTime(ea, time));
     return 1;
 }
 
@@ -740,14 +850,14 @@ static int easingArray_reset(lua_State* L)
 
     ea->currentTime         = 0.0f;
     ea->completed           = 0;
+    ea->travelAccum         = 0.0f;
     ea->loopCounter         = 0;
     ea->pingPongHalfCycles  = 0;
-    ea->isForward           = 1;  // Start moving forward
+    ea->isForward           = 1;
 
     lua->pushBool(1);
     return 1;
 }
-
 
 // ! Clear Easing Array
 static int easingArray_clear(lua_State* L)
@@ -760,15 +870,16 @@ static int easingArray_clear(lua_State* L)
     ea->completed           = 0;
     ea->totalDuration       = 0.0f;
     ea->loopType            = 0;
-    ea->loopCount           = 0;
+    ea->loopCount           = 0.0f;
+    ea->travelAccum         = 0.0f;
     ea->loopCounter         = 0;
     ea->pingPongHalfCycles  = 0;
-    ea->isForward           = 1;  // Default to forward
+    ea->isForward           = 1;
+    ea->isSorted            = 1;
 
     lua->pushBool(1);
     return 1;
 }
-
 
 // ----------------------------------------
 // ! Class Registration
@@ -779,11 +890,11 @@ static const lua_reg easingArrayLib[] =
     { "new",                easingArray_newobject         },
     { "__gc",               easingArray_gc                },
     { "__index",            easingArray_index             },
-    { "__newindex",         easingArray_newindex          },
     { "__len",              easingArray_len               },
     { "setName",            easingArray_setName           },
     { "getName",            easingArray_getName           },
     { "addEasing",          easingArray_addEasing         },
+    { "setEasingAt",        easingArray_setEasingAt       },
     { "from",               easingArray_from              },
     { "to",                 easingArray_to                },
     { "set",                easingArray_set               },

--- a/core/sequences/roxy_sequence.h
+++ b/core/sequences/roxy_sequence.h
@@ -1,4 +1,6 @@
-/*
+// core/sequences/roxy_sequence.h
+
+/**
  *
  * Adapted from Nic Magnier's Sequence library.
  * (https://github.com/NicMagnier/PlaydateSequence)
@@ -9,6 +11,38 @@
 #define ROXY_SEQUENCE_H
 
 #include "pd_api.h"
+
+// ! Easing Segment Struct
+typedef struct
+{
+    float timestamp;
+    float from;
+    float to;
+    float duration;
+    float endTime;
+    int easeFunction;
+} EasingSegment;
+
+// ! Easing Array Struct
+typedef struct
+{
+    const char* name;
+    int count;
+    int capacity;
+    EasingSegment* segments;
+    float currentTime;
+    int completed;          // 1 = finished, 0 = running
+    float totalDuration;
+    int loopType;           // 0=none,1=loop,2=pingpong
+    float loopCount;        // Number of loops; 0.0f = infinite (supports fractions)
+    float travelAccum;      // Total forward "path" distance consumed (seconds)
+    int loopCounter;
+    int pingPongHalfCycles;
+    int isForward;          // 1 = forward, 0 = backward
+    int isSorted;           // 1 = timestamps non-decreasing
+} EasingArray;
+
+typedef void (*LoopHandler)(EasingArray*, float*, float);
 
 void registerRoxySequenceC(PlaydateAPI* pd);
 

--- a/core/sprites/RoxyParticles.lua
+++ b/core/sprites/RoxyParticles.lua
@@ -166,7 +166,6 @@ function RoxyParticles:init(x, y, opts)
   self.cpool = new_C(
     opts.maxCount,
     opts.imageTable or nil,
-    self.frameCount or 1,
     self.frameMode,
     self.staticFrame,
     self.opts.loop,

--- a/core/sprites/roxy_particles.c
+++ b/core/sprites/roxy_particles.c
@@ -2,7 +2,9 @@
 
 #include "roxy_particles.h"
 #include "../../utilities/roxy_math.h"
+#include "../../utilities/roxy_heapguard.h"
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <math.h>
 
@@ -10,16 +12,21 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+// Absolute hard ceiling, engine will never exceed this
+#ifndef ROXY_PARTICLES_MAX_COUNT
+#define ROXY_PARTICLES_MAX_COUNT 4096
+#endif
+
+// Recommended safe budget; allocations above this are warned
+#ifndef ROXY_PARTICLES_SAFE_MAX
+#define ROXY_PARTICLES_SAFE_MAX 2048
+#endif
+
 static PlaydateAPI* pd = NULL;
 
-void roxy_particles_setPlaydateAPI(PlaydateAPI* playdate)
-{
-    pd = playdate;
-}
-
-// ----------------------------------------
-// Helpers
-// ----------------------------------------
+/*******************************************//**
+ *  Helpers
+ ***********************************************/
 
 static inline float rnd01(void)
 {
@@ -36,18 +43,10 @@ static inline float deg_to_rad(float d)
     return d * (float)M_PI / 180.0f;
 }
 
-static void* pd_alloc(size_t sz)
-{
-    return pd->system->realloc(NULL, sz);
-}
-
-static void pd_free(void* ptr)
-{
-    pd->system->realloc(ptr, 0);
-}
-
 // ! Normalize Range
 // Normalizes an angle range to determine min, max, and if it spans a full circle
+// Note: Angular ranges are directed - order matters for determining long vs short arcs
+// For example: (350, 10) creates a 20° arc crossing 0°, while (10, 350) creates a 340° arc
 static void normalizeRange(float a, float b, float* outA, float* outB, int* fullCircle)
 {
     // Normalize angles to [0, 360)
@@ -56,7 +55,7 @@ static void normalizeRange(float a, float b, float* outA, float* outB, int* full
     b = fmodf(b, 360.0f);
     if (b < 0) b += 360.0f;
 
-    // Calculate the clockwise span from a to b
+    // Calculate the directed angular span from a to b
     float span;
     if (b >= a) {
         span = b - a;
@@ -65,7 +64,7 @@ static void normalizeRange(float a, float b, float* outA, float* outB, int* full
     }
 
     // Check if this represents a full circle (or nearly full circle)
-    if (span >= 359.0f || fabsf(span - 360.0f) < 0.001f) {
+    if (span >= 359.0f || fabsf(span - 360.0f) < 0.05f) {
         *outA = 0.0f;
         *outB = 360.0f;
         *fullCircle = 1;
@@ -99,43 +98,123 @@ static int angle_in_sweep(float deg, float angMin, float angMax, int fullCircle)
     }
 }
 
-// ----------------------------------------
-//  Object Lifecycle
-// ----------------------------------------
+// ! Initialize Particle Frame
+// Helper to set up frame-related properties for a new particle
+static void init_particle_frame(RoxyParticle* p, const RoxyParticlesC* ps)
+{
+    if (ps->imageTable && ps->frameCount > 0) {
+        p->frameRate = ps->frameRate;
+        p->frameTimer = 0.0f;
+
+        switch (ps->frameMode) {
+            case FRAME_STATIC:
+                p->frame = ps->staticFrame;
+                break;
+            case FRAME_REVERSE:
+                p->frame = ps->frameCount - 1;
+                break;
+            case FRAME_RANDOM:
+                if (ps->frameCount > 0) {
+                    p->frame = rand() % ps->frameCount;
+                } else {
+                    p->frame = 0;
+                }
+                break;
+            case FRAME_SEQUENTIAL:
+            default:
+                p->frame = 0;
+                break;
+        }
+    } else {
+        p->frame = 0;
+        p->frameRate = 0.0f;
+        p->frameTimer = 0.0f;
+    }
+}
+
+/*******************************************//**
+ *  Object Lifecycle
+ ***********************************************/
 
 // ! New Particles Pool
 // Creates a new particle system with a specified maximum particle count
-RoxyParticlesC* roxy_particles_new(int maxCount, LCDBitmapTable* tbl, int frameCount, FrameMode frameMode, int staticFrame, int shouldLoop, float initFrameRate)
-
+RoxyParticlesC* roxy_particles_new(int maxCount, LCDBitmapTable* tbl, FrameMode frameMode, int staticFrameLua, int shouldLoop, float initFrameRate)
 {
-    if (!pd) return NULL;
-    if (maxCount <= 0) maxCount = 1;
-
-    RoxyParticlesC* ps = (RoxyParticlesC*)pd_alloc(sizeof(RoxyParticlesC));
-    if (!ps) return NULL;
-    memset(ps, 0, sizeof(RoxyParticlesC));
-
-    ps->maxCount = maxCount;
-    ps->pool = (RoxyParticle*)pd_alloc(sizeof(RoxyParticle) * (size_t)maxCount);
-    if (!ps->pool) {
-        pd_free(ps);
+    if (!pd) {
         return NULL;
     }
-    memset(ps->pool, 0, sizeof(RoxyParticle) * (size_t)maxCount);
+
+    if (maxCount <= 0) maxCount = 1;
+    if (maxCount > ROXY_PARTICLES_SAFE_MAX) {
+        pd->system->logToConsole("roxy_particles_new: maxCount %d exceeds safe limit %d", maxCount, ROXY_PARTICLES_SAFE_MAX);
+        maxCount = ROXY_PARTICLES_SAFE_MAX;
+    }
+
+    RoxyParticlesC* ps = (RoxyParticlesC*)roxy_malloc(sizeof(RoxyParticlesC));
+    if (!ps) {
+        pd->system->logToConsole("roxy_particles_new: Failed to allocate particle system");
+        return NULL;
+    }
+    ROXY_LABEL(ps, "RoxyParticlesC");
+    roxy_memset(ps, 0, sizeof(RoxyParticlesC));
+
+    ps->maxCount = maxCount;
+    ps->activeCount = 0;
+    ps->pool = (RoxyParticle*)roxy_malloc(sizeof(RoxyParticle) * (size_t)maxCount);
+    if (!ps->pool) {
+        pd->system->logToConsole("roxy_particles_new: Failed to allocate particle pool for %d particles", maxCount);
+        roxy_free(ps);
+        return NULL;
+    }
+    ROXY_LABEL(ps->pool, "RoxyParticlesC.pool");
+    roxy_memset(ps->pool, 0, sizeof(RoxyParticle) * (size_t)maxCount);
+
+    ps->frameRate = initFrameRate;
+
+    // Cache bitmap dimensions for performance
+    ps->cachedFrameW = 0;
+    ps->cachedFrameH = 0;
+
     if (tbl) {
-        ps->imageTable  = tbl;
-        ps->frameCount  = frameCount;
-        ps->frameMode   = frameMode;
-        ps->staticFrame = staticFrame;
-        ps->shouldLoop  = shouldLoop;
-        ps->frameRate   = initFrameRate;
+        ps->imageTable = tbl;
+
+        // Authoritative, dynamic frame count
+        int actualCount = 0;
+        while (pd->graphics->getTableBitmap(tbl, actualCount)) {
+            actualCount++;
+        }
+
+        if (actualCount > 0) {
+            ps->frameCount = actualCount;
+            ps->frameMode  = frameMode;
+
+            // Convert & clamp static frame (Lua 1-based -> C 0-based)
+            int luaStatic = staticFrameLua;
+            if (luaStatic < 1) luaStatic = 1;
+            luaStatic -= 1; // now 0-based
+            if (luaStatic >= ps->frameCount) luaStatic = ps->frameCount - 1;
+            ps->staticFrame = luaStatic;
+            ps->shouldLoop  = shouldLoop;
+
+            LCDBitmap* first = pd->graphics->getTableBitmap(tbl, 0);
+            if (first) {
+                pd->graphics->getBitmapData(first, &ps->cachedFrameW, &ps->cachedFrameH, NULL, NULL, NULL);
+            }
+        } else {
+            // Empty table: treat as no imagetable
+            ps->imageTable  = NULL;
+            ps->frameCount  = 0;
+            ps->frameMode   = FRAME_SEQUENTIAL;
+            ps->staticFrame = 0;
+            ps->shouldLoop  = 0;
+        }
     } else {
+        // No imagetable
         ps->imageTable  = NULL;
-        ps->frameCount  = 1;
+        ps->frameCount  = 0;
         ps->frameMode   = FRAME_SEQUENTIAL;
         ps->staticFrame = 0;
         ps->shouldLoop  = 0;
-        ps->frameRate   = initFrameRate;
     }
 
     return ps;
@@ -143,20 +222,20 @@ RoxyParticlesC* roxy_particles_new(int maxCount, LCDBitmapTable* tbl, int frameC
 
 // ! Free Pool
 // Frees the particle pool and sets the pointer to NULL to prevent double-free
-static void roxy_particles_free_pool(RoxyParticlesC* ps)
+void roxy_particles_free_pool(RoxyParticlesC* ps)
 {
-    if (ps == NULL || ps->pool == NULL) // Already freed --> nothing to do
+    if (ps == NULL || ps->pool == NULL)
         return;
 
     void *pool = ps->pool;
     ps->pool = NULL; // Mark as gone
 
-    pd_free(pool);
+    roxy_free(pool);
 }
 
-// ----------------------------------------
-// Lua Class Methods
-// ----------------------------------------
+/*******************************************//**
+ *  Lua Class Methods
+ ***********************************************/
 
 // ! New Object
 // Lua constructor: Creates a new particle system object
@@ -164,19 +243,16 @@ int roxy_particles_newobject(lua_State* L)
 {
     int maxCount        = pd->lua->getArgInt(1);
     LCDBitmapTable* tbl = pd->lua->getArgObject(2, "playdate.graphics.imagetable", NULL);
-    int frameCount      = pd->lua->getArgInt(3);
-    FrameMode frameMode = pd->lua->getArgInt(4);
-    int staticFrame     = pd->lua->getArgInt(5);
-    int shouldLoop      = pd->lua->getArgInt(6);
-    float initFrameRate = pd->lua->getArgFloat(7);
+    FrameMode frameMode = (FrameMode)pd->lua->getArgInt(3);
+    int staticFrameLua  = pd->lua->getArgInt(4);  // 1-based from Lua
+    int shouldLoop      = pd->lua->getArgInt(5);
+    float initFrameRate = pd->lua->getArgFloat(6);
 
-    // Pass all six into roxy_particles_new
     RoxyParticlesC* ps = roxy_particles_new(
         maxCount,
         tbl,
-        frameCount,
         frameMode,
-        staticFrame,
+        staticFrameLua,   // pass 1-based; clamp/convert inside roxy_particles_new
         shouldLoop,
         initFrameRate
     );
@@ -196,14 +272,14 @@ int roxy_particles_gc(lua_State* L)
     RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
     if (ps) {
         roxy_particles_free_pool(ps);
-        pd_free(ps);
+        roxy_free(ps);
     }
     return 0;
 }
 
-// ----------------------------------------
-// Lua-Exposed Methods
-// ----------------------------------------
+/*******************************************//**
+ *  Lua-Exposed Methods
+ ***********************************************/
 
 // ! Set Pattern
 // Args: 1 = ps, 2 = Lua string of length 8 or 16 (raw bytes)
@@ -220,10 +296,10 @@ int roxy_particles_setPattern_l(lua_State* L)
     }
 
     // Copy fill & mask (mask defaults to opaque if only 8 bytes)
-    memcpy(ps->pattern, bytes, len);
-    if (len == 8) {
-        memset(ps->pattern + 8, 0xFF, 8);
-    }
+    if (len > sizeof(ps->pattern)) len = sizeof(ps->pattern);
+    roxy_memcpy(ps->pattern, bytes, len);
+    if (len == 8) roxy_memset(ps->pattern + 8, 0xFF, 8);
+    if (len < 16) roxy_memset(ps->pattern + len, 0, 16 - len);
 
     ps->hasPattern = true;
     return 0;
@@ -232,11 +308,11 @@ int roxy_particles_setPattern_l(lua_State* L)
 // ! Set Frame Rate
 int roxy_particles_setFrameRate_l(lua_State* L)
 {
-  RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
-  if (!ps) return 0;
+    RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
+    if (!ps) return 0;
 
-  ps->frameRate = fmaxf(0.0f, pd->lua->getArgFloat(2));
-  return 0;
+    ps->frameRate = fmaxf(0.0f, pd->lua->getArgFloat(2));
+    return 0;
 }
 
 // ! Set Image Table
@@ -258,6 +334,14 @@ int roxy_particles_setImageTable_l(lua_State* L)
         }
         ps->frameCount = count;
 
+        LCDBitmap* first = pd->graphics->getTableBitmap(tbl, 0);
+        if (first) {
+            pd->graphics->getBitmapData(first, &ps->cachedFrameW, &ps->cachedFrameH, NULL, NULL, NULL);
+        } else {
+            ps->cachedFrameW = 0;
+            ps->cachedFrameH = 0;
+        }
+
         // Validate frameCount to prevent division by zero
         if (ps->frameCount <= 0) {
             ps->imageTable = NULL;
@@ -265,6 +349,8 @@ int roxy_particles_setImageTable_l(lua_State* L)
             ps->frameMode = FRAME_SEQUENTIAL;
             ps->staticFrame = 0;
             ps->shouldLoop = false;
+            ps->cachedFrameW = 0;
+            ps->cachedFrameH = 0;
             return 0;
         }
 
@@ -285,6 +371,8 @@ int roxy_particles_setImageTable_l(lua_State* L)
         ps->frameMode = FRAME_SEQUENTIAL;
         ps->staticFrame = 0;
         ps->shouldLoop = false;
+        ps->cachedFrameW = 0;
+        ps->cachedFrameH = 0;
     }
 
     return 0;
@@ -300,7 +388,6 @@ int roxy_particles_spawn_l(lua_State* L)
         return 1;
     }
 
-    // [Parameter reading code remains the same...]
     float lifeMin = fmaxf(0.0f, pd->lua->getArgFloat(2));
     float lifeMax = fmaxf(0.0f, pd->lua->getArgFloat(3));
     float speedMin = pd->lua->getArgFloat(4);
@@ -321,58 +408,33 @@ int roxy_particles_spawn_l(lua_State* L)
         return 1;
     }
 
-    // Find free slot
-    int slot = -1;
-    for (int i = 0; i < ps->maxCount; ++i) {
-        if (!ps->pool[i].alive) {
-            slot = i;
-            break;
-        }
-    }
-    if (slot < 0) {
+    // O(1) slot allocation: check if we have space
+    if (ps->activeCount >= ps->maxCount) {
         pd->lua->pushBool(0);
         return 1;
     }
 
+    // Use the next available slot at activeCount
+    int slot = ps->activeCount;
+    ps->activeCount++;
+
+    // Initialize particle (only set necessary fields)
     RoxyParticle* p = &ps->pool[slot];
-    memset(p, 0, sizeof(RoxyParticle));
     p->alive = 1;
     p->age = 0.0f;
     p->lifetime = rand_range(lifeMin, lifeMax);
 
-    if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
-        p->frameRate = ps->frameRate;
-        p->frameTimer = 0.0f;
+    // Frame initialization
+    init_particle_frame(p, ps);
 
-        // Pick the starting frame based on mode
-        switch (ps->frameMode) {
-          case FRAME_STATIC:
-            p->frame = ps->staticFrame;
-            break;
-          case FRAME_REVERSE:
-            p->frame = ps->frameCount - 1;
-            break;
-          case FRAME_RANDOM:
-            p->frame = rand() % ps->frameCount;
-            break;
-          case FRAME_SEQUENTIAL:
-          default:
-            p->frame = 0;
-            break;
-        }
+    // Angle and velocity calculation
+    float span = fullCircle ? 360.0f : (nAngMax - nAngMin);
+    if (!fullCircle && nAngMax < nAngMin) {
+        span += 360.0f;
     }
-    else {
-        p->frame = 0;
-        p->frameRate = 0.0f;
-        p->frameTimer = 0.0f;
-    }
-
-    float theta;
-    if (fullCircle) {
-        theta = deg_to_rad(rnd01() * 360.0f);
-    } else {
-        theta = deg_to_rad(rand_range(nAngMin, nAngMax));
-    }
+    float angle = nAngMin + rnd01() * span;
+    angle = fmodf(angle, 360.0f);
+    float theta = deg_to_rad(angle);
     float speed = rand_range(speedMin, speedMax);
 
     p->vx   = speed * cosf(theta);
@@ -421,67 +483,43 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
         return 1;
     }
 
+    // Calculate how many we can actually spawn (O(1) check)
+    int availableSlots = ps->maxCount - ps->activeCount;
+    int actualCount = (count < availableSlots) ? count : availableSlots;
+
+    if (actualCount <= 0) {
+        pd->lua->pushInt(0);
+        return 1;
+    }
+
     // Pre-calculate ranges for efficiency
     float lifeRange = lifeMax - lifeMin;
     float speedRange = speedMax - speedMin;
     float sizeRange = sizeMax - sizeMin;
-    float angleRange = nAngMax - nAngMin;
 
-    int spawned = 0;
+    // Pre-calculate angle span
+    float span = fullCircle ? 360.0f : (nAngMax - nAngMin);
+    if (!fullCircle && nAngMax < nAngMin) {
+        span += 360.0f;
+    }
 
-    for (int i = 0; i < count; i++) {
-        // Find free slot
-        int slot = -1;
-        for (int j = 0; j < ps->maxCount; ++j) {
-            if (!ps->pool[j].alive) {
-                slot = j;
-                break;
-            }
-        }
-        if (slot < 0) {
-            break;  // No more free slots
-        }
+    // Spawn particles in O(actualCount) time
+    for (int i = 0; i < actualCount; i++) {
+        int slot = ps->activeCount + i;
+        RoxyParticle* p = &ps->pool[slot];
 
         // Initialize particle
-        RoxyParticle* p = &ps->pool[slot];
-        memset(p, 0, sizeof(RoxyParticle));
         p->alive = 1;
         p->age = 0.0f;
         p->lifetime = lifeMin + rnd01() * lifeRange;
 
-        // Frame initialization with SAFETY CHECK
-        if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
-            p->frameRate = ps->frameRate;
-            p->frameTimer = 0.0f;
-
-            switch (ps->frameMode) {
-              case FRAME_STATIC:
-                p->frame = ps->staticFrame;
-                break;
-              case FRAME_REVERSE:
-                p->frame = ps->frameCount - 1;
-                break;
-              case FRAME_RANDOM:
-                p->frame = rand() % ps->frameCount; // Now safe from division by zero
-                break;
-              case FRAME_SEQUENTIAL:
-              default:
-                p->frame = 0;
-                break;
-            }
-        } else {
-            p->frame = 0;
-            p->frameRate = 0.0f;
-            p->frameTimer = 0.0f;
-        }
+        // Frame initialization
+        init_particle_frame(p, ps);
 
         // Angle and velocity calculation
-        float theta;
-        if (fullCircle) {
-            theta = deg_to_rad(rnd01() * 360.0f);
-        } else {
-            theta = deg_to_rad(nAngMin + rnd01() * angleRange);
-        }
+        float angle = nAngMin + rnd01() * span;
+        angle = fmodf(angle, 360.0f);
+        float theta = deg_to_rad(angle);
         float speed = speedMin + rnd01() * speedRange;
 
         p->vx = speed * cosf(theta);
@@ -489,11 +527,12 @@ int roxy_particles_spawnMultiple_l(lua_State* L)
         p->x = ex;
         p->y = ey;
         p->size = sizeMin + rnd01() * sizeRange;
-
-        spawned++;
     }
 
-    pd->lua->pushInt(spawned);
+    // Update activeCount once at the end
+    ps->activeCount += actualCount;
+
+    pd->lua->pushInt(actualCount);
     return 1;
 }
 
@@ -518,16 +557,23 @@ int roxy_particles_update_l(lua_State* L)
     float axdt = ax * dt;
     float aydt = ay * dt;
 
-    int hasActiveParticles = 0;
-    for (int i = 0; i < ps->maxCount; ++i) {
+    float frameStep = 0.0f;
+    int doAnim = (ps->frameCount > 0);
+    if (doAnim) {
+        frameStep = 1.0f / fmaxf(ps->frameRate, 1.0f);
+    }
+
+    for (int i = ps->activeCount - 1; i >= 0; --i) {
         RoxyParticle* p = &ps->pool[i];
-        if (!p->alive) continue;
-        hasActiveParticles = 1;
 
         p->age += dt;
         if (p->age >= p->lifetime) {
-            p->alive = 0;
-            p->age = 0.0f;
+            // Kill particle by swapping with the last active particle
+            ps->activeCount--;
+            if (i < ps->activeCount) *p = ps->pool[ps->activeCount];
+            // Mark the now-unused slot as dead
+            ps->pool[ps->activeCount].alive = 0;
+            ps->pool[ps->activeCount].age = 0.0f;
             continue;
         }
 
@@ -539,38 +585,41 @@ int roxy_particles_update_l(lua_State* L)
         // FrameCount validation for animation
         if (p->frameRate > 0.0f && ps->frameCount > 0) {
             p->frameTimer += dt;
-            float frameStep = 1.0f / p->frameRate;
-            while (p->frameTimer >= frameStep) {
-                p->frameTimer -= frameStep;
+            float thisStep = (p->frameRate > 0.0f) ? (1.0f / p->frameRate) : frameStep;
+            while (p->frameTimer >= thisStep) {
+                p->frameTimer -= thisStep;
 
                 // Advance (or pick) the next frame
                 switch (ps->frameMode) {
-                  case FRAME_SEQUENTIAL:
-                    p->frame++;
-                    if (p->frame >= ps->frameCount) {
-                      if (ps->shouldLoop) p->frame = 0;
-                      else p->frame = ps->frameCount - 1;
-                    }
-                    break;
-                  case FRAME_REVERSE:
-                    p->frame--;
-                    if (p->frame < 0) {
-                      if (ps->shouldLoop) p->frame = ps->frameCount - 1;
-                      else p->frame = 0;
-                    }
-                    break;
-                  case FRAME_RANDOM:
-                    p->frame = rand() % ps->frameCount;
-                    break;
-                  case FRAME_STATIC:
-                  default:
-                    // No change
-                    break;
+                    case FRAME_SEQUENTIAL:
+                        p->frame++;
+                        if (p->frame >= ps->frameCount) {
+                            if (ps->shouldLoop) p->frame = 0;
+                            else p->frame = ps->frameCount - 1;
+                        }
+                        break;
+                    case FRAME_REVERSE:
+                        p->frame--;
+                        if (p->frame < 0) {
+                            if (ps->shouldLoop) p->frame = ps->frameCount - 1;
+                            else p->frame = 0;
+                        }
+                        break;
+                    case FRAME_RANDOM:
+                        if (ps->frameCount > 0) {
+                            p->frame = rand() % ps->frameCount;
+                        }
+                        break;
+                    case FRAME_STATIC:
+                    default:
+                        // No change
+                        break;
                 }
             }
         }
     }
-    pd->lua->pushBool(hasActiveParticles);
+
+    pd->lua->pushBool(ps->activeCount > 0);
     return 1;
 }
 
@@ -578,7 +627,7 @@ int roxy_particles_update_l(lua_State* L)
 // Draws all active particles
 int roxy_particles_draw_l(lua_State* L)
 {
-    RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
+    const RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
     if (!ps || !ps->pool) return 0;
 
     int color = pd->lua->getArgInt(2); // kColorBlack or kColorWhite
@@ -586,14 +635,12 @@ int roxy_particles_draw_l(lua_State* L)
     shapeID = roxy_math_clampi(shapeID, 0, 3);
 
     if (ps->imageTable && ps->frameCount > 0) { // FrameCount validation
-        int frameW = 0, frameH = 0;
-        // Get first frame using 0-based indexing
-        LCDBitmap *first = pd->graphics->getTableBitmap(ps->imageTable, 0);
-        if (first) pd->graphics->getBitmapData(first, &frameW, &frameH, NULL, NULL, NULL);
+        int frameW = ps->cachedFrameW;
+        int frameH = ps->cachedFrameH;
 
-        for (int i = 0; i < ps->maxCount; ++i) {
-            RoxyParticle* p = &ps->pool[i];
-            if (!p->alive) continue;
+        // Only loop through active particles
+        for (int i = 0; i < ps->activeCount; ++i) {
+            const RoxyParticle* p = &ps->pool[i];
 
             // Clamp frame to valid range
             int frame = p->frame;
@@ -603,7 +650,8 @@ int roxy_particles_draw_l(lua_State* L)
             // Use 0-based indexing for frame access
             LCDBitmap* bmp = pd->graphics->getTableBitmap(ps->imageTable, frame);
             if (bmp)
-                pd->graphics->drawBitmap(bmp, (int)(p->x - frameW/2), (int)(p->y - frameH/2), kBitmapUnflipped);
+                pd->graphics->drawBitmap(bmp, (int)(p->x - frameW/2.0f), (int)(p->y - frameH/2.0f), kBitmapUnflipped);
+
         }
         return 0;
     }
@@ -611,18 +659,20 @@ int roxy_particles_draw_l(lua_State* L)
     // Decide once: for filled shapes use pattern ptr or solid color
     void* fillColorPtr;
     if (ps->hasPattern && (shapeID == 0 || shapeID == 2)) {
-        fillColorPtr = ps->pattern;
+        fillColorPtr = (void*)(ps->pattern); // Cast is safe for API
     } else {
         fillColorPtr = (void*)(intptr_t)color;
     }
 
-    for (int i = 0; i < ps->maxCount; ++i) {
-        RoxyParticle* p = &ps->pool[i];
-        if (!p->alive) continue;
+    // Only loop through active particles
+    for (int i = 0; i < ps->activeCount; ++i) {
+        const RoxyParticle* p = &ps->pool[i];
 
         int x = (int)(p->x);
         int y = (int)(p->y);
         int size = (int)(p->size + 0.5f);
+        if (size < 1) size = 1;
+        if (size > 256) size = 256;
 
         switch (shapeID) {
             case 0: // Filled circle
@@ -773,11 +823,32 @@ int roxy_particles_resizePool_l(lua_State* L)
         return 1;
     }
 
-    // Compute sizes and attempt to realloc
-    size_t oldBytes = sizeof(RoxyParticle) * (size_t)ps->maxCount;
+    // Hard cap to avoid runaway allocations on device
+    if (newMax > ROXY_PARTICLES_MAX_COUNT) {
+        pd->system->logToConsole("RoxyParticlesC.resizePool: newMax=%d exceeds cap=%d",
+                                 newMax, ROXY_PARTICLES_MAX_COUNT);
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    // Additional safety check for reasonable limits on resource-constrained hardware
+    if (newMax > ROXY_PARTICLES_SAFE_MAX) {
+        pd->system->logToConsole("RoxyParticlesC.resizePool: newMax=%d exceeds safe limit=%d, consider using multiple smaller systems",
+                                 newMax, ROXY_PARTICLES_SAFE_MAX);
+    }
+
+    // Overflow guard for multiplication
+    if ((size_t)newMax > (SIZE_MAX / sizeof(RoxyParticle))) {
+        pd->system->logToConsole("RoxyParticlesC.resizePool: size overflow for newMax=%d", newMax);
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
     size_t newBytes = sizeof(RoxyParticle) * (size_t)newMax;
-    RoxyParticle* newBuf = pd->system->realloc(ps->pool, newBytes);
+
+    RoxyParticle* newBuf = (RoxyParticle*)roxy_realloc(ps->pool, newBytes);
     if (!newBuf) {
+        pd->system->logToConsole("RoxyParticlesC.resizePool: Failed to reallocate pool to %d particles", newMax);
         // On failure, leave the old pool intact
         pd->lua->pushBool(0);
         return 1;
@@ -785,11 +856,17 @@ int roxy_particles_resizePool_l(lua_State* L)
 
     // If we grew the pool, zero out the new slots
     if (newMax > ps->maxCount) {
-        memset(newBuf + ps->maxCount, 0, sizeof(RoxyParticle) * (newMax - ps->maxCount));
+        roxy_memset(newBuf + ps->maxCount, 0, sizeof(RoxyParticle) * (size_t)(newMax - ps->maxCount));
+    } else if (newMax < ps->maxCount) {
+        // If we shrunk the pool, adjust activeCount if necessary
+        if (ps->activeCount > newMax) {
+            ps->activeCount = newMax;
+        }
     }
 
-    // pdate our struct and report success
-    ps->pool     = newBuf;
+    // Update our struct and (re)label for nicer heap dumps
+    ps->pool = newBuf;
+    ROXY_LABEL(ps->pool, "RoxyParticlesC.pool");
     ps->maxCount = newMax;
 
     pd->lua->pushBool(1);
@@ -802,16 +879,17 @@ int roxy_particles_clear_l(lua_State* L)
 {
     RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
     if (!ps || !ps->pool) {
-        pd->lua->pushBool(0); // Indicate no particles active
+        pd->lua->pushBool(0);
         return 1;
     }
 
     for (int i = 0; i < ps->maxCount; ++i) {
         ps->pool[i].alive = 0;
-        ps->pool[i].age = 0.0f; // Reset age for safety
+        ps->pool[i].age = 0.0f;
     }
+    ps->activeCount = 0;
 
-    pd->lua->pushBool(0); // Indicate no particles active
+    pd->lua->pushBool(1);
     return 1;
 }
 
@@ -820,9 +898,16 @@ int roxy_particles_clear_l(lua_State* L)
 int roxy_particles_destroy_l(lua_State* L)
 {
     RoxyParticlesC* ps = pd->lua->getArgObject(1, "RoxyParticlesC", NULL);
-    if (ps) {
-        roxy_particles_free_pool(ps);
-    }
+    if (!ps) return 0;
+
+    // Idempotent: safe to call multiple times
+    roxy_particles_free_pool(ps);
+    ps->activeCount = 0;
+    ps->maxCount    = 0;
+    ps->imageTable  = NULL;
+    ps->frameCount  = 0;
+    // __gc will free the struct when Lua releases the userdata
+
     return 0;
 }
 

--- a/core/sprites/roxy_particles.h
+++ b/core/sprites/roxy_particles.h
@@ -1,39 +1,73 @@
+// core/sprites/roxy_particles.h
+
 #ifndef ROXY_PARTICLES_H
 #define ROXY_PARTICLES_H
 
 #include "pd_api.h"
 
+// Frame animation modes for particles
 typedef enum {
-    FRAME_STATIC = 0,
-    FRAME_SEQUENTIAL = 1,
-    FRAME_REVERSE = 2,
-    FRAME_RANDOM = 3
+    FRAME_SEQUENTIAL = 0,   // Play frames 0, 1, 2... in order
+    FRAME_REVERSE    = 1,   // Play frames backwards (n-1, n-2, ... 0)
+    FRAME_RANDOM     = 2,   // Pick random frame each step
+    FRAME_STATIC     = 3    // Use only the staticFrame
 } FrameMode;
 
+// Individual particle data
 typedef struct {
-    float x, y;
-    float vx, vy;
-    float age, lifetime;
-    float size;
-    int   frame;
-    float frameTimer;
-    float frameRate;
-    int   alive;
+    float x, y;         // Position
+    float vx, vy;       // Velocity
+    float size;         // Particle size
+    float age;          // Current age
+    float lifetime;     // Total lifetime
+    int alive;          // Whether particle is active
+    int frame;          // Current animation frame (0-based)
+    float frameRate;    // Animation frame rate (fps)
+    float frameTimer;   // Animation timing accumulator
 } RoxyParticle;
 
+// Particle system container
 typedef struct {
-    int maxCount;
-    RoxyParticle *pool;
-    LCDBitmapTable* imageTable;
-    int frameCount;
-    FrameMode frameMode;
-    int staticFrame;
-    int shouldLoop;
-    float frameRate;
-    uint8_t pattern[16];
-    bool hasPattern;
+    RoxyParticle* pool;         // Particle pool array
+    int maxCount;               // Maximum number of particles
+    int activeCount;            // Number of active particles
+    LCDBitmapTable* imageTable; // Optional image table for sprite particles
+    int cachedFrameW;           // Cached bitmap width
+    int cachedFrameH;           // Cached bitmap height
+    int frameCount;             // Number of frames in imageTable
+    FrameMode frameMode;        // Animation mode
+    int staticFrame;            // Frame to use for FRAME_STATIC mode (0-based)
+    int shouldLoop;             // Whether animations should loop
+    float frameRate;            // Default frame rate for new particles
+    int hasPattern;             // Whether a fill pattern is set
+    uint8_t pattern[16];        // Fill pattern data (8 bytes fill + 8 bytes mask)
 } RoxyParticlesC;
 
-void registerRoxyParticlesC(PlaydateAPI* pd);
+// Function prototypes for external use and better modularity
 
-#endif /* ROXY_PARTICLES_H */
+// Core lifecycle functions
+RoxyParticlesC* roxy_particles_new(int maxCount, LCDBitmapTable* tbl, FrameMode frameMode,
+                                   int staticFrame, int shouldLoop, float initFrameRate);
+void roxy_particles_free_pool(RoxyParticlesC* ps);
+
+// Lua constructor and destructor
+int roxy_particles_newobject(lua_State* L);
+int roxy_particles_gc(lua_State* L);
+
+// Lua-exposed methods
+int roxy_particles_setPattern_l(lua_State* L);
+int roxy_particles_setFrameRate_l(lua_State* L);
+int roxy_particles_setImageTable_l(lua_State* L);
+int roxy_particles_spawn_l(lua_State* L);
+int roxy_particles_spawnMultiple_l(lua_State* L);
+int roxy_particles_update_l(lua_State* L);
+int roxy_particles_draw_l(lua_State* L);
+int roxy_particles_computeAABB_l(lua_State* L);
+int roxy_particles_resizePool_l(lua_State* L);
+int roxy_particles_clear_l(lua_State* L);
+int roxy_particles_destroy_l(lua_State* L);
+
+// Registration function
+void registerRoxyParticlesC(PlaydateAPI* playdate);
+
+#endif // ROXY_PARTICLES_H

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -2,6 +2,7 @@
 
 #include "roxy_tileRenderer.h"
 #include "../../utilities/roxy_math.h"
+#include "../../utilities/roxy_heapguard.h"
 #include <string.h>
 #include <math.h>
 #include <limits.h>
@@ -19,17 +20,25 @@ void roxy_tileRenderer_setPlaydateAPI(PlaydateAPI* playdate)
 // Helpers
 // -----------------------------------------------------------------------------
 
-static void* pd_alloc(size_t sz)
-{
+// Site-aware pd_alloc / pd_free that preserve the caller's file:line
+static inline void* pd_alloc_site(size_t sz, const char* file, uint32_t line) {
+    (void)file; (void)line;
     if (!pd || !pd->system) return NULL;
-    return pd->system->realloc(NULL, sz);
+    return roxy_realloc_site(NULL, sz, file, line);
 }
-
-static void pd_free(void* p)
-{
+static inline void pd_free_site(void* p, const char* file, uint32_t line) {
+    (void)file; (void)line;
     if (!pd || !pd->system) return;
-    pd->system->realloc(p, 0);
+    roxy_free_site(p, file, line);
 }
+#ifdef pd_alloc
+#undef pd_alloc
+#endif
+#ifdef pd_free
+#undef pd_free
+#endif
+#define pd_alloc(sz) pd_alloc_site((sz), __FILE__, (uint32_t)__LINE__)
+#define pd_free(p) pd_free_site((p), __FILE__, (uint32_t)__LINE__)
 
 static inline int roxy_valid(const RoxyTileRendererC* tileRenderer) {
     return tileRenderer && tileRenderer->magic == ROXY_MAGIC && tileRenderer->alive;
@@ -117,7 +126,8 @@ static int roxy_tileRenderer_newobject(lua_State* L)
 
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd_alloc(sizeof(RoxyTileRendererC));
     if (!tileRenderer) return 0; // Do not call roxy_valid before initialization
-    memset(tileRenderer, 0, sizeof(*tileRenderer));
+    roxy_memset(tileRenderer, 0, sizeof(*tileRenderer));
+    ROXY_LABEL(tileRenderer, "RoxyTileRendererC");
     tileRenderer->magic = ROXY_MAGIC; // Initialize magic cookie
     tileRenderer->alive = 1;          // Mark as alive
 
@@ -135,7 +145,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     // Validate map size to avoid overflow on multiplication
     const int mw = tileRenderer->mapWidth;
     const int mh = tileRenderer->mapHeight;
-    if (mw <= 0 || mh <= 0 || mw > (INT_MAX / (mh > 0 ? mh : 1))) {
+    if (mw <= 0 || mh <= 0 || mw > INT_MAX / mh) {
         pd->system->logToConsole("RoxyTileRendererC.new: invalid map size %d x %d", mw, mh);
         pd_free(tileRenderer);
         return 0;
@@ -163,15 +173,30 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     tileRenderer->imageCount = pd->lua->getArgInt(12);
     if (tileRenderer->imageCount < 0) tileRenderer->imageCount = 0; // Sanitize
 
-    // Precompute draw offsets
-    tileRenderer->offsetX = (int16_t*)pd_alloc(sizeof(int16_t) * (tileRenderer->imageCount + 1));
-    tileRenderer->offsetY = (int16_t*)pd_alloc(sizeof(int16_t) * (tileRenderer->imageCount + 1));
+    // Precompute draw offsets with overflow guard
+    if (tileRenderer->imageCount < 0) tileRenderer->imageCount = 0;
+    size_t countWithZero = (size_t)tileRenderer->imageCount + 1;
+    if (countWithZero > SIZE_MAX / sizeof(int16_t)) {
+        pd->system->logToConsole("RoxyTileRendererC.new: offset array size overflow");
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
+
+    tileRenderer->offsetX = (int16_t*)pd_alloc(countWithZero * sizeof(int16_t));
+    if (tileRenderer->offsetX) ROXY_LABEL(tileRenderer->offsetX, "RoxyTileRendererC.offsetX");
+
+    tileRenderer->offsetY = (int16_t*)pd_alloc(countWithZero * sizeof(int16_t));
+    if (tileRenderer->offsetY) ROXY_LABEL(tileRenderer->offsetY, "RoxyTileRendererC.offsetY");
+
     if (!tileRenderer->offsetX || !tileRenderer->offsetY) {
         roxy_tileRenderer_free(tileRenderer);
         pd_free(tileRenderer);
         return 0;
     }
-    tileRenderer->offsetX[0] = tileRenderer->offsetY[0] = 0;
+
+    tileRenderer->offsetX[0] = 0;
+    tileRenderer->offsetY[0] = 0;
 
     for (int i = 1; i <= tileRenderer->imageCount; ++i) {
         // Convert 1-based tile index to 0-based bitmap table index
@@ -190,15 +215,22 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         tileRenderer->offsetY[i] = offsetY;
     }
 
-    // Tiles blob (optional)
+    // Tiles blob (optional) with overflow guard
     const int tilesCount = mw * mh;
+    if ((size_t)tilesCount > SIZE_MAX / sizeof(int32_t)) {
+        pd->system->logToConsole("RoxyTileRendererC.new: tiles size overflow");
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
     tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
     if (!tileRenderer->tiles) {
         roxy_tileRenderer_free(tileRenderer);
         pd_free(tileRenderer);
         return 0;
     }
-    memset(tileRenderer->tiles, 0, sizeof(int32_t) * tilesCount);
+    roxy_memset(tileRenderer->tiles, 0, sizeof(int32_t) * tilesCount);
+    ROXY_LABEL(tileRenderer->tiles, "RoxyTileRendererC.tiles");
 
     if (argumentCount >= 13 && !pd->lua->argIsNil(13)) {
         size_t bytesLength = 0;
@@ -256,14 +288,19 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
 
     const int tilesCount = tileRenderer->mapWidth * tileRenderer->mapHeight;
     if ((int)bytesLength != tilesCount * 2 && (int)bytesLength != tilesCount * 4) {
-        pd->system->logToConsole("updateTilesBytes: bad size %d (expected %d or %d)",
+        pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: bad size %d (expected %d or %d)",
                                  (int)bytesLength, tilesCount*2, tilesCount*4);
         return 0;
     }
 
     if (!tileRenderer->tiles) {
+        if ((size_t)tilesCount > SIZE_MAX / sizeof(int32_t)) {
+            pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: tiles size overflow");
+            return 0;
+        }
         tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
         if (!tileRenderer->tiles) return 0;
+        ROXY_LABEL(tileRenderer->tiles, "RoxyTileRendererC.tiles");
     }
 
     if ((int)bytesLength == tilesCount * 2) {
@@ -274,7 +311,7 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
             if (v < 0 || v > tileRenderer->imageCount) v = 0;
             tileRenderer->tiles[i] = v;
         }
-        tileRenderer->tilesCountBytes = (int)bytesLength; // unchanged
+        tileRenderer->tilesCountBytes = (int)bytesLength;
     } else {
         for (int i = 0; i < tilesCount; ++i) {
             const uint8_t* p = (const uint8_t*)bytes + 4*i;
@@ -283,7 +320,7 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
             if (v < 0 || v > tileRenderer->imageCount) v = 0;
             tileRenderer->tiles[i] = v;
         }
-        tileRenderer->tilesCountBytes = (int)bytesLength; // unchanged
+        tileRenderer->tilesCountBytes = (int)bytesLength;
     }
     return 0;
 }
@@ -421,11 +458,12 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     const int offsetY = pd->lua->getArgInt(4);
     const int bufferWidth = pd->lua->getArgInt(5);
     const int bufferHeight = pd->lua->getArgInt(6);
+    if (bufferWidth <= 0 || bufferHeight <= 0) return 0;
 
     // Defensive check to prevent division-by-zero
     if (tileRenderer->tileWidth <= 0 || tileRenderer->halfTileHeight <= 0 ||
         tileRenderer->halfTileWidth <= 0) {
-        pd->system->logToConsole("renderToBuffer: invalid tile dimensions, cannot render");
+        pd->system->logToConsole("RoxyTileRendererC.renderToBuffer: invalid tile dimensions, cannot render");
         return 0;
     }
 

--- a/roxy.c
+++ b/roxy.c
@@ -1,4 +1,4 @@
-// source/libraries/roxy/roxy.c
+// roxy.c
 
 #include "pd_api.h"
 #include "utilities/roxy_math.h"
@@ -8,6 +8,7 @@
 #include "core/animations/roxy_animation.h"
 #include "core/sprites/roxy_particles.h"
 #include "core/tilemaps/roxy_tileRenderer.h"
+#include "utilities/roxy_heapguard.h"
 
 static PlaydateAPI* pd = NULL;
 static uint32_t previousTime = 0;
@@ -19,15 +20,14 @@ static uint32_t previousTime = 0;
 static int getDeltaTime_l(lua_State* L);
 static float clampDeltaTime(float deltaTime, float min, float max);
 
-// ----------------------------------------
-// Public API
-// ----------------------------------------
+/*******************************************//**
+ *  Public API
+ ***********************************************/
 
 #ifdef _WINDLL
 __declspec(dllexport)
 #endif
-int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg)
-{
+int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg) {
     (void)arg;
 
     if (event != kEventInitLua) {
@@ -222,12 +222,20 @@ int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg)
     // ! Register RoxyTileRendererC Class
     registerRoxyTileRendererC(pd);
 
+    // ! Heap Guard
+    // Debug only; registrar is a no-op in release
+    roxy_heapguard_init(pd);
+    if (roxy_heapguard_register_lua(pd) < 0) {
+        pd->system->logToConsole("roxy: heapguard lua registration failed");
+        return -1;
+    }
+
     return 0;
 }
 
-// ----------------------------------------
-// Lua-Exposed Functions
-// ----------------------------------------
+/*******************************************//**
+ *  Lua-Exposed Functions
+ ***********************************************/
 
 //
 // ! Get Delta Time
@@ -239,8 +247,9 @@ int eventHandler(PlaydateAPI* playdate, PDSystemEvent event, uint32_t arg)
 //   local dt = roxy.getDeltaTime()
 //   player.x = player.x + (player.speed * dt)
 //
-static int getDeltaTime_l(lua_State* L)
-{
+static int getDeltaTime_l(lua_State* L) {
+    (void)L;
+
     if (pd == NULL) {
         return 0;
     }

--- a/roxy.lua
+++ b/roxy.lua
@@ -67,7 +67,6 @@ local Sprite    <const> = Graphics.sprite
 
 local r           <const> = roxy
 local Debug       <const> = r.Debug
-local GameData    <const> = r.GameData
 local Cache       <const> = r.Cache
 local Config      <const> = r.Config
 local Input       <const> = r.Input
@@ -83,8 +82,6 @@ local randomseed <const> = math.randomseed
 local getSecondsSinceEpoch  <const> = pd.getSecondsSinceEpoch
 local spriteUpdate          <const> = Sprite.update
 
-local mergeImmutable <const> =roxy.Table.mergeImmutable
-
 local initConfig <const> = Config.init
 
 local getDeltaTime <const> = r.getDeltaTime
@@ -94,7 +91,6 @@ local drawCrankIndicator  <const> = Input.drawCrankIndicator
 
 local updateSequences <const> = Sequencer.update
 
-local loadTransitions             <const> = Transition.loadTransitions
 local prepareTransitionScreenshot <const> = Transition.prepareTransitionScreenshot
 local executeTransitionDrawing    <const> = Transition.executeTransitionDrawing
 
@@ -103,10 +99,9 @@ local getUpdateList     <const> = Scene.getUpdateList
 local getBackgroundList <const> = Scene.getBackgroundList
 local getDrawList       <const> = Scene.getDrawList
 
-local updateDebug <const> = Debug.update --#DEBUG
-local drawFPS     <const> = pd.drawFPS --#DEBUG
+local updateDebug <const> = Debug.update  --#DEBUG
+local drawFPS     <const> = pd.drawFPS    --#DEBUG
 
--- Constants
 local SHOW_FPS_DEFAULT  <const> = true    --#DEBUG
 local FPS_X_DEFAULT     <const> = 385     --#DEBUG
 local FPS_Y_DEFAULT     <const> = 228     --#DEBUG

--- a/utilities/roxy_heapguard.c
+++ b/utilities/roxy_heapguard.c
@@ -1,0 +1,419 @@
+// utilities/roxy_heapguard.c
+
+/**
+ * Roxy Heap Guard implementation
+ *
+ * Debug mode adds canaries + red-zone around each allocation, tracks blocks in
+ * a linked list, verifies integrity, and can dump all live allocations.
+ * Release mode compiles these functions as thin forwards or no-ops so that
+ * header macros can expand directly to the Playdate allocator with zero overhead.
+ */
+
+#include "roxy_heapguard.h"
+
+#include <string.h>
+#include <stdio.h>
+
+/*******************************************//**
+ *  Configuration and Constants (Debug Path)
+ ***********************************************/
+
+#ifndef ROXY_HG_HEAD
+#define ROXY_HG_HEAD 0xC0DEF00Du
+#endif
+#ifndef ROXY_HG_TAIL
+#define ROXY_HG_TAIL 0xDEADC0DEu
+#endif
+#ifndef ROXY_HG_POISON
+#define ROXY_HG_POISON 0xA5
+#endif
+
+#define ROXY_HG_TAILBYTES 4u
+#define ROXY_HG_POISON_BYTES (ROXY_HG_REDZONE - ROXY_HG_TAILBYTES)
+
+#if ROXY_HEAP_GUARD
+_Static_assert(ROXY_HG_REDZONE >= ROXY_HG_TAILBYTES, "ROXY_HG_REDZONE must be >= 4");
+_Static_assert((ROXY_HG_REDZONE % ROXY_HG_TAILBYTES) == 0, "ROXY_HG_REDZONE must be multiple of 4");
+#endif
+
+/*******************************************//**
+ *  Internal State
+ ***********************************************/
+
+typedef struct RoxyHgHeader {
+    uint32_t headCanary;
+    uint32_t size;      // User allocation size
+    const char* label;  // Optional label (not owned)
+    const char* file;   // Allocation site
+    uint32_t line;      // Allocation site
+    struct RoxyHgHeader* prev;
+    struct RoxyHgHeader* next;
+} RoxyHgHeader;
+
+static const struct PlaydateAPI* s_pd = NULL;
+
+#if ROXY_HEAP_GUARD
+static RoxyHgHeader* s_head = NULL; // Intrusive list head
+static size_t s_total_allocated = 0;
+static size_t s_peak_allocated  = 0;
+#endif
+
+/******************************************//**
+ *   Small Helpers
+ ***********************************************/
+
+#if ROXY_HEAP_GUARD
+static inline uint8_t* roxy_hg_user(RoxyHgHeader* h) {
+    return (uint8_t*)h + sizeof(RoxyHgHeader);
+}
+static inline uint32_t* roxy_hg_tailp(RoxyHgHeader* h) {
+    return (uint32_t*)(roxy_hg_user(h) + h->size + ROXY_HG_POISON_BYTES);
+}
+static inline void roxy_hg_link(RoxyHgHeader* h) {
+    h->prev = NULL;
+    h->next = s_head;
+    if (s_head) s_head->prev = h;
+    s_head = h;
+}
+static inline void roxy_hg_unlink(RoxyHgHeader* h) {
+    if (h->prev) h->prev->next = h->next;
+    else s_head = h->next;
+    if (h->next) h->next->prev = h->prev;
+}
+static void roxy_hg_fail(const char* reason, RoxyHgHeader* h) {
+    if (!s_pd || !s_pd->system) return;
+    s_pd->system->error(
+        "HeapGuard: %s (size=%u, site=%s:%u%s%s)",
+        reason,
+        (unsigned)h->size,
+        h->file ? h->file : "?",
+        (unsigned)h->line,
+        h->label ? ", label=" : "",
+        h->label ? h->label : ""
+    );
+}
+static void roxy_hg_check(RoxyHgHeader* h) {
+    if (h->headCanary != ROXY_HG_HEAD) roxy_hg_fail("Head canary clobbered", h);
+    if (ROXY_HG_POISON_BYTES) {
+        uint8_t* rz = roxy_hg_user(h) + h->size;
+        for (uint32_t i = 0; i < ROXY_HG_POISON_BYTES; ++i) {
+            if (rz[i] != ROXY_HG_POISON) roxy_hg_fail("Red zone overwritten", h);
+        }
+    }
+    if (*roxy_hg_tailp(h) != ROXY_HG_TAIL) roxy_hg_fail("Tail canary clobbered", h);
+}
+#endif // ROXY_HEAP_GUARD
+
+/*******************************************//**
+ *  Public API
+ ***********************************************/
+
+// ! Initialize
+void roxy_heapguard_init(const struct PlaydateAPI* playdate) {
+    s_pd = playdate;
+#if ROXY_HEAP_GUARD
+    // Reset debug state (useful on hot reloads)
+    s_head = NULL;
+    s_total_allocated = 0;
+    s_peak_allocated  = 0;
+#endif
+}
+
+// ! Verify All
+void roxy_heapguard_verify_all(void) {
+#if ROXY_HEAP_GUARD
+    for (RoxyHgHeader* h = s_head; h; h = h->next) roxy_hg_check(h);
+#endif
+}
+
+// ! Dump Active
+void roxy_heapguard_dump_active(void) {
+    if (!s_pd || !s_pd->system) return;
+#if ROXY_HEAP_GUARD
+    s_pd->system->logToConsole("=== Roxy HeapGuard active allocations ===");
+    for (RoxyHgHeader* h = s_head; h; h = h->next) {
+        uintptr_t start = (uintptr_t)roxy_hg_user(h);
+        uintptr_t end   = start + h->size - 1;
+        uintptr_t rz_s  = end + 1;
+        uintptr_t rz_e  = rz_s + ROXY_HG_POISON_BYTES + 4 - 1; // +tail
+        if (h->label) {
+            s_pd->system->logToConsole(
+                " %08x..%08x size=%u label=%s (site %s:%u) rz=%08x..%08x",
+                (unsigned)start, (unsigned)end, (unsigned)h->size,
+                h->label, h->file ? h->file : "?", (unsigned)h->line,
+                (unsigned)rz_s, (unsigned)rz_e
+            );
+        } else {
+            s_pd->system->logToConsole(
+                " %08x..%08x size=%u from %s:%u rz=%08x..%08x",
+                (unsigned)start, (unsigned)end, (unsigned)h->size,
+                h->file ? h->file : "?", (unsigned)h->line,
+                (unsigned)rz_s, (unsigned)rz_e
+            );
+        }
+    }
+    s_pd->system->logToConsole(
+        "Total allocated: %u bytes, Peak: %u bytes",
+        (unsigned)s_total_allocated, (unsigned)s_peak_allocated
+    );
+#else
+    s_pd->system->logToConsole("HeapGuard: dump_active (release): no tracking (ROXY_HEAP_GUARD=0)");
+#endif
+}
+
+// ! Label
+void roxy_heapguard_label(void* user, const char* label) {
+#if ROXY_HEAP_GUARD
+    if (!user) return;
+    RoxyHgHeader* h = (RoxyHgHeader*)((uint8_t*)user - sizeof(RoxyHgHeader));
+    h->label = label;
+#else
+    (void)user; (void)label;
+#endif
+}
+
+/*******************************************//**
+ *  Allocation Wrappers
+ ***********************************************/
+
+// ! malloc
+void* roxy_malloc_site(size_t size, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    if (!s_pd || !s_pd->system) return NULL;
+    size_t total = sizeof(RoxyHgHeader) + size + ROXY_HG_REDZONE;
+    RoxyHgHeader* h = (RoxyHgHeader*)s_pd->system->realloc(NULL, total);
+    if (!h) return NULL;
+    h->headCanary = ROXY_HG_HEAD;
+    h->size       = (uint32_t)size;
+    h->label      = NULL;
+    h->file       = file;
+    h->line       = line;
+    roxy_hg_link(h);
+    uint8_t* user = (uint8_t*)h + sizeof(RoxyHgHeader);
+    if (ROXY_HG_POISON_BYTES) memset(user + h->size, ROXY_HG_POISON, ROXY_HG_POISON_BYTES);
+    *roxy_hg_tailp(h) = ROXY_HG_TAIL;
+    s_total_allocated += size;
+    if (s_total_allocated > s_peak_allocated) s_peak_allocated = s_total_allocated;
+    return user;
+#else
+    (void)file; (void)line;
+    return (s_pd && s_pd->system) ? s_pd->system->realloc(NULL, size) : NULL;
+#endif
+}
+
+// ! Label (alloc)
+void* roxy_alloc_label_site(size_t size, const char* label, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    void* p = roxy_malloc_site(size, file, line);
+    if (p) roxy_heapguard_label(p, label);
+    return p;
+#else
+    (void)label; (void)file; (void)line;
+    return (s_pd && s_pd->system) ? s_pd->system->realloc(NULL, size) : NULL;
+#endif
+}
+
+// ! calloc
+void* roxy_calloc_site(size_t count, size_t size, const char* file, uint32_t line) {
+    size_t bytes = count * size;
+    void* p = roxy_malloc_site(bytes, file, line);
+    if (p) memset(p, 0, bytes);
+    return p;
+}
+
+// ! realloc
+void* roxy_realloc_site(void* user, size_t newSize, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    if (!s_pd || !s_pd->system) return NULL;
+    if (!user) return roxy_malloc_site(newSize, file, line);
+    RoxyHgHeader* h = (RoxyHgHeader*)((uint8_t*)user - sizeof(RoxyHgHeader));
+    roxy_hg_check(h);
+
+    size_t oldSize  = h->size;
+    size_t totalNew = sizeof(RoxyHgHeader) + newSize + ROXY_HG_REDZONE;
+    RoxyHgHeader* hNew = (RoxyHgHeader*)s_pd->system->realloc(h, totalNew);
+    if (!hNew) return NULL;
+
+    // Fix intrusive list pointers if block moved
+    if (hNew != h) {
+        if (hNew->prev) hNew->prev->next = hNew; else s_head = hNew;
+        if (hNew->next) hNew->next->prev = hNew;
+    }
+
+    hNew->size = (uint32_t)newSize;
+    hNew->file = file;
+    hNew->line = line;
+
+    uint8_t* userNew = (uint8_t*)hNew + sizeof(RoxyHgHeader);
+    if (ROXY_HG_POISON_BYTES) memset(userNew + newSize, ROXY_HG_POISON, ROXY_HG_POISON_BYTES);
+    *roxy_hg_tailp(hNew) = ROXY_HG_TAIL;
+
+    if (newSize >= oldSize) {
+        s_total_allocated += (newSize - oldSize);
+        if (s_total_allocated > s_peak_allocated) s_peak_allocated = s_total_allocated;
+    } else {
+        s_total_allocated -= (oldSize - newSize);
+    }
+
+    return userNew;
+#else
+    (void)file; (void)line;
+    return (s_pd && s_pd->system) ? s_pd->system->realloc(user, newSize) : NULL;
+#endif
+}
+
+// ! Free
+void roxy_free_site(void* user, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    (void)file; (void)line;
+    if (!s_pd || !s_pd->system || !user) return;
+    // Find header: defense-in-depth to ensure it's one of ours.
+    RoxyHgHeader* h = (RoxyHgHeader*)((uint8_t*)user - sizeof(RoxyHgHeader));
+    // Basic header sanity before list operations:
+    if (h->headCanary != ROXY_HG_HEAD) {
+        s_pd->system->error("HeapGuard: free of untracked pointer %p", user);
+        return;
+    }
+    roxy_hg_check(h);
+    memset(user, ROXY_HG_POISON, h->size); // catch UAF reads
+    s_total_allocated -= h->size;
+    roxy_hg_unlink(h);
+    s_pd->system->realloc(h, 0);
+#else
+    (void)file; (void)line;
+    if (s_pd && s_pd->system && user) s_pd->system->realloc(user, 0);
+#endif
+}
+
+/*******************************************//**
+ *  Bounds-Aware memcpy/memset (Debug Only)
+ ***********************************************/
+
+#if ROXY_HEAP_GUARD
+// ! Heap Guard Span Okay
+static int roxy_hg_span_ok(void* dst, size_t n) {
+    uint8_t* p = (uint8_t*)dst;
+    for (RoxyHgHeader* h = s_head; h; h = h->next) {
+        uint8_t* u = (uint8_t*)h + sizeof(RoxyHgHeader);
+        if (p >= u && p < u + h->size) {
+            size_t used = (size_t)(p - u) + n;
+            return used <= h->size;
+        }
+    }
+    return 0;
+}
+#endif
+
+// ! memcpy
+void* roxy_memcpy_site(void* dst, const void* src, size_t n, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    if (!roxy_hg_span_ok(dst, n)) {
+        if (s_pd && s_pd->system) {
+            s_pd->system->logToConsole("roxy_memcpy overflow at %s:%u (n=%u)", file, (unsigned)line, (unsigned)n);
+            s_pd->system->error("roxy_memcpy overflow");
+        }
+    }
+#else
+    (void)file; (void)line;
+#endif
+    return memcpy(dst, src, n);
+}
+
+// ! memset
+void* roxy_memset_site(void* dst, int v, size_t n, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    if (!roxy_hg_span_ok(dst, n)) {
+        if (s_pd && s_pd->system) {
+            s_pd->system->logToConsole("roxy_memset overflow at %s:%u (n=%u)", file, (unsigned)line, (unsigned)n);
+            s_pd->system->error("roxy_memset overflow");
+        }
+    }
+#else
+    (void)file; (void)line;
+#endif
+    return memset(dst, v, n);
+}
+
+// ! Bounds
+void roxy_bounds_site(void* dst, size_t n, const char* file, uint32_t line) {
+#if ROXY_HEAP_GUARD
+    uint8_t* p = (uint8_t*)dst;
+    int ok = 0;
+    for (RoxyHgHeader* h = s_head; h; h = h->next) {
+        uint8_t* u = (uint8_t*)h + sizeof(RoxyHgHeader);
+        if (p >= u && p < u + h->size) {
+            size_t used = (size_t)(p - u) + n;
+            ok = (used <= h->size);
+            if (!ok) {
+                if (s_pd && s_pd->system) {
+                    s_pd->system->logToConsole("roxy_bounds overflow at %s:%u (n=%u)", file, (unsigned)line, (unsigned)n);
+                }
+                roxy_hg_fail("Bounds assertion failed", h);
+            }
+            break;
+        }
+    }
+    if (!ok) {
+        if (s_pd && s_pd->system) {
+            s_pd->system->error("roxy_bounds: pointer not tracked (at %s:%u)", file, (unsigned)line);
+        }
+    }
+#else
+    (void)dst; (void)n; (void)file; (void)line;
+#endif
+}
+
+/*******************************************//**
+ *  Lua bindings & registration
+ ***********************************************/
+
+#if ROXY_HEAP_GUARD
+static uint32_t s_snap = 0;
+
+static int roxy_heapguard_verify_all_l(lua_State* L) {
+    (void)L;
+    roxy_heapguard_verify_all();
+    return 0;
+}
+
+static int roxy_heapguard_dump_active_l(lua_State* L) {
+    (void)L;
+    roxy_heapguard_dump_active();
+    return 0;
+}
+
+static int roxy_heapguard_snap_l(lua_State* L) {
+    if (!s_pd) return 0;
+    const char* tag = s_pd->lua->getArgString(1);
+    roxy_heapguard_verify_all();
+    s_pd->system->logToConsole("HG SNAPSHOT %u BEGIN [%s]", ++s_snap, tag ? tag : "?");
+    roxy_heapguard_dump_active();
+    s_pd->system->logToConsole("HG SNAPSHOT %u END", s_snap);
+    return 0;
+}
+#endif
+
+int roxy_heapguard_register_lua(struct PlaydateAPI* playdate) {
+#if ROXY_HEAP_GUARD
+    if (!playdate || !playdate->lua || !playdate->system) return -1;
+
+    const char* error = NULL;
+
+    struct Reg { const char* name; int (*fn)(lua_State*); } regs[] = {
+        { "roxy.heapGuardVerifyAll", roxy_heapguard_verify_all_l },
+        { "roxy.heapGuardDumpActive", roxy_heapguard_dump_active_l },
+        { "roxy.heapGuardSnap",       roxy_heapguard_snap_l      },
+    };
+
+    for (size_t i = 0; i < sizeof(regs)/sizeof(regs[0]); ++i) {
+        if (!playdate->lua->addFunction(regs[i].fn, regs[i].name, &error)) {
+            playdate->system->logToConsole("heapguard register failed: %s (%s)", regs[i].name, error ? error : "?");
+            return -1;
+        }
+    }
+    return 0;
+#else
+    (void)playdate;
+    return 0; // noop in release
+#endif
+}

--- a/utilities/roxy_heapguard.h
+++ b/utilities/roxy_heapguard.h
@@ -1,0 +1,164 @@
+// utilities/roxy_heapguard.h
+
+/**
+ * Roxy Heap Guard (debug-only allocator instrumentation)
+ *
+ *  - When ROXY_HEAP_GUARD == 1, allocations get canaries + a red zone,
+ *    are tracked in a list, and can be verified/dumped.
+ *  - When ROXY_HEAP_GUARD == 0, the macros below expand directly to
+ *    Playdate's allocator / standard C functions with *no* overhead.
+ *
+ * Usage:
+ *  // In a TU that has a PlaydateAPI* (usually named `pd`):
+ *  #define ROXY_HEAP_GUARD 1 // Enable instrumentation in debug
+ *  #include "utilities/roxy_heapguard.h"
+ *
+ *  // Allocate:
+ *  MyStruct* s = (MyStruct*)roxy_malloc(sizeof(MyStruct));
+ *  ROXY_LABEL(s, "MyStruct");
+ *
+ *  // Or typed helpers (label optional):
+ *  MyStruct* t = ROXY_NEW(MyStruct);                   // sizeof(MyStruct)
+ *  MyStruct* u = ROXY_NEW_LABEL(MyStruct, "Player");   // + label
+ *
+ *  // Bytes helpers:
+ *  void* buf = ROXY_ALLOC_BYTES(1024);
+ *  void* str = ROXY_ALLOC_BYTES_LABEL(len+1, "name");
+ *
+ *  // Realloc/Free:
+ *  p = roxy_realloc(p, newBytes);
+ *  roxy_free(p);
+ *
+ *  // Optional bounds assertions (debug only):
+ *  ROXY_BOUNDS(dst, n);
+ *
+ *  // Lua side (only if ROXY_HEAP_GUARD==1):
+ *  roxy.heapGuardVerifyAll()
+ *  roxy.heapGuardDumpActive()
+ *
+ * If your PlaydateAPI* is not named `pd`, define ROXY_PD_SYMBOL before include:
+ *  #define ROXY_PD_SYMBOL playdate
+ *  #include "utilities/roxy_heapguard.h"
+ */
+
+#ifndef ROXY_HEAP_GUARD_H
+#define ROXY_HEAP_GUARD_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "pd_api.h"
+
+/*******************************************//**
+ *  Configuration
+ ***********************************************/
+
+// Default OFF unless explicitly enabled by build flags or before-include define
+#ifndef ROXY_HEAP_GUARD
+#define ROXY_HEAP_GUARD 0
+#endif
+
+// Which symbol names your PlaydateAPI* in this translation unit?
+#ifndef ROXY_PD_SYMBOL
+#define ROXY_PD_SYMBOL pd
+#endif
+
+// Red-zone size (bytes) when guard is on; multiple of 4, >= 4
+#ifndef ROXY_HG_REDZONE
+#define ROXY_HG_REDZONE 256u
+#endif
+
+/*******************************************//**
+ *  Public API
+ ***********************************************/
+
+struct PlaydateAPI;
+
+// Call exactly once at init. Safe to call when ROXY_HEAP_GUARD==0.
+void roxy_heapguard_init(const struct PlaydateAPI* playdate);
+
+// Verify all tracked blocks (debug only; no-op in release)
+void roxy_heapguard_verify_all(void);
+
+// Dump all active blocks (debug only; no-op in release)
+void roxy_heapguard_dump_active(void);
+
+// Label an allocation for nicer dumps (debug only; no-op in release)
+void roxy_heapguard_label(void* user, const char* label);
+
+// Site-aware functions (normally use the macros below instead)
+void* roxy_malloc_site(size_t size, const char* file, uint32_t line);
+void* roxy_calloc_site(size_t count, size_t size, const char* file, uint32_t line);
+void* roxy_realloc_site(void* user, size_t newSize, const char* file, uint32_t line);
+void  roxy_free_site(void* user, const char* file, uint32_t line);
+
+void* roxy_memcpy_site(void* dst, const void* src, size_t n, const char* file, uint32_t line);
+void* roxy_memset_site(void* dst, int v, size_t n, const char* file, uint32_t line);
+
+void  roxy_bounds_site(void* dst, size_t n, const char* file, uint32_t line);
+
+// Helper used only when guard is ON: allocate and label in one call
+void* roxy_alloc_label_site(size_t size, const char* label, const char* file, uint32_t line);
+
+// Register heap-guard Lua functions (debug only; no-op in release).
+// Returns 0 on success, -1 on failure.
+int roxy_heapguard_register_lua(struct PlaydateAPI* playdate);
+
+/*******************************************//**
+ *  Convenience Macros
+ ***********************************************/
+
+#if ROXY_HEAP_GUARD
+
+    // Debug: record site, add guards, track blocks
+    #define roxy_malloc(sz)         roxy_malloc_site((sz), __FILE__, (uint32_t)__LINE__)
+    #define roxy_calloc(cnt, sz)    roxy_calloc_site((cnt), (sz), __FILE__, (uint32_t)__LINE__)
+    #define roxy_realloc(ptr, sz)   roxy_realloc_site((ptr), (sz), __FILE__, (uint32_t)__LINE__)
+    #define roxy_free(ptr)          roxy_free_site((ptr), __FILE__, (uint32_t)__LINE__)
+    #define roxy_memcpy(dst,src,n)  roxy_memcpy_site((dst),(src),(n), __FILE__, (uint32_t)__LINE__)
+    #define roxy_memset(dst,v,n)    roxy_memset_site((dst),(v),(n), __FILE__, (uint32_t)__LINE__)
+    #define ROXY_BOUNDS(dst, n)     roxy_bounds_site((dst),(n), __FILE__, (uint32_t)__LINE__)
+    #define ROXY_LABEL(ptr, label)  roxy_heapguard_label((ptr), (label))
+
+    // Typed helpers
+    #define ROXY_NEW(type)               ( (type*)roxy_malloc_site(sizeof(type), __FILE__, (uint32_t)__LINE__) )
+    #define ROXY_NEW_LABEL(type, label)  ( (type*)roxy_alloc_label_site(sizeof(type), (label), __FILE__, (uint32_t)__LINE__) )
+
+    // Byte helpers
+    #define ROXY_ALLOC_BYTES(n)              roxy_malloc_site((n), __FILE__, (uint32_t)__LINE__)
+    #define ROXY_ALLOC_BYTES_LABEL(n,label)  roxy_alloc_label_site((n), (label), __FILE__, (uint32_t)__LINE__)
+
+    // Optional one-liners for quick checks from C (vanish in release)
+    #define ROXY_HG_VERIFY()  roxy_heapguard_verify_all()
+    #define ROXY_HG_DUMP()    roxy_heapguard_dump_active()
+
+#else
+
+    // Release: expand to Playdate allocator + libc. No extra calls or checks.
+    // Assumes a PlaydateAPI* named by ROXY_PD_SYMBOL is in scope.
+    #define roxy_malloc(sz) (ROXY_PD_SYMBOL->system->realloc(NULL, (sz)))
+    // calloc: inline helper for zero-init (likely inlined by compiler)
+    #define roxy_calloc(cnt, sz) ({ \
+        void* __p = ROXY_PD_SYMBOL->system->realloc(NULL, (cnt)*(sz)); \
+        if (__p) memset(__p, 0, (cnt)*(sz)); \
+        __p; \
+    })
+    #define roxy_realloc(ptr, sz)   (ROXY_PD_SYMBOL->system->realloc((ptr), (sz)))
+    #define roxy_free(ptr)          do { if ((ptr)) ROXY_PD_SYMBOL->system->realloc((ptr), 0); } while (0)
+    #define roxy_memcpy(dst,src,n)  memcpy((dst),(src),(n))
+    #define roxy_memset(dst,v,n)    memset((dst),(v),(n))
+    #define ROXY_BOUNDS(dst, n)     ((void)0)
+    #define ROXY_LABEL(ptr, label)  ((void)0)
+
+    #define ROXY_NEW(type)               ( (type*)ROXY_PD_SYMBOL->system->realloc(NULL, sizeof(type)) )
+    #define ROXY_NEW_LABEL(type, label)  ( (type*)ROXY_PD_SYMBOL->system->realloc(NULL, sizeof(type)) )
+
+    #define ROXY_ALLOC_BYTES(n)              (ROXY_PD_SYMBOL->system->realloc(NULL, (n)))
+    #define ROXY_ALLOC_BYTES_LABEL(n,label)  (ROXY_PD_SYMBOL->system->realloc(NULL, (n)))
+
+    #define ROXY_HG_VERIFY() ((void)0)
+    #define ROXY_HG_DUMP()   ((void)0)
+
+#endif
+
+#endif /* ROXY_HEAP_GUARD_H */


### PR DESCRIPTION
### Overview
This release introduces `roxy_heapguard`, a debug-only memory instrumentation system that improves detection of heap corruption and unsafe allocations. The sequencer has been refactored for safer memory handling, fractional loop support, and more predictable timing, while particle emitters gain both performance optimizations and safer frame indexing. Tilemap rendering also benefits from HeapGuard integration with added validation, and several core cleanups improve maintainability.

### Key Changes
- **Core**
  - Removed unused aliases from `roxy.lua` to reduce clutter and improve readability

- **Debug Utilities**
  - Added `roxy_heapguard` for memory safety in debug builds
  - Provides canary/red-zone checks, allocation labeling, runtime verification, and frame-based analysis helpers

- **Sequences**
  - Refactored to use HeapGuard for memory operations
  - Introduced `setEasingAt` in place of `__newindex`
  - Improved loop handling with fractional loop count support and deterministic completion
  - Fixed ping-pong and reverse logic, clarified repeat handling
  - Optimized evaluation and binary search for better performance
  - Improved timing precision, with callbacks/completions firing earlier but consistently

- **Tilemaps**
  - Integrated HeapGuard into `RoxyTileRendererC` allocator paths
  - Added buffer and dimension validation, overflow guards, and stronger log messages
  - Minor performance improvements with early exits for invalid states

- **Particles**
  - Integrated HeapGuard into particle system
  - Added active pool tracking, frame dimension caching, and O(1) update loops
  - Enforced 0-based frame indexing internally with Lua-side conversion
  - Changed `spawnMultiple` to return integer counts instead of booleans
  - Removed explicit `frameCount` parameter; automatically derived from imagetables

### Breaking Changes
- **Sequences**
  - `__newindex` removed; use `setEasingAt(index, timestamp, from, to, duration, ease)`
  - Loop timing and callback completions may shift slightly due to new evaluation model
  - `again` and `reverse` behavior updated with stricter semantics
  - Sequences now require ordered segments for optimal performance

- **Particles**
  - `spawnMultiple` now returns an integer count, not a boolean
  - Internal frame indexing is 0-based; Lua APIs still accept 1-based values but clamp safely
  - `frameCount` argument removed from constructors; now derived from imagetables
  - Direct iteration over `maxCount` replaced by `activeCount` or Lua API methods

### Challenges/Notes
- Heap corruption issues on Playdate devices drove the introduction of `roxy_heapguard`, providing tools to surface subtle memory bugs during development. (Turned out to not be the Roxy code causing the crash)
- Sequencer refactor required balancing backward compatibility with correctness, resulting in small but consistent timing shifts
- Particle system overhaul focused on making emitters safer and faster