### PR TITLE
[0.14.6] - Animation caching, pooled views, tilemap lifecycle overhaul

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -4,50 +4,106 @@ local pd        <const> = playdate
 local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
 
-local r         <const> = roxy
-
 local max             <const> = math.max
 local min             <const> = math.min
 local fmod            <const> = math.fmod
-local clamp           <const> = r.Math.clamp
-local truncateDecimal <const> = r.Math.truncateDecimal
 
 local newImagetable <const> = Graphics.imagetable.new
 local drawImage     <const> = Graphics.imagetable.drawImage
 
 local performAfterDelay <const> = pd.timer.performAfterDelay
 
-local updateAnimation <const> = r.Animation.update -- C Function
+local r         <const> = roxy
+local Math      <const> = r.Math
+local Assets    <const> = r.Assets
+local Animation <const> = r.Animation
+
+local clamp           <const> = Math.clamp
+local truncateDecimal <const> = Math.truncateDecimal
+
+local getAsset <const> = Assets.getAsset
+
+local updateAnimation <const> = Animation.update -- C Function
 
 local UNFLIPPED <const> = Graphics.kImageUnflipped
 
-local FRAME_DURATION_DEFAULT  <const> = 0.033 -- ≈30 FPS
-local MIN_FRAME_DURATION      <const> = 0.016 -- Guard against >60 FPS
+local FRAME_DURATION_DEFAULT  <const> = 0.033 -- About 30 FPS
+local MIN_FRAME_DURATION      <const> = 0.016 -- Guard against >60 FPS
 local MAX_FRAME_DURATION      <const> = 10    -- Sensible upper limit (sec)
 local MAX_ANIMATION_SPEED     <const> = 100   -- UI clamp for setSpeed
 
+-- Track shared animations by imagetable identity (weak keys)
+local _animCache = setmetatable({}, { __mode = "k" })
+
 -- ----------------------------------------
--- Class Definition & Init
+-- Class Definition and Initialize
 -- ----------------------------------------
 
 class("RoxyAnimation").extends(Object)
 
+-- ! Helper: From Image Table
+-- Constructor for imagetable objects
+function RoxyAnimation.fromImagetable(imagetable)
+  if not (imagetable and imagetable.drawImage) then
+    Log.error("[RoxyAnimation.fromImagetable] Expected imagetable userdata")
+    return nil
+  end
+
+  local cached = _animCache[imagetable]
+  if cached then
+    return cached:retain()
+  end
+
+  local self = RoxyAnimation(imagetable) -- init handles imagetable or path
+  self._refcount = 1
+  _animCache[imagetable] = self
+  return self
+end
+
+-- ! Helper: From Pool
+-- Helper to fetch from Assets pool directly
+function RoxyAnimation.fromPool(poolKey)
+  local imagetable = getAsset(poolKey)
+  if not imagetable then
+    Log.error("[RoxyAnimation.fromPool] No asset for key: ", tostring(poolKey)) --#DEBUG
+    return nil
+  end
+  return RoxyAnimation.fromImagetable(imagetable)
+end
+
+-- ! Initialize
+-- Keep existing path constructor but delegate the config init to a helper
 function RoxyAnimation:init(view)
   self.isRoxyAnimation = true
 
-  --#DEBUG START
-  if type(view) ~= "string" then
-    Log.error("[RoxyAnimation:init] Invalid view type for RoxyAnimation:", type(view), 2)
+  local viewType = type(view)
+  if viewType == "string" then
+    local imagetable = Graphics.imagetable.new(view)
+    --#DEBUG START
+    Log.assert(imagetable, function()
+      return string.format("[RoxyAnimation:init] Failed to create imagetable from: %s", tostring(view))
+    end, 1)
+    --#DEBUG END
+    self:_initCommon()
+    self.imagetable = imagetable
+    self._refcount  = 1
+    return
   end
-  --#DEBUG END
 
-  self.imagetable = newImagetable(view)
-  --#DEBUG START
-  if not self.imagetable then
-    Log.error("[RoxyAnimation:init] Failed to create imagetable from view:", view)
+  -- Support imagetables directly
+  if viewType == "userdata" and view and view.drawImage then
+    self:_initCommon()
+    self.imagetable = view
+    self._refcount = 1
+    return
   end
-  --#DEBUG END
 
+  Log.error("[RoxyAnimation:init] Expected string path or imagetable userdata (got " .. viewType .. ")", 1) --#DEBUG
+end
+
+-- ! Common Initialize
+-- Common initialization for both constructors
+function RoxyAnimation:_initCommon()
   self.animations       = {}
   self.defaultName      = nil
   self.currentName      = nil
@@ -56,6 +112,26 @@ function RoxyAnimation:init(view)
   self.isFirstCycle     = true
   self.isReversed       = false
   self.accumulator      = 0
+end
+
+-- ! Retain
+-- Increment reference count
+function RoxyAnimation:retain()
+  self._refcount = (self._refcount or 0) + 1
+  return self
+end
+
+-- ! Release
+-- Reference release; recycles imagetable when count drops to zero
+function RoxyAnimation:release()
+  if not self._refcount then return end
+
+  self._refcount = self._refcount - 1
+  if self._refcount <= 0 then
+    _animCache[self.imagetable] = nil
+    -- Do not free imagetable here; Assets pool owns it.
+    self:destroy()
+  end
 end
 
 -- ----------------------------------------
@@ -354,4 +430,5 @@ function RoxyAnimation:destroy()
   self.currentAnimation = nil
   self.animations = {}
   self.imagetable = nil
+  self._refcount = nil
 end

--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -4,9 +4,9 @@ local pd        <const> = playdate
 local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
 
-local max             <const> = math.max
-local min             <const> = math.min
-local fmod            <const> = math.fmod
+local max   <const> = math.max
+local min   <const> = math.min
+local fmod  <const> = math.fmod
 
 local newImagetable <const> = Graphics.imagetable.new
 local drawImage     <const> = Graphics.imagetable.drawImage
@@ -34,6 +34,8 @@ local MAX_ANIMATION_SPEED     <const> = 100   -- UI clamp for setSpeed
 
 -- Track shared animations by imagetable identity (weak keys)
 local _animCache = setmetatable({}, { __mode = "k" })
+-- Cache animations by path to avoid duplicate imagetables
+local _pathCache = setmetatable({}, { __mode = "k" })
 
 -- ----------------------------------------
 -- Class Definition and Initialize
@@ -78,6 +80,12 @@ function RoxyAnimation:init(view)
 
   local viewType = type(view)
   if viewType == "string" then
