### PR TITLE
[0.15.7] - Stabilize Transition Initialization and Logging

### DIFF
--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -1,13 +1,18 @@
 -- core/modules/Transition.lua
 
+roxy = roxy or {}
+roxy.Transition = roxy.Transition or {}
+
+if roxy.Transition.STACK_OP_REPLACE == nil then roxy.Transition.STACK_OP_REPLACE = 0 end
+if roxy.Transition.STACK_OP_PUSH == nil then roxy.Transition.STACK_OP_PUSH = 1 end
+if roxy.Transition.STACK_OP_POP == nil then roxy.Transition.STACK_OP_POP = 2 end
+
 import "libraries/roxy/core/transitions/RoxyTransition"
 import "libraries/roxy/core/transitions/Cut"
 import "libraries/roxy/core/transitions/FadeToColor"
 import "libraries/roxy/core/transitions/CrossDissolve"
 import "libraries/roxy/core/transitions/ImageTable"
 
-roxy = roxy or {}
-roxy.Transition = roxy.Transition or {}
 local Transition <const> = roxy.Transition
 
 local pd        <const> = playdate

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -70,11 +70,20 @@ Transition.STACK_OP_PUSH      = STACK_OP_PUSH
 Transition.STACK_OP_POP       = STACK_OP_POP
 
 -- Local
-local transitions = {}
+local transitions         = {}
+local busyWarnedOnce      = false
+local busySuppressedCount = 0
+local activeTransitionKey = nil
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
+
+local function _resetBusyWarnState()
+  busyWarnedOnce = false
+  busySuppressedCount = 0
+  activeTransitionKey = nil
+end
 
 -- ! Helper: Foce Scene Tilemaps Redraw
 -- Nudge all tilemaps in a scene to repaint for a few frames
@@ -93,6 +102,18 @@ local function _forceSceneTilemapsRedraw(scene, frames)
   end
 end
 
+function Transition._flushBusyTransitionSummary(completedName)
+  local suppressedCount = busySuppressedCount
+  local transitionName = completedName or activeTransitionKey or "unknown"
+  _resetBusyWarnState()
+
+  --#DEBUG START
+  if suppressedCount > 0 then
+    Log.warn("[Transition.transitionToScene] Suppressed " .. suppressedCount .. " additional transition request(s) while '" .. tostring(transitionName) .. "' was in progress.")
+  end
+  --#DEBUG END
+end
+
 --------------------------------------------------------------------------------
 -- ! Initialize Transition module
 --------------------------------------------------------------------------------
@@ -102,6 +123,7 @@ function Transition.init()
   Transition.currentTransition = nil
   Transition.isTransitioning   = false
   Transition.stackOp           = STACK_OP_REPLACE
+  _resetBusyWarnState()
 
   -- Clear out any previously loaded classes
   transitions = {}
@@ -207,9 +229,19 @@ end
 -- Initiates a scene transition using the specified effect and timing.
 function Transition.transitionToScene(newSceneClass, transitionName, opts)
   if Transition.isTransitioning then
-    Log.warn("[Transition.transitionToScene] Transition already in progress.") --#DEBUG
+    if not busyWarnedOnce then
+      --#DEBUG START
+      local transitionNameInProgress = activeTransitionKey or "unknown"
+      Log.warn("[Transition.transitionToScene] Transition '" .. tostring(transitionNameInProgress) .. "' already in progress; suppressing repeated warnings until completion.")
+      --#DEBUG END
+      busyWarnedOnce = true
+    else
+      busySuppressedCount += 1
+    end
     return
   end
+
+  _resetBusyWarnState()
 
   local stackOp = Transition.stackOp
   local newScene = nil
@@ -222,17 +254,21 @@ function Transition.transitionToScene(newSceneClass, transitionName, opts)
     --#DEBUG END
   end
 
-  Transition.isTransitioning = true
-  local scene = Scene.currentScene
-
   -- Use transition or fallback to default
   local config = getConfig("transitions") or EMPTY_TABLE