+    -- Check path cache first to avoid duplicate imagetables
+    local cached = _pathCache[view]
+    if cached then
+      return cached:retain()
+    end
+
     local imagetable = Graphics.imagetable.new(view)
     --#DEBUG START
     Log.assert(imagetable, function()
@@ -86,7 +94,11 @@ function RoxyAnimation:init(view)
     --#DEBUG END
     self:_initCommon()
     self.imagetable = imagetable
+    self._length = #imagetable
     self._refcount  = 1
+    self._path = view -- Store path for cleanup
+    _pathCache[view] = self
+    _animCache[imagetable] = self -- Add to both caches
     return
   end
 
@@ -94,6 +106,7 @@ function RoxyAnimation:init(view)
   if viewType == "userdata" and view and view.drawImage then
     self:_initCommon()
     self.imagetable = view
+    self._length = #view
     self._refcount = 1
     return
   end
@@ -112,6 +125,7 @@ function RoxyAnimation:_initCommon()
   self.isFirstCycle     = true
   self.isReversed       = false
   self.accumulator      = 0
+  -- _length will be set after imagetable is assigned
 end
 
 -- ! Retain
@@ -129,6 +143,10 @@ function RoxyAnimation:release()
   self._refcount = self._refcount - 1
   if self._refcount <= 0 then
     _animCache[self.imagetable] = nil
+    -- Remove from path cache using stored path
+    if self._path then
+      _pathCache[self._path] = nil
+    end
     -- Do not free imagetable here; Assets pool owns it.
     self:destroy()
   end
@@ -152,43 +170,49 @@ end
 
 -- ! Add Animation
 function RoxyAnimation:addAnimation(opts)
-  local def = {}
-  def.name                = opts.name
-  def.startFrame          = opts.startFrame or 1
-  def.endFrame            = opts.endFrame or #self.imagetable
-  def.loop                = (opts.loop ~= false)
-  def.next                = opts.next
-  def.onCompleteCallback  = opts.onCompleteCallback or opts.onComplete
-  def.speed               = opts.speed or 1
-  def.frameDuration       = opts.frameDuration or FRAME_DURATION_DEFAULT
+  -- Validate animation name
+  if not opts.name or type(opts.name) ~= "string" then
+    Log.error("[RoxyAnimation:addAnimation] Animation name must be a non-empty string")
+    return self
+  end
 
-  -- Ensure numeric defaults
-  def.startFrame  = tonumber(def.startFrame) or 1
-  def.endFrame    = tonumber(def.endFrame) or #self.imagetable
+  -- Check for empty imagetable
+  if self._length == 0 then
+    Log.error("[RoxyAnimation:addAnimation] Cannot add animation to empty imagetable")
+    return self
+  end
+
+  -- Build animation directly to avoid unnecessary table creation
+  local animation = {
+    name               = opts.name,
+    startFrame         = tonumber(opts.startFrame) or 1,
+    endFrame           = tonumber(opts.endFrame) or self._length,
+    loop               = (opts.loop ~= false),
+    next               = opts.next,
+    onCompleteCallback = opts.onCompleteCallback or opts.onComplete,
+    speed              = opts.speed or 1,
+    frameDuration      = opts.frameDuration or FRAME_DURATION_DEFAULT
+  }
 
   -- Swap if out of order
-  if def.startFrame > def.endFrame then
-    def.startFrame, def.endFrame = def.endFrame, def.startFrame
+  if animation.startFrame > animation.endFrame then
+    animation.startFrame, animation.endFrame = animation.endFrame, animation.startFrame
   end
 
   -- Clamp into valid ranges
-  def.startFrame    = max(1, def.startFrame)
-  def.endFrame      = min(#self.imagetable, def.endFrame)
-  def.loop          = def.loop ~= false
-  def.speed         = clamp(def.speed, 0, MAX_ANIMATION_SPEED)
-  def.frameDuration = clamp(def.frameDuration, MIN_FRAME_DURATION, MAX_FRAME_DURATION)
+  animation.startFrame    = max(1, animation.startFrame)
+  animation.endFrame      = min(self._length, animation.endFrame)
+  animation.speed         = clamp(animation.speed, 0, MAX_ANIMATION_SPEED)
+  animation.frameDuration = clamp(animation.frameDuration, MIN_FRAME_DURATION, MAX_FRAME_DURATION)
 
-  -- Build the actual animation entry
-  local animation = {
-    name                = def.name,
-    startFrame          = def.startFrame,
-    endFrame            = def.endFrame,
-    loop                = def.loop,
-    next                = def.next,
-    onCompleteCallback  = def.onCompleteCallback,
-    speed               = def.speed,
-    frameDuration       = def.frameDuration,
-  }
+  -- Validate frame range after clamping
+  if animation.endFrame < animation.startFrame then
+    Log.warn("[RoxyAnimation:addAnimation] Invalid frame range after clamping: start=" .. animation.startFrame .. " end=" .. animation.endFrame)
+    return self
+  end
+
+  -- Precompute range for performance
+  animation.range = animation.endFrame - animation.startFrame + 1
 
   self.animations[animation.name] = animation
 
@@ -209,12 +233,27 @@ function RoxyAnimation:getStartFrame(newAnimation, nextContinuity)
     return newAnimation.startFrame
   end
 
-  local range     = currentAnimation.endFrame - currentAnimation.startFrame + 1
-  local newRange  = newAnimation.endFrame - newAnimation.startFrame + 1
+  local range     = currentAnimation.range or (currentAnimation.endFrame - currentAnimation.startFrame + 1)
+  local newRange  = newAnimation.range or (newAnimation.endFrame - newAnimation.startFrame + 1)
   local frame     = newAnimation.startFrame
 
   if nextContinuity then
-    local progress = (self.currentFrame - currentAnimation.startFrame) / range
+    -- Handle edge cases for range calculations
+    if range <= 0 or newRange <= 0 then
+      return newAnimation.startFrame
+    end
+
+    -- Ensure current frame is within bounds for robust calculation
+    local current = clamp(self.currentFrame, currentAnimation.startFrame, currentAnimation.endFrame)
+    -- Adjust progress calculation for reversed animations
+    local progress
+    if self.isReversed then
+      progress = (currentAnimation.endFrame - current) / range
+    else
+      progress = (current - currentAnimation.startFrame) / range
+    end
+
+    -- Handle NaN
     progress = (progress == progress) and progress or 0
     frame = newAnimation.startFrame + truncateDecimal(progress * newRange)
     frame = clamp(frame, newAnimation.startFrame, newAnimation.endFrame)
@@ -308,6 +347,8 @@ end
 
 -- ! Start With Delay
 function RoxyAnimation:startWithDelay(delay, animationName)
+  -- Add type check for animationName and fallback to defaultName
+  animationName = animationName or self.defaultName
   if type(delay) ~= "number" or delay <= 0 or not self.animations[animationName] then
     Log.warn("[RoxyAnimation:startWithDelay] Invalid delay or animation for startWithDelay:", delay, tostring(animationName)) --#DEBUG
     return self
@@ -331,26 +372,25 @@ function RoxyAnimation:jumpToSpecificFrame(frame)
 end
 
 -- ! Step Frame
+-- Note: This steps absolute frame indices, not in playback direction
 function RoxyAnimation:stepFrame(direction)
   local currentAnimation = self.currentAnimation
   if not currentAnimation then return self end
 
   local step = (direction == -1 or direction == "back") and -1 or 1
-  local startFrame = currentAnimation.startFrame
-  local endFrame = currentAnimation.endFrame
+  local range = currentAnimation.range or (currentAnimation.endFrame - currentAnimation.startFrame + 1)
+
   -- Guard against zero-length animations
-  -- (Shouldn't happen under normal addAnimation, but protects against division by zero)
-  local range = endFrame - startFrame + 1
   if range <= 0 then return self end
 
   -- Compute offset relative to startFrame
-  local offset = self.currentFrame + step - startFrame
+  local offset = self.currentFrame + step - currentAnimation.startFrame
   -- Wrap using fmod, ensure positive
   local wrapped = fmod(offset, range)
   if wrapped < 0 then wrapped = wrapped + range end
 
   -- Translate back into absolute frame index
-  self.currentFrame = wrapped + startFrame
+  self.currentFrame = wrapped + currentAnimation.startFrame
 
   return self
 end
@@ -402,7 +442,11 @@ function RoxyAnimation:update()
       (self.isReversed   and newFrame <= currentAnimation.startFrame)) then
 
     if currentAnimation.next then
-      self:setAnimation(currentAnimation.next)
+      -- Call completion callback before transitioning if both exist
+      if type(currentAnimation.onCompleteCallback) == "function" then
+        currentAnimation.onCompleteCallback()
+      end
+      self:setAnimation(currentAnimation.next, true) -- Use continuity for smoother chaining
     elseif type(currentAnimation.onCompleteCallback) == "function" then
       currentAnimation.onCompleteCallback()
     end
@@ -431,4 +475,5 @@ function RoxyAnimation:destroy()
   self.animations = {}
   self.imagetable = nil
   self._refcount = nil
+  self._length = nil
 end

--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -7,6 +7,7 @@ local Camera <const> = roxy.Camera
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
+local Timer     <const> = pd.timer
 
 local abs   <const> = math.abs
 local min   <const> = math.min
@@ -19,6 +20,8 @@ local ceil  <const> = math.ceil
 local pi    <const> = math.pi
 local lerp  <const> = roxy.Math.lerp
 local round <const> = roxy.Math.roundInt
+
+local performAfterDelay <const> = Timer.performAfterDelay
 
 local tableRemove <const> = table.remove
 local tableInsert <const> = table.insert
@@ -57,7 +60,7 @@ Camera.biasReturnRate = 6       -- How fast bias returns to 0 (1/sec)
 Camera.mode           = "lerp"  -- "lerp" or "spring"
 
 -- Spring parameters (used when mode=="spring")
-Camera.springFreq = 6.0 -- Hz, natural frequency
+Camera.springFreq = 4.0 -- Hz, natural frequency
 Camera.springDamp = 0.9 -- 0..1 (1=critical-ish)
 
 --
@@ -339,7 +342,7 @@ function Camera.reset()
   Camera.targetBiasY        = 0
   Camera.biasReturnRate     = 6
   Camera.mode               = "lerp"
-  Camera.springFreq         = 6.0
+  Camera.springFreq         = 4.0
   Camera.springDamp         = 0.9
   Camera._onOffsetChanged   = {}
 
@@ -368,6 +371,19 @@ end
 -- ! Set Mode
 function Camera.setMode(mode) -- "lerp" or "spring"
   if mode == "spring" or mode == "lerp" then Camera.mode = mode end
+end
+
+-- ! Follow After Delay
+-- Delayed follow helper: stop following, then start after N ms
+function Camera.followAfterDelay(sprite, delayMS, smoothing)
+  -- Keep current offset; just stop following briefly
+  Camera.setTarget(nil)
+  performAfterDelay(delayMS or 0, function()
+    -- Only re-attach if the sprite still exists
+    if sprite and sprite.getPosition then
+      Camera.setTarget(sprite, smoothing)
+    end
+  end)
 end
 
 -- ! Update
@@ -455,8 +471,11 @@ function Camera.updateFollow(dt)
 
   -- Clamp final position
   if Camera._hasBounds then
+    local boundsX, boundsY = Camera.x, Camera.y
     Camera.x = clamp(Camera.x, Camera._minX, Camera._maxX)
     Camera.y = clamp(Camera.y, Camera._minY, Camera._maxY)
+    if Camera.x ~= boundsX then Camera._velocityX = 0 end
+    if Camera.y ~= boundsY then Camera._velocityY = 0 end
   end
 
   if Camera.smoothing > 0

--- a/core/modules/Log.lua
+++ b/core/modules/Log.lua
@@ -61,10 +61,42 @@ function Log.setLogLevel(level)
   end)
 end
 
+-- ! Message Resolution Helper
+-- Resolves messages with vararg support for formatting and concatenation
+local function resolveMessage(msgOrFn, ...)
+  local argCount = select("#", ...)
+
+  -- If it's a function, call it with the extra args
+  if type(msgOrFn) == "function" then
+    return msgOrFn(...)
+  end
+
+  -- If no extra arguments, return as-is
+  if argCount == 0 then
+    return msgOrFn
+  end
+
+  -- If first arg is string and we have extra args, try string.format
+  if type(msgOrFn) == "string" then
+    local success, result = pcall(string.format, msgOrFn, ...)
+    if success then
+      return result
+    end
+    -- If format failed, fall through to concatenation
+  end
+
+  -- Concatenate all arguments with spaces (like print does)
+  local parts = {tostring(msgOrFn)}
+  for i = 1, argCount do
+    parts[#parts + 1] = tostring((select(i, ...)))
+  end
+  return table.concat(parts, " ")
+end
+
 -- ! Emit
-local function emit(level, msgOrFn, stackLevel)
-  -- Evaluate lazily if passed a function
-  local message = (type(msgOrFn) == "function") and msgOrFn() or msgOrFn
+local function emit(level, msgOrFn, stackLevel, ...)
+  -- Resolve message with vararg support
+  local message = resolveMessage(msgOrFn, ...)
 
   if level == Log.ERROR then
     -- stackLevel == 0 => caller wants NO prefix from error()
@@ -78,33 +110,93 @@ local function emit(level, msgOrFn, stackLevel)
 end
 
 -- ! Error
-function Log.error(msgOrFn, stackLevel)
+function Log.error(msgOrFn, ...)
+  local args = {...}
+  local stackLevel = nil
+
+  -- Check if second argument is a numeric stackLevel
+  if #args > 0 and type(args[1]) == "number" then
+    stackLevel = args[1]
+    -- Remove stackLevel from args to forward the rest
+    table.remove(args, 1)
+  end
+
   if Log.ERROR > Log.level then return end
-  emit(Log.ERROR, msgOrFn, stackLevel)
+  emit(Log.ERROR, msgOrFn, stackLevel, table.unpack(args))
 end
 
 -- ! Warn
-function Log.warn (msgOrFn, stackLevel)
+function Log.warn(msgOrFn, ...)
+  local args = {...}
+  local stackLevel = nil
+
+  -- Check if second argument is a numeric stackLevel
+  if #args > 0 and type(args[1]) == "number" then
+    stackLevel = args[1]
+    table.remove(args, 1)
+  end
+
   if Log.WARN > Log.level then return end
-  emit(Log.WARN, msgOrFn, stackLevel)
+  emit(Log.WARN, msgOrFn, stackLevel, table.unpack(args))
 end
 
 -- ! Info
-function Log.info (msgOrFn, stackLevel)
+function Log.info(msgOrFn, ...)
+  local args = {...}
+  local stackLevel = nil
+
+  -- Check if second argument is a numeric stackLevel
+  if #args > 0 and type(args[1]) == "number" then
+    stackLevel = args[1]
+    table.remove(args, 1)
+  end
+
   if Log.INFO > Log.level then return end
-  emit(Log.INFO, msgOrFn, stackLevel)
+  emit(Log.INFO, msgOrFn, stackLevel, table.unpack(args))
 end
 
 -- ! Debug
-function Log.debug(msgOrFn, stackLevel)
+function Log.debug(msgOrFn, ...)
+  local args = {...}
+  local stackLevel = nil
+
+  -- Check if second argument is a numeric stackLevel
+  if #args > 0 and type(args[1]) == "number" then
+    stackLevel = args[1]
+    table.remove(args, 1)
+  end
+
   if Log.DEBUG > Log.level then return end
-  emit(Log.DEBUG, msgOrFn, stackLevel)
+  emit(Log.DEBUG, msgOrFn, stackLevel, table.unpack(args))
 end
 
 -- ! Assert
 function Log.assert(condition, msgOrFn, stackLevel, ...)
   if not condition then
-    Log.error(msgOrFn or "Assertion failed!", (stackLevel or 1) + 2)
+    -- CRITICAL FIX: Bypass Log.error's level guard by calling emit directly
+    -- This ensures assertions always fire regardless of log level
+    local message = resolveMessage(msgOrFn or "Assertion failed!", ...)
+    local errLevel = (stackLevel == 0) and 0 or ((stackLevel or 1) + 2)
+    error_(message, errLevel)
   end
   return condition, ...
 end
+
+--[[
+USAGE EXAMPLE:
+-- String formatting (your examples now work!)
+Log.warn("[RoxyAnimation:setAnimation] Animation %s not found", tostring(name))
+Log.warn("[RoxyStagTilemap] Failed to allocate chunk image (%dx%d)", width, height)
+
+-- Print-style concatenation
+Log.info("Player health:", health, "Score:", score)
+
+-- Function producers with args
+Log.debug(function(x, y) return string.format("Position: (%d, %d)", x, y) end, player.x, player.y)
+
+-- Stack level still works
+Log.error("Critical error", 2, "additional", "context")
+
+-- Assertions now always fire regardless of log level
+Log.assert(player ~= nil, "Player object is nil!")
+]]--

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -363,6 +363,12 @@ function RoxyScene:addTilemap(tilemap)
 
   -- Give the tilemap a back-pointer so it can self-remove later
   tilemap.scene = self
+
+  -- Set the layer manager’s scene so callers don’t have to
+  local layerManager = tilemap.layerManager
+  if layerManager then
+    layerManager:setScene(self)
+  end
 end
 
 -- ! Remove Tilemap
@@ -370,9 +376,22 @@ function RoxyScene:removeTilemap(tilemap)
   if not tilemap then return end
   for i = #self.tilemaps, 1, -1 do
     if self.tilemaps[i] == tilemap then
+      -- Detach layer sprites first (defensive; layerManager:destroy usually does this)
+      local layerManager = tilemap.layerManager
+      if layerManager and layerManager.detachSprites then layerManager:detachSprites() end
+
+      -- Clear wiring
+      if layerManager and layerManager.setScene then
+        layerManager:setScene(nil)
+      end
       tilemap.scene = nil -- Clear back-pointer
-      tilemap:destroy()
+
+      -- Destroy the tilemap object
+      if tilemap.destroy then tilemap:destroy() end
+
+      -- Remove from the scene list
       tableRemove(self.tilemaps, i)
+
       return
     end
   end
@@ -383,8 +402,11 @@ function RoxyScene:removeAllTilemaps()
   local tilemaps = self.tilemaps
   for i = #tilemaps, 1, -1 do
     local tilemap = tilemaps[i]
+    local layerManager = tilemap.layerManager
+    if layerManager and layerManager.detachSprites then layerManager:detachSprites() end
     tilemap.scene = nil -- Clear back-pointer
-    tilemap:destroy()
+    if layerManager and layerManager.setScene then layerManager:setScene(nil) end
+    if tilemap.destroy then tilemap:destroy() end
   end
   self.tilemaps = {}
 end

--- a/core/sprites/RoxyActor.lua
+++ b/core/sprites/RoxyActor.lua
@@ -23,7 +23,7 @@ function RoxyActor:init(manifest, defaultState)
 
   --#DEBUG START
   if not manifest.sheet then
-    Log.warn("[RoxyActor:init] No spritesheet provided in manifest")
+    Log.warn("[RoxyActor:init] No spritesheet/imagetable provided in manifest")
   end
   --#DEBUG END
 
@@ -33,65 +33,78 @@ function RoxyActor:init(manifest, defaultState)
   self.nextState    = nil
   self.facing       = 1
 
-  -- Set up view if sheet provided
+  -- Set up view based on sheet type
   if manifest.sheet then
-    self:setView(manifest.sheet, true, false, false)
+    local sheet = manifest.sheet
+    local sheetType = type(sheet)
+
+    if sheetType == "string" then
+      self:setView(sheet, true, false, false)
+    elseif sheetType == "userdata" and sheet.drawImage then
+      self:setView(RoxyAnimation.fromImagetable(sheet))
+    elseif sheetType == "table" then
+      -- Accept a direct RoxyAnimation, or a wrapper {animation=anim}
+      if sheet.isRoxyAnimation then
+        self:setView(s:retain()) -- Direct animation instance
+      elseif sheet.animation and sheet.animation.isRoxyAnimation then
+        self:setView(sheet.animation:retain())
+      else --#DEBUG
+        Log.warn("[RoxyActor:init] Unsupported table for 'sheet' (expected RoxyAnimation or {animation=...})") --#DEBUG
+      end
+    else --#DEBUG
+      Log.warn("[RoxyActor:init] Unsupported sheet type; expected path, imagetable, RoxyAnimation, or {animation=...}") --#DEBUG
+    end
   end
 
   -- Prepare for building animations
   local animation = self.animation
   local imagetable = animation and animation.imagetable
-  local perRow = manifest.frames or (imagetable and #imagetable) or 1
   local rows = manifest.rows
-  if type(rows) ~= "table" then
-    Log.warn("[RoxyActor:init] Manifest.rows missing or not a table; defaulting to empty") --#DEBUG
-    rows = {}
-  end
-  local doLoop = manifest.loop or {}
-  local doNext = manifest.next or {}
 
-  -- Build animations from rows
-  if imagetable then
+  -- Only build if rows is actually a table.
+  if type(rows) == "table" and imagetable then
+    local perRow = manifest.frames or #imagetable or 1
+    local doLoop = manifest.loop or {}
+    local doNext = manifest.next or {}
+
     for stateName, info in pairs(rows) do
       local startFrame, endFrame
       if type(info) == "table" then
         startFrame = info.start
-        endFrame = info.finish
+        endFrame   = info.finish
       else
-        -- fallback older style: index by row
         startFrame = (info - 1) * perRow + 1
-        endFrame = info * perRow
+        endFrame   = info * perRow
       end
-
-      local loop      = doLoop[stateName] ~= false
-      local nextState = doNext[stateName]
-      local speed    = (type(info) == "table") and info.speed or nil
-      local frameDur = (type(info) == "table") and info.frameDuration or nil
       self:addAnimation{
-        name                = stateName,
-        startFrame          = startFrame,
-        endFrame            = endFrame,
-        loop                = loop,
-        next                = nextState,
-        speed               = speed,
-        frameDuration       = frameDur,
-        onCompleteCallback  = function()
-          self:_onAnimationComplete(stateName)
-        end,
+        name       = stateName,
+        startFrame = startFrame,
+        endFrame   = endFrame,
+        loop       = (doLoop[stateName] ~= false),
+        next       = doNext[stateName],
+        speed      = (type(info) == "table") and info.speed or nil,
+        frameDuration = (type(info) == "table") and info.frameDuration or nil,
+        onCompleteCallback = function() self:_onAnimationComplete(stateName) end,
       }
     end
-  else --#DEBUG
-    Log.warn("[RoxyActor:init] No valid imagetable; animation states not set up") --#DEBUG
+  else
+    -- rows missing is fine when we already have a prebuilt animation
+    -- (do nothing)
   end
 
   -- Ensure animations table is present
-  self.animations = self.animations or (animation and animation.animations) or {}
+  local animation = self.animation
+  self.animations = (animation and animation.animations) or self.animations or {}
 
   -- Cache transition rules for physics updates
   self:_cacheTransitionRules()
 
-  -- Start in default or first-added state
-  self:setState(self.defaultState or self.defaultName)
+  -- Start in default or first-added state (only if it exists)
+  if self.defaultState and self.animations[self.defaultState] then
+    self:setState(self.defaultState)
+  elseif self.defaultName and self.animations[self.defaultName] then
+    self:setState(self.defaultName)
+  end
 end
 
 -- ----------------------------------------
@@ -200,26 +213,19 @@ end
 -- ! Play Once
 -- Play a one-shot animation state, then return to the previous/default.
 function RoxyActor:playOnce(stateName, onFinish)
-  --#DEBUG START
-  if type(stateName) ~= "string" then
-    Log.warn("[RoxyActor:playOnce] Expected string for playOnce stateName, got", type(stateName))
-    return self
-  end
-  if not self.animations[stateName] then
-    Log.warn("[RoxyActor:playOnce] Unknown one-shot state:", stateName)
-    return self
-  end
-  --#DEBUG END
+  if not self.animation or not self.animations then return self end
 
+  if type(stateName) ~= "string" or not self.animations[stateName] then
+    Log.warn("[RoxyActor:playOnce] Unknown one-shot state:" .. tostring(stateName)) --#DEBUG
+    return self
+  end
   local prev = self.currentState or self.defaultState
   self:queueState(prev)
   if type(onFinish) == "function" then
-    -- Attach a temporary callback for when the animation completes
     self._onPlayOnceFinish = onFinish
   else
     self._onPlayOnceFinish = nil
   end
-
   return self:setState(stateName, true)
 end
 

--- a/core/sprites/RoxyActor.lua
+++ b/core/sprites/RoxyActor.lua
@@ -40,12 +40,12 @@ function RoxyActor:init(manifest, defaultState)
 
     if sheetType == "string" then
       self:setView(sheet, true, false, false)
-    elseif sheetType == "userdata" and sheet.drawImage then
+    elseif sheetType == "userdata" and sheet.getImage then  -- Fixed: changed from drawImage to getImage
       self:setView(RoxyAnimation.fromImagetable(sheet))
     elseif sheetType == "table" then
       -- Accept a direct RoxyAnimation, or a wrapper {animation=anim}
       if sheet.isRoxyAnimation then
-        self:setView(s:retain()) -- Direct animation instance
+        self:setView(sheet:retain()) -- Fixed: changed from s:retain() to sheet:retain()
       elseif sheet.animation and sheet.animation.isRoxyAnimation then
         self:setView(sheet.animation:retain())
       else --#DEBUG
@@ -63,7 +63,7 @@ function RoxyActor:init(manifest, defaultState)
 
   -- Only build if rows is actually a table.
   if type(rows) == "table" and imagetable then
-    local perRow = manifest.frames or #imagetable or 1
+    local perRow = manifest.frames or (imagetable and #imagetable) or 1  -- Fixed: safer nil handling
     local doLoop = manifest.loop or {}
     local doNext = manifest.next or {}
 
@@ -99,11 +99,10 @@ function RoxyActor:init(manifest, defaultState)
   -- Cache transition rules for physics updates
   self:_cacheTransitionRules()
 
-  -- Start in default or first-added state (only if it exists)
+  -- Start in default state (only if it exists)
+  -- Fixed: Removed the undefined self.defaultName condition
   if self.defaultState and self.animations[self.defaultState] then
     self:setState(self.defaultState)
-  elseif self.defaultName and self.animations[self.defaultName] then
-    self:setState(self.defaultName)
   end
 end
 
@@ -121,12 +120,36 @@ function RoxyActor:_cacheTransitionRules()
   if type(rules) ~= "table" then
     return
   end
+
+  -- Pre-parse condition types for performance
   for _, rule in ipairs(rules) do
     if rule.state then
       local conds = {}
       for key, value in pairs(rule) do
         if key ~= "state" then
-          conds[key] = value
+          -- Parse condition type once during caching
+          local condType = "eq" -- default to equality
+          local optionName = key
+
+          if key:find("GreaterThan$") then
+            condType = "gt"
+            optionName = key:gsub("GreaterThan$", "")
+          elseif key:find("LessThan$") then
+            condType = "lt"
+            optionName = key:gsub("LessThan$", "")
+          elseif key:find("AtLeast$") then
+            condType = "gte"
+            optionName = key:gsub("AtLeast$", "")
+          elseif key:find("AtMost$") then
+            condType = "lte"
+            optionName = key:gsub("AtMost$", "")
+          end
+
+          table.insert(conds, {
+            type = condType,
+            option = optionName,
+            value = value
+          })
         end
       end
       table.insert(self._transitionRulesCache, { state = rule.state, conditions = conds })
@@ -270,32 +293,42 @@ end
 
 function RoxyActor:updatePhysics(opts)
   opts = opts or {}
+
+  -- Provide defaults for commonly used options
   local vx        = opts.vx        or 0
   local vy        = opts.vy        or 0
   local desiredVx = opts.intentVX  or vx
+  local onGround  = opts.onGround ~= nil and opts.onGround or true  -- Fixed: safer default handling
 
-  self:setFacing(vx)
+  -- Cache frequently accessed values
+  local anim = self.animation
+  local currentAnimation = anim and anim.currentAnimation
 
-  -- Cached transition rules
+  -- Check one-shots first to avoid interruption
+  if currentAnimation and not currentAnimation.loop then
+    return self
+  end
+
+  -- Set facing based on desired velocity (intent, not actual)
+  self:setFacing(desiredVx)
+
+  -- Cached transition rules with optimized condition checking
   local cache = self._transitionRulesCache
   if cache and #cache > 0 then
     for _, rule in ipairs(cache) do
       local ok = true
-      for key, value in pairs(rule.conditions) do
-        if key:find("GreaterThan$") then
-          local option = key:gsub("GreaterThan$", "")
-          if not (opts[option] and opts[option] > value) then ok = false break end
-        elseif key:find("LessThan$") then
-          local option = key:gsub("LessThan$", "")
-          if not (opts[option] and opts[option] < value) then ok = false break end
-        elseif key:find("AtLeast$") then
-          local option = key:gsub("AtLeast$", "")
-          if not (opts[option] and opts[option] >= value) then ok = false break end
-        elseif key:find("AtMost$") then
-          local option = key:gsub("AtMost$", "")
-          if not (opts[option] and opts[option] <= value) then ok = false break end
-        else
-          if opts[key] ~= value then ok = false break end
+      for _, cond in ipairs(rule.conditions) do
+        local optVal = opts[cond.option]
+        if cond.type == "gt" then
+          if not (optVal and optVal > cond.value) then ok = false break end
+        elseif cond.type == "lt" then
+          if not (optVal and optVal < cond.value) then ok = false break end
+        elseif cond.type == "gte" then
+          if not (optVal and optVal >= cond.value) then ok = false break end
+        elseif cond.type == "lte" then
+          if not (optVal and optVal <= cond.value) then ok = false break end
+        else -- equality
+          if optVal ~= cond.value then ok = false break end
         end
       end
       if ok and rule.state ~= self.currentState then
@@ -304,19 +337,11 @@ function RoxyActor:updatePhysics(opts)
     end
   end
 
-  -- Don't interrupt one-shots
-  local currentAnimation = self.animation and self.animation.currentAnimation
-  if currentAnimation and not currentAnimation.loop then
-    return self
-  end
-
   -- Generic fallback (idle / run / jump / fall)
   local targetState
-  if opts.onGround == false then
+  if onGround == false then
     targetState = (vy < 0) and "jump" or "fall"
   elseif abs(desiredVx) > 0 then
-    self.facing = desiredVx < 0 and -1 or 1
-    if self.facing < 0 then self:flipX() else self:unflip() end
     targetState = "run"
   else
     targetState = "idle"

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -113,11 +113,82 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
   -- Dispose previous visual
   if self.animation then
     self.animation:stop()
+    if self.animation.release then self.animation:release() end -- balance any retain
     self.animation = nil
   end
   self.simpleAnim = nil -- Clear any previous simpleAnim
   if self:getImage() then
     self:setImage(nil)
+  end
+
+  -- Small helper: size this sprite from the first frame of an imagetable
+  local function _applySizeFromImagetable(imagetable)
+    if imagetable and imagetable.getImage then
+      local first = imagetable:getImage(1)
+      if first and first.getSize then
+        local width, height = first:getSize()
+        if width and height then
+          self:setSize(width, height)
+          self:setCenter(0.5, 0.5)
+        end
+      end
+    end
+  end
+
+  -- Handle descriptor table form
+  if type(view) == "table" and view.poolKey then
+    local kind = view.kind or "sheet"
+    if kind == "sheet" then
+      -- Load imagetable from pool; wrap as RoxyAnimation
+      local imagetable = roxy.Assets.getAsset(view.poolKey)
+      if not imagetable then
+        Log.error("[RoxySprite:setView] Pool key not found: ", view.poolKey) --#DEBUG
+        return self
+      end
+      self.animation = RoxyAnimation.fromImagetable(imagetable) -- Refcount owned by this sprite
+      _applySizeFromImagetable(self.animation.imagetable)
+      self._drawFn = function(sprite, x, y, flip) sprite.animation:draw(x, y, flip) end
+
+    elseif kind == "animation" then
+      -- Pooled/shared animation object in Assets pool
+      local animation = roxy.Assets.getAsset(view.poolKey)
+      if type(animation) == "table" and animation.isRoxyAnimation then
+        if animation.retain then animation:retain() end -- Retain while this sprite uses it
+        self.animation = animation
+        _applySizeFromImagetable(self.animation.imagetable)
+        self._drawFn = function(sprite, x, y, flip) sprite.animation:draw(x, y, flip) end
+      else --#DEBUG
+        Log.error("[RoxySprite:setView] Pool key does not resolve to RoxyAnimation: ", view.poolKey) --#DEBUG
+      end
+
+    elseif kind == "image" then
+      local img = roxy.Assets.getAsset(view.poolKey)
+      if img and img.draw then
+        self:setImage(img) -- Sets sprite size from image
+        self._drawFn = function(_, x, y, flip) img:draw(x, y, flip) end
+      else --#DEBUG
+        Log.error("[RoxySprite:setView] Pool key does not resolve to Image: ", view.poolKey) --#DEBUG
+      end
+    end
+    return self
+  end
+
+  -- Handle direct pooled objects (existing extension)
+  if type(view) == "table" and view.imagetable then
+    -- Direct imagetable object from pool
+    self.animation = RoxyAnimation.fromImagetable(view.imagetable) -- refcount owned by this sprite
+    _applySizeFromImagetable(self.animation.imagetable)
+    self._drawFn = function(sprite, x, y, flip) sprite.animation:draw(x, y, flip) end
+    return self
+  end
+
+  if type(view) == "table" and view.animation and (type(view.animation) == "table" and view.animation.isRoxyAnimation) then
+    -- Direct pooled animation object
+    if view.animation.retain then view.animation:retain() end -- retain while this sprite uses it
+    self.animation = view.animation
+    _applySizeFromImagetable(self.animation.imagetable)
+    self._drawFn = function(sprite, x, y, flip) sprite.animation:draw(x, y, flip) end
+    return self
   end
 
   -- Pick and cache draw path
@@ -135,10 +206,12 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
           startFrame    = 1,
           endFrame      = imagetable:getLength(),
           currentFrame  = 1,
-          frameDuration = frameDuration,
+          frameDuration = frameDuration or 0.1,
           accumulator   = 0,
-          loop          = singleAnimationLoop,
+          loop          = (singleAnimationLoop ~= false),
         }
+        -- Ensure the sprite has bounds for culling/dirty-rects
+        _applySizeFromImagetable(imagetable)
         -- Draw function for simpleanim
         self._drawFn = function(sprite, x, y, flip)
           local simpleAnim = sprite.simpleAnim
@@ -148,10 +221,11 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
         end
       else
         -- Full RoxyAnimation
-        self.animation = RoxyAnimation(view)
+        self.animation = RoxyAnimation(view) -- path-based constructor
         if not (self.animation and self.animation.imagetable) then
           Log.error("[RoxySprite:setView] Failed to load spritesheet for RoxySprite") --#DEBUG
         end
+        _applySizeFromImagetable(self.animation and self.animation.imagetable)
         self._drawFn = function(sprite, x, y, flip)
           sprite.animation:draw(x, y, flip)
         end
@@ -159,19 +233,24 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
     else
       -- Static
       local image = newImage(view)
-      self:setImage(image)
+      self:setImage(image) -- playdate sets sprite size from image
       self._drawFn = function(sprite, x, y, flip)
         local img = sprite:getImage()
         if img then img:draw(x, y, flip) end
       end
     end
-  elseif type(view) == "table" and RoxyAnimation:isa(view) then
+
+  elseif type(view) == "table" and (view.isRoxyAnimation == true) then
+    -- Passed a RoxyAnimation instance directly
+    if view.retain then view:retain() end -- retain while this sprite uses it
     self.animation = view
+    _applySizeFromImagetable(self.animation.imagetable)
     self._drawFn = function(sprite, x, y, flip)
       sprite.animation:draw(x, y, flip)
     end
+
   elseif type(view) == "userdata" then
-    -- If it's an ImageTable (has drawImage), treat as a simpleAnim
+    -- If it is an ImageTable (has drawImage), treat as a simpleAnim
     if view.drawImage then
       local length = view:getLength()
       self.simpleAnim = {
@@ -183,6 +262,8 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
         accumulator   = 0,
         loop          = true,
       }
+      -- Ensure the sprite has bounds for culling/dirty-rects
+      _applySizeFromImagetable(view)
       self._drawFn = function(sprite, x, y, flip)
         local anim = sprite.simpleAnim
         if anim and anim.imagetable then
@@ -191,11 +272,12 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
       end
     else
       -- otherwise it must be a plain image
-      self:setImage(view)
+      self:setImage(view) -- playdate sets sprite size from image
       self._drawFn = function(_, x, y, flip)
         view:draw(x, y, flip)
       end
     end
+
   else
     Log.error("[RoxySprite:setView] Unsupported view type for RoxySprite:", type(view)) --#DEBUG
     self._drawFn = nil
@@ -625,8 +707,12 @@ function RoxySprite:getScreenPosition()
 end
 
 -- ! Destroy
+-- On destroy/remove, release shared animation
 function RoxySprite:destroy()
   self:remove()
+  if self.animation and self.animation.release then
+    self.animation:release()
+  end
   self.animation  = nil
   self.simpleAnim = nil
   self:setImage(nil)

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -4,8 +4,8 @@ local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
-local r         <const> = roxy
-local Camera   <const> = r.Camera
+local r       <const> = roxy
+local Camera  <const> = r.Camera
 
 local newImage      <const> = Graphics.image.new
 local newImagetable <const> = Graphics.imagetable.new
@@ -100,26 +100,35 @@ end
 -- View Management
 --------------------------------------------------------------------------------
 
--- ! Set View
--- Sets the visual representation for the sprite (image or animation).
-function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnimationLoop, frameDuration)
-  if not view then
-    self:setVisible(false)
-    self._drawFn = nil
-    return self
-  end
-  self:setVisible(true)
-
+-- ! Clear View Helper
+function RoxySprite:clearView()
   -- Dispose previous visual
   if self.animation then
     self.animation:stop()
-    if self.animation.release then self.animation:release() end -- balance any retain
+    if self.animation.release then self.animation:release() end -- Balance any retain
     self.animation = nil
   end
   self.simpleAnim = nil -- Clear any previous simpleAnim
   if self:getImage() then
     self:setImage(nil)
   end
+  self._drawFn = nil
+  -- Set fallback size when clearing view
+  self:setSize(0, 0)
+end
+
+-- ! Set View
+-- Sets the visual representation for the sprite (image or animation).
+function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnimationLoop, frameDuration)
+  if not view then
+    self:setVisible(false)
+    self:clearView()
+    return self
+  end
+  self:setVisible(true)
+
+  -- Clear previous state
+  self:clearView()
 
   -- Small helper: size this sprite from the first frame of an imagetable
   local function _applySizeFromImagetable(imagetable)
@@ -260,7 +269,7 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
         currentFrame  = 1,
         frameDuration = frameDuration or 0.1,
         accumulator   = 0,
-        loop          = true,
+        loop          = (singleAnimationLoop ~= false),
       }
       -- Ensure the sprite has bounds for culling/dirty-rects
       _applySizeFromImagetable(view)
@@ -547,29 +556,33 @@ function RoxySprite:update()
     local oldFrame = currentFrame -- Track if frame changes
 
     accumulator = accumulator + dt
-    if accumulator >= frameDuration then
+
+    -- Use while loop to handle large delta times properly
+    while accumulator >= frameDuration do
       currentFrame = currentFrame + 1
       if currentFrame > endFrame then
         if loop then
           currentFrame = startFrame
         else
           currentFrame = endFrame
+          -- Auto-pause completed one-shot animations for performance
+          if not loop then
+            self:pause()
+          end
         end
       end
-      accumulator = accumulator - frameDuration -- Preserve overflow for smooth timing
-
-      -- Write back the changed values
-      simpleAnim.currentFrame = currentFrame
-      simpleAnim.accumulator = accumulator
-
-      -- Only mark dirty if frame actually changed
-      if currentFrame ~= oldFrame then
-        self:markDirty()
-      end
-    else
-      -- Only update accumulator if we didn't enter the timing branch
-      simpleAnim.accumulator = accumulator
+      accumulator = accumulator - frameDuration
     end
+
+    -- Write back the changed values
+    simpleAnim.currentFrame = currentFrame
+    simpleAnim.accumulator = accumulator
+
+    -- Only mark dirty if frame actually changed
+    if currentFrame ~= oldFrame then
+      self:markDirty()
+    end
+
     return
   end
 