-  local transition = config.defaultTransition or TRANSITION_DEFAULT
-  local transitionClass = transitions[(transitionName or transition)]
+  local defaultTransition = config.defaultTransition or TRANSITION_DEFAULT
+  local requestedTransition = transitionName or defaultTransition
+  local transitionClass = transitions[requestedTransition]
+  local resolvedTransitionKey = requestedTransition
   if not transitionClass then
-    Log.warn("[Transition.transitionToScene] Unknown transition " .. transitionName .. ", falling back to " .. transition) --#DEBUG
-    transitionClass = transitions[transition]
+    Log.warn("[Transition.transitionToScene] Unknown transition " .. tostring(transitionName) .. ", falling back to " .. defaultTransition) --#DEBUG
+    resolvedTransitionKey = defaultTransition
+    transitionClass = transitions[resolvedTransitionKey]
   end
+
+  activeTransitionKey = resolvedTransitionKey
+  Transition.isTransitioning = true
+  local scene = Scene.currentScene
 
   -- Merge options (arguments take precedence)
   local transitionOpts = mergeImmutable(opts or {}, { stackOp = stackOp })

--- a/core/transitions/CrossDissolve.lua
+++ b/core/transitions/CrossDissolve.lua
@@ -6,23 +6,22 @@ local Graphics  <const> = pd.graphics
 local Image     <const> = Graphics.image
 
 -- Roxy Framework
-local r           <const> = roxy
-local Config      <const> = r.Config
-local Assets      <const> = r.Assets
-local Registry    <const> = r.AssetPoolRegistry
-local Ease        <const> = r.EasingFunctions
-local Scene       <const> = r.Scene
-local Transition  <const> = r.Transition
+local r         <const> = roxy
+local Config    <const> = r.Config
+local Assets    <const> = r.Assets
+local Registry  <const> = r.AssetPoolRegistry
+local Ease      <const> = r.EasingFunctions
+local Scene     <const> = r.Scene
 
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
 
 -- Assets
-local getAsset            <const> = Assets.getAsset
-local recycleAsset        <const> = Assets.recycleAsset
-local ensurePool          <const> = Registry.ensurePool
-local markFromPool        <const> = Registry.markFromPool
-local isFromPool          <const> = Registry.isFromPool
+local getAsset      <const> = Assets.getAsset
+local recycleAsset  <const> = Assets.recycleAsset
+local ensurePool    <const> = Registry.ensurePool
+local markFromPool  <const> = Registry.markFromPool
+local isFromPool    <const> = Registry.isFromPool
 
 -- Math
 local min   <const> = math.min
@@ -39,13 +38,24 @@ local getDisplayImage   <const> = Graphics.getDisplayImage
 local fillRect          <const> = Graphics.fillRect
 local newImage          <const> = Image.new
 
--- C-side binding
-local drawFrame_C <const> = Transition.crossDissolveDrawFrame
-
 -- Stack operations
-local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
-local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
-local STACK_OP_POP     <const> = Transition.STACK_OP_POP
+local STACK_OP_REPLACE  <const> = RoxyTransition.STACK_OP_REPLACE
+local STACK_OP_PUSH     <const> = RoxyTransition.STACK_OP_PUSH
+local STACK_OP_POP      <const> = RoxyTransition.STACK_OP_POP
+
+-- Transition binding cache
+local transitionBindingCache = {}
+
+local function resolveTransitionBinding(bindingName)
+  local fn = transitionBindingCache[bindingName]
+  if fn then return fn end
+
+  local transition = roxy and roxy.Transition
+  fn = transition and transition[bindingName]
+  assert(type(fn) == "function", "[TransitionBinding] missing roxy.Transition." .. bindingName)
+  transitionBindingCache[bindingName] = fn
+  return fn
+end
 
 -- Graphics constants
 local COLOR_BLACK       <const> = Graphics.kColorBlack