@@ -632,69 +645,64 @@ function RoxySprite:isAdded()
 end
 
 -- ! Is on Screen
+-- Unified bounds calculation logic with proper center anchor handling
 function RoxySprite:isOnScreen()
-  -- Direct property access instead of method calls
-  local spriteX = self.x or 0.5
-  local spriteY = self.y or 0.5
-  local spriteWidth = self.width
-  local spriteHeight = self.height
+  local spriteX = self.x or 0
+  local spriteY = self.y or 0
+  local spriteWidth = self.width or 0
+  local spriteHeight = self.height or 0
+  local centerX = self.centerX or 0.5
+  local centerY = self.centerY or 0.5
 
+  -- Calculate actual bounds based on center anchor
+  local left = spriteX - spriteWidth * centerX
+  local top = spriteY - spriteHeight * centerY
+  local right = left + spriteWidth
+  local bottom = top + spriteHeight
+
+  local leftLimit, topLimit, rightLimit, bottomLimit
   if self._ignoresDrawOffset then
-    -- Screen-space check (simpler case)
-    return not (
-      spriteX + spriteWidth < 0 or spriteX > DISPLAY_WIDTH or
-      spriteY + spriteHeight < 0 or spriteY > DISPLAY_HEIGHT
-    )
+    -- Screen-space bounds
+    leftLimit, topLimit = 0, 0
+    rightLimit, bottomLimit = DISPLAY_WIDTH, DISPLAY_HEIGHT
   else
-    -- World-space check with camera
-    local centerX = self.centerX
-    local centerY = self.centerY
-    local left = spriteX - spriteWidth * centerX
-    local top = spriteY - spriteHeight * centerY
-    local right = left + spriteWidth
-    local bottom = top + spriteHeight
-
-    -- Cache camera position once
+    -- World-space bounds with camera
     local camX, camY = getPosition()
-    return not (
-      right < camX or
-      left > camX + DISPLAY_WIDTH or
-      bottom < camY or
-      top > camY + DISPLAY_HEIGHT
-    )
+    leftLimit, topLimit = camX, camY
+    rightLimit, bottomLimit = camX + DISPLAY_WIDTH, camY + DISPLAY_HEIGHT
   end
+
+  return not (right < leftLimit or left > rightLimit or bottom < topLimit or top > bottomLimit)
 end
 
 -- ! Is on Screen (with cached camera)
+-- Unified with isOnScreen logic and proper fallbacks
 function RoxySprite:isOnScreenCached(camX, camY)
-  -- Direct property access instead of method calls
-  local spriteX = self.x
-  local spriteY = self.y
-  local spriteWidth = self.width
-  local spriteHeight = self.height
+  local spriteX = self.x or 0
+  local spriteY = self.y or 0
+  local spriteWidth = self.width or 0
+  local spriteHeight = self.height or 0
+  local centerX = self.centerX or 0.5
+  local centerY = self.centerY or 0.5
 