@@ -54,7 +64,7 @@ local DITHER_BAYER_8X8  <const> = Image.kDitherTypeBayer8x8
 
 -- Easing constants
 local FLAT_EASING    <const> = Ease.flat
-local LINEAR_EASING  <const> = Ease.linear
+local LINEAR_EASING <const> = Ease.linear
 
 -- Defaults
 local DURATION_DEFAULT    <const> = 1.5
@@ -281,7 +291,8 @@ function CrossDissolve:draw()
   -- Calculate pattern index based on alpha value
   local idx = min(fadeSteps, floor(alpha * fadeStepsMinus1) + 1)
   local pattern = patterns[idx]
-  drawFrame_C(screenshot, pattern)
+  local drawFrame = resolveTransitionBinding("crossDissolveDrawFrame")
+  drawFrame(screenshot, pattern)
 end
 
 -- ! Cleanup

--- a/core/transitions/Cut.lua
+++ b/core/transitions/Cut.lua
@@ -4,17 +4,16 @@
 local pd <const> = playdate
 
 -- Roxy Framework
-local r           <const> = roxy
-local Config      <const> = r.Config
-local Transition  <const> = r.Transition
+local r       <const> = roxy
+local Config  <const> = r.Config
 
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
 
 -- Expose stack-op constants so children don't need to re-require them
-local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
-local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
-local STACK_OP_POP     <const> = Transition.STACK_OP_POP
+local STACK_OP_REPLACE  <const> = RoxyTransition.STACK_OP_REPLACE
+local STACK_OP_PUSH     <const> = RoxyTransition.STACK_OP_PUSH
+local STACK_OP_POP      <const> = RoxyTransition.STACK_OP_POP
 
 -- Utility constants
 local EMPTY_TABLE <const> = {}

--- a/core/transitions/FadeToColor.lua
+++ b/core/transitions/FadeToColor.lua
@@ -6,22 +6,21 @@ local Graphics  <const> = pd.graphics
 local Image     <const> = Graphics.image
 
 -- Roxy Framework
-local r           <const> = roxy
-local Config      <const> = r.Config
-local Assets      <const> = r.Assets
-local Registry    <const> = r.AssetPoolRegistry
-local Ease        <const> = r.EasingFunctions
-local Transition  <const> = r.Transition
+local r         <const> = roxy
+local Config    <const> = r.Config
+local Assets    <const> = r.Assets
+local Registry  <const> = r.AssetPoolRegistry
+local Ease      <const> = r.EasingFunctions
 
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
 
 -- Assets
-local getAsset            <const> = Assets.getAsset
-local recycleAsset        <const> = Assets.recycleAsset
-local ensurePool          <const> = Registry.ensurePool
-local markFromPool        <const> = Registry.markFromPool
-local isFromPool          <const> = Registry.isFromPool
+local getAsset      <const> = Assets.getAsset
+local recycleAsset  <const> = Assets.recycleAsset
+local ensurePool    <const> = Registry.ensurePool
+local markFromPool  <const> = Registry.markFromPool
+local isFromPool    <const> = Registry.isFromPool
 
 -- Math
 local min   <const> = math.min
@@ -39,13 +38,24 @@ local newImage          <const> = Image.new
 local getEaseEnter  <const> = Ease.enter
 local getEaseExit   <const> = Ease.exit
 
--- C-side binding
-local drawTiled_C <const> = Transition.fadeToColorDrawFrame
-
 -- Stack operations
-local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
-local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
-local STACK_OP_POP     <const> = Transition.STACK_OP_POP
+local STACK_OP_REPLACE  <const> = RoxyTransition.STACK_OP_REPLACE
+local STACK_OP_PUSH     <const> = RoxyTransition.STACK_OP_PUSH
+local STACK_OP_POP      <const> = RoxyTransition.STACK_OP_POP
+
+-- Transition binding cache
+local transitionBindingCache = {}
+
+local function resolveTransitionBinding(bindingName)
+  local fn = transitionBindingCache[bindingName]
+  if fn then return fn end
+
+  local transition = roxy and roxy.Transition
+  fn = transition and transition[bindingName]
+  assert(type(fn) == "function", "[TransitionBinding] missing roxy.Transition." .. bindingName)
+  transitionBindingCache[bindingName] = fn
+  return fn
+end
 
 -- Graphics constants
 local COLOR_BLACK       <const> = Graphics.kColorBlack