+  -- Calculate actual bounds based on center anchor
+  local left = spriteX - spriteWidth * centerX
+  local top = spriteY - spriteHeight * centerY
+  local right = left + spriteWidth
+  local bottom = top + spriteHeight
+
+  local leftLimit, topLimit, rightLimit, bottomLimit
   if self._ignoresDrawOffset then
-    -- Screen-space check (simpler case) - camera position irrelevant
-    return not (
-      spriteX + spriteWidth < 0 or spriteX > DISPLAY_WIDTH or
-      spriteY + spriteHeight < 0 or spriteY > DISPLAY_HEIGHT
-    )
+    -- Screen-space bounds (camera position irrelevant)
+    leftLimit, topLimit = 0, 0
+    rightLimit, bottomLimit = DISPLAY_WIDTH, DISPLAY_HEIGHT
   else
-    -- World-space check with provided camera coordinates
-    local centerX = self.centerX or 0.5
-    local centerY = self.centerY or 0.5
-    local left = spriteX - spriteWidth * centerX
-    local top = spriteY - spriteHeight * centerY
-    local right = left + spriteWidth
-    local bottom = top + spriteHeight
-
-    return not (
-      right < camX or
-      left > camX + DISPLAY_WIDTH or
-      bottom < camY or
-      top > camY + DISPLAY_HEIGHT
-    )
+    -- World-space bounds with provided camera coordinates
+    leftLimit, topLimit = camX, camY
+    rightLimit, bottomLimit = camX + DISPLAY_WIDTH, camY + DISPLAY_HEIGHT
   end
+
+  return not (right < leftLimit or left > rightLimit or bottom < topLimit or top > bottomLimit)
 end
 
 -- ! Get Screen Position

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -942,6 +942,11 @@ function RoxyTilemap:_getValidLayer(layerName)
   return layerData
 end
 
+-- ! Get Map Size in Tiles
+function RoxyTilemap:getMapSizeInTiles()
+  return self.mapWidth, self.mapHeight
+end
+
 -- ! World to Screen
 -- Converts world coordinates to screen coordinates for the given layer
 function RoxyTilemap:worldToScreen(worldX, worldY, layer)
@@ -1024,11 +1029,9 @@ function RoxyTilemap:destroy()
         release(sprite._retainedImagePath)
         sprite._retainedImagePath = nil
       end
-      if self.scene and self.scene.removeSprite then
-        self.scene:removeSprite(sprite)
-      else
-        sprite:remove()
-      end
+      -- Always remove the sprite directly;
+      -- the scene will remove the tilemap itself
+      sprite:remove()
     end
   end
 
@@ -1046,9 +1049,6 @@ function RoxyTilemap:destroy()
   self.tilesets = nil
   self.objectLayers = nil
 
-  if self.scene then
-    local scene = self.scene
-    self.scene = nil
-    if scene.removeTilemap then scene:removeTilemap(self) end
-  end
+  -- Just clear the back-pointer; do not call back into the scene
+  self.scene = nil
 end