@@ -275,7 +285,8 @@ function FadeToColor:draw()
   local idx = min(fadeSteps, floor(alpha * fadeStepsMinus1) + 1)
   -- patterns[idx]:drawTiled(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
   local pattern = patterns[idx]
-  drawTiled_C(pattern)
+  local drawFrame = resolveTransitionBinding("fadeToColorDrawFrame")
+  drawFrame(pattern)
 end
 
 -- ! Cleanup

--- a/core/transitions/ImageTable.lua
+++ b/core/transitions/ImageTable.lua
@@ -5,50 +5,60 @@ local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 
 -- Roxy Framework
-local r           <const> = roxy
-local Config      <const> = r.Config
-local Assets      <const> = r.Assets
-local Registry    <const> = r.AssetPoolRegistry
-local Ease        <const> = r.EasingFunctions
-local Transition  <const> = r.Transition
+local r         <const> = roxy
+local Config    <const> = r.Config
+local Assets    <const> = r.Assets
+local Registry  <const> = r.AssetPoolRegistry
+local Ease      <const> = r.EasingFunctions
 
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
 
 -- Assets
-local getAsset            <const> = Assets.getAsset
-local recycleAsset        <const> = Assets.recycleAsset
-local ensurePool          <const> = Registry.ensurePool
-local markFromPool        <const> = Registry.markFromPool
-local isFromPool          <const> = Registry.isFromPool
+local getAsset      <const> = Assets.getAsset
+local recycleAsset  <const> = Assets.recycleAsset
+local ensurePool    <const> = Registry.ensurePool
+local markFromPool  <const> = Registry.markFromPool
+local isFromPool    <const> = Registry.isFromPool
 
 -- Graphics
-local newImageTable     <const> = Graphics.imagetable.new
+local newImageTable <const> = Graphics.imagetable.new
 
 -- Easing
 local getEaseEnter  <const> = Ease.enter
 local getEaseExit   <const> = Ease.exit
 
--- C-side binding
-local drawFrame_C <const> = Transition.imageTableDrawFrame
-
 -- Stack operations
-local STACK_OP_REPLACE <const> = Transition.STACK_OP_REPLACE
-local STACK_OP_PUSH    <const> = Transition.STACK_OP_PUSH
-local STACK_OP_POP     <const> = Transition.STACK_OP_POP
+local STACK_OP_REPLACE  <const> = RoxyTransition.STACK_OP_REPLACE
+local STACK_OP_PUSH     <const> = RoxyTransition.STACK_OP_PUSH
+local STACK_OP_POP      <const> = RoxyTransition.STACK_OP_POP
+
+-- Transition binding cache
+local transitionBindingCache = {}
+
+local function resolveTransitionBinding(bindingName)
+  local fn = transitionBindingCache[bindingName]
+  if fn then return fn end
+
+  local transition = roxy and roxy.Transition
+  fn = transition and transition[bindingName]
+  assert(type(fn) == "function", "[TransitionBinding] missing roxy.Transition." .. bindingName)
+  transitionBindingCache[bindingName] = fn
+  return fn
+end
 
 -- Graphics constants
-local FLIPPED_XY        <const> = Graphics.kImageFlippedXY
-local FLIPPED_X         <const> = Graphics.kImageFlippedX
-local FLIPPED_Y         <const> = Graphics.kImageFlippedY
-local UNFLIPPED         <const> = Graphics.kImageUnflipped
+local FLIPPED_XY  <const> = Graphics.kImageFlippedXY
+local FLIPPED_X   <const> = Graphics.kImageFlippedX
+local FLIPPED_Y   <const> = Graphics.kImageFlippedY
+local UNFLIPPED   <const> = Graphics.kImageUnflipped
 
 -- Easing constants
-local LINEAR_EASING  <const> = Ease.linear
+local LINEAR_EASING <const> = Ease.linear
 
 -- Defaults
-local DURATION_DEFAULT    <const> = 1.5
-local HOLD_TIME_DEFAULT   <const> = 0
+local DURATION_DEFAULT  <const> = 1.5
+local HOLD_TIME_DEFAULT <const> = 0
 
 -- Utility constants
 local SEQUENCE_POOL_KEY         <const> = "Transition_Sequence"
@@ -380,7 +390,8 @@ function ImageTable:draw()
   local value = sequence:getValue()
   if not value then return end
 
-  drawFrame_C(
+  local drawFrame = resolveTransitionBinding("imageTableDrawFrame")
+  drawFrame(
     self.imageTableEnter, self.frameCountEnter, self.flipValueEnter,
     self.imageTableExit,  self.frameCountExit,  self.flipValueExit,
     value,

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -7,16 +7,19 @@ local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
 -- Graphics helpers
-local getDisplayImage       <const> = Graphics.getDisplayImage
+local getDisplayImage <const> = Graphics.getDisplayImage
 
 -- Roxy Framework
-local r           <const> = roxy
-local Scene       <const> = r.Scene
-local Transition  <const> = r.Transition
+local r     <const> = roxy
+local Scene <const> = r.Scene
 
 -- Sprite helpers used during scene switching
 local redrawBackground      <const> = Sprite.redrawBackground
 local setBackgroundDrawing  <const> = Sprite.setBackgroundDrawingCallback
+
+local STACK_OP_REPLACE  <const> = 0
+local STACK_OP_PUSH     <const> = 1
+local STACK_OP_POP      <const> = 2
 
 -- Scene management
 local pushRaw     <const> = Scene.pushRaw
@@ -24,8 +27,8 @@ local popRaw      <const> = Scene.popRaw
 local replaceRaw  <const> = Scene.replaceRaw
 
 -- Bit-flags that track where we are in the life-cycle
-local STATE_MIDPOINT_REACHED <const> = 1
-local STATE_HOLD_ELAPSED     <const> = 2
+local STATE_MIDPOINT_REACHED  <const> = 1
+local STATE_HOLD_ELAPSED      <const> = 2
 
 --------------------------------------------------------------------------------
 -- ! Class Definition & Initialization
@@ -39,7 +42,7 @@ function RoxyTransition:init(opts)
   -- Basic properties
   self.name = opts.name or "UnnamedTransition"
   self.type = opts.type or "Base"
-  self.stackOp  = opts.stackOp or Transition.STACK_OP_REPLACE
+  self.stackOp  = opts.stackOp or STACK_OP_REPLACE
 
   -- bookkeeping
   self.state = 0
@@ -61,7 +64,7 @@ end
 function RoxyTransition:_onStart()
   Log.debug("Transition '" .. self.name .. "' started") --#DEBUG
 
-  if self.stackOp == Transition.STACK_OP_REPLACE and self._currentScene then
+  if self.stackOp == STACK_OP_REPLACE and self._currentScene then
     self._currentScene:exit()
   end
 end
@@ -78,9 +81,9 @@ function RoxyTransition:_onMidpoint()
   local oldScene = self._currentScene
 
   -- Perform stack operation
-  if stackOp == Transition.STACK_OP_PUSH then
+  if stackOp == STACK_OP_PUSH then
     pushRaw(newScene)
-  elseif stackOp == Transition.STACK_OP_POP then
+  elseif stackOp == STACK_OP_POP then
     popRaw()
     newScene = Scene.currentScene
   else -- Replace
@@ -88,14 +91,14 @@ function RoxyTransition:_onMidpoint()
   end
 
   -- Handle scene lifecycle
-  if stackOp == Transition.STACK_OP_POP then
+  if stackOp == STACK_OP_POP then
     if oldScene then
       oldScene:cleanup()
     end
     if newScene then
       newScene:resume()
     end
-  elseif stackOp == Transition.STACK_OP_PUSH then
+  elseif stackOp == STACK_OP_PUSH then
     if oldScene then
       oldScene:pause()
     end
@@ -144,8 +147,10 @@ function RoxyTransition:_onComplete()
     scene:start()
   end
 
-  Transition.isTransitioning = false
-  Transition.currentTransition = nil
+  local transition = roxy and roxy.Transition
+  assert(type(transition) == "table", "[RoxyTransition] missing roxy.Transition during completion")
+  transition.isTransitioning = false
+  transition.currentTransition = nil
   self:cleanup()
   Log.debug("Transition '" .. self.name .. "' completed") --#DEBUG
 end
@@ -172,12 +177,12 @@ function RoxyTransition:cleanup()
   self._newScene     = nil
   self._currentScene = nil
   self.state         = 0
-  self._capturedScreenshot   = nil
+  self._capturedScreenshot  = nil
 end
 
 -- Re-export constants so children can reference them via RoxyTransition
 RoxyTransition.STATE_MIDPOINT_REACHED = STATE_MIDPOINT_REACHED
 RoxyTransition.STATE_HOLD_ELAPSED     = STATE_HOLD_ELAPSED
-RoxyTransition.STACK_OP_REPLACE       = Transition.STACK_OP_REPLACE
-RoxyTransition.STACK_OP_PUSH          = Transition.STACK_OP_PUSH
-RoxyTransition.STACK_OP_POP           = Transition.STACK_OP_POP
+RoxyTransition.STACK_OP_REPLACE       = STACK_OP_REPLACE
+RoxyTransition.STACK_OP_PUSH          = STACK_OP_PUSH
+RoxyTransition.STACK_OP_POP           = STACK_OP_POP

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -142,6 +142,7 @@ end
 -- ! On Complete
 function RoxyTransition:_onComplete()
   local scene = self._newScene
+  local completedName = self.name
 
   if scene and scene.start then
     scene:start()
@@ -151,6 +152,12 @@ function RoxyTransition:_onComplete()
   assert(type(transition) == "table", "[RoxyTransition] missing roxy.Transition during completion")
   transition.isTransitioning = false
   transition.currentTransition = nil
+
+  local flushBusySummary = transition._flushBusyTransitionSummary
+  if type(flushBusySummary) == "function" then
+    flushBusySummary(completedName)
+  end
+
   self:cleanup()
   Log.debug("Transition '" .. self.name .. "' completed") --#DEBUG
 end


### PR DESCRIPTION
### Overview
This patch release hardens the transition system by removing module load-order coupling and improving diagnostics. Transition stack operations and bindings are now resolved in safer places, with clear fail-fast asserts when required globals/bindings are missing, and busy-transition logging is reduced to useful summaries instead of flood-level noise.

### Key Changes
- Initialized `Transition` stack-op defaults before loading transition modules, while preserving existing values on reload.
- Decoupled `RoxyTransition` from `roxy.Transition` load-time globals by defining local stack-op constants and asserting `roxy.Transition` exists before completion cleanup.
- Updated `Cut` to use `RoxyTransition` stack-op constants so it no longer depends on `Transition` init order.
- Switched `FadeToColor`, `CrossDissolve`, and `ImageTable` to cached lazy runtime resolution for transition draw-frame bindings, with clear asserts if bindings are unavailable.
- Added warn-once suppression for transition requests made while busy, plus a completion summary reporting suppressed request count.
- Improved busy/re-entrant logging naming by resolving the transition key before setting the busy flag, while keeping logs debug-only in release builds.

### Challenges/Notes
- Lazy binding and local constants were chosen to break initialization-order dependencies without changing public transition behavior.
- Fail-fast asserts intentionally surface configuration/init bugs early, rather than allowing silent or delayed failures.