--- a/roxy.lua
+++ b/roxy.lua
@@ -13,6 +13,7 @@ import "CoreLibs/crank"
 import "CoreLibs/animation"
 import "CoreLibs/animator"
 import "CoreLibs/timer"
+import "CoreLibs/frameTimer"
 import "CoreLibs/ui/crankIndicator"
 import "CoreLibs/ui/gridview"
 
@@ -81,6 +82,9 @@ local randomseed <const> = math.randomseed
 
 local getSecondsSinceEpoch  <const> = pd.getSecondsSinceEpoch
 local spriteUpdate          <const> = Sprite.update
+
+local updateTimers      <const> = pd.timer.updateTimers
+local updateFrameTimers <const> = pd.frameTimer.updateTimers
 
 local initConfig <const> = Config.init
 
@@ -245,6 +249,9 @@ function pd.update()
     Log.debug("Long frame: " .. dt)
   end
   --#DEBUG END
+
+  updateTimers()
+  updateFrameTimers()
 
   handleInput()
   updateSequences(dt)


### PR DESCRIPTION
### Overview
This release of **Roxy Engine v0.14.6** (roxy-engine-tests) improves memory efficiency and stability by introducing animation and path caching, pooled view management with reference counting, and safer lifecycle handling across graphics and scenes. It also adds reliable timer updates in the core loop and enhances the camera with delay and spring tuning.

**Note:** This release introduces breaking changes to tilemap and logging behavior—see migration details below.

### Key Changes
- **feat(animation): Imagetable constructors and cache**
  - New `RoxyAnimation.fromImagetable` and `fromPool` constructors.
  - Weak-key cache to reuse animations and reduce allocations.
  - Reference counting with retain/release lifecycle.

- **feat(animation): Path cache and safer sequences**
  - Reuse imagetables from a weak-key path cache.
  - Validate names, ranges, and precompute sequences for stability.
  - Ensure callbacks and chaining run in the correct order.

- **feat(graphics): Flexible actor sheets and pooled views**
  - `manifest.sheet` now accepts path, imagetable, or `RoxyAnimation`.
  - Support descriptor tables with `poolKey` to load pooled assets.
  - Wrap imagetables as `RoxyAnimation` with balanced retain/release.
  - Improve defaults for `frameDuration` and `loop`.

- **fix(graphics): Actor sheet handling and sprite lifecycle**
  - Safer handling of nil imagetables, one-shots, and default states.
  - Add `clearView` to fully reset and release retained assets.
  - Unified `isOnScreen` checks with proper anchors and camera bounds.

- **feat(core): Timer updates**
  - Run `pd.timer.updateTimers` and `pd.frameTimer.updateTimers` each frame automatically.

- **refactor(scene): Centralize tilemap lifecycle (BREAKING)**
  - Scenes now own adding/removing tilemaps and detaching sprites.
  - `RoxyTilemap:destroy` only clears its own resources, not the scene.
  - New `RoxyTilemap:getMapSizeInTiles()` convenience method.

- **feat(camera): Delay follow and spring tuning**
  - Add `followAfterDelay` for delayed re-attachment.
  - Lower default spring frequency for smoother feel.
  - Clamp to bounds without jitter.

- **feat(core): Vararg logging and assert fix (BREAKING)**
  - Logging functions (`error`, `warn`, `info`, `debug`) accept varargs with optional stack level.
  - `Log.assert` now always throws, independent of log level.

### Challenges/Notes
- Reference counting was added carefully to avoid leaks; pooled views must always balance `retain`/`release`.
- Tilemap lifecycle ownership is now clear and centralized, but requires migration for existing projects.
- Logging overhaul ensures safer assertions but may break projects that relied on suppressed asserts.