### PR TITLE
[0.15.8] - Harden Asset Pools and Add Tilemap Probes

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -41,7 +41,6 @@ local clamp           <const> = Math.clamp
 local truncateDecimal <const> = Math.truncateDecimal
 local getAsset        <const> = Assets.getAsset
 local recycleAsset    <const> = Assets.recycleAsset
-local markFromPool    <const> = Registry.markFromPool
 local isFromPool      <const> = Registry.isFromPool
 local updateAnimation <const> = Animation.update -- C Function
 
@@ -104,7 +103,7 @@ end
 -- ! From Pool
 -- Create animation from Assets pool
 function RoxyAnimation.fromPool(poolKey)
-  local imagetable = markFromPool(getAsset(poolKey))
+  local imagetable = getAsset(poolKey)
   if not imagetable then
     error("[RoxyAnimation.fromPool] No asset for key: ", tostring(poolKey))
     return nil

--- a/core/modules/AssetPoolRegistry.lua
+++ b/core/modules/AssetPoolRegistry.lua
@@ -11,8 +11,13 @@
 -- Key Features:
 --  - Pool registration with lazy initialization
 --  - Weak-reference tagging for pool-sourced assets
+--  - Ownership tracking by origin pool key
 --  - Convenience wrappers for path-based and object-based pools
 --  - Integration with roxy.Assets core pooling system
+--
+-- Pool Key Contract:
+--  - key must be a non-empty string
+--  - key cannot have leading/trailing whitespace
 --
 --------------------------------------------------------------------------------
 
@@ -29,12 +34,31 @@ local Assets              <const> = roxy.Assets
 local getIsPoolRegistered <const> = Assets.getIsPoolRegistered
 local registerPool        <const> = Assets.registerPool
 
+-- String functions
+local stringFormat        <const> = string.format
+
 --------------------------------------------------------------------------------
 -- Local State Variables
 --------------------------------------------------------------------------------
 
--- Weak-key set to remember "came from pool"
-local poolTag = setmetatable({}, { __mode = "k" })  -- Weak keys
+-- Weak-key map to remember pooled state and origin pool ownership
+-- value: string pool key (owned) | true (legacy pooled tag)
+local poolTag = setmetatable({}, { __mode = "k" })
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+local function formatPoolKeyValue(key)
+  return stringFormat("%q", tostring(key))
+end
+
+local function isValidPoolKey(key)
+  if type(key) ~= "string" then return false end
+  if not key:match("%S") then return false end
+  if key:match("^%s") or key:match("%s$") then return false end
+  return true
+end
 
 --------------------------------------------------------------------------------
 -- Public API
@@ -43,11 +67,28 @@ local poolTag = setmetatable({}, { __mode = "k" })  -- Weak keys
 -- ! Mark From Pool
 -- Tags an asset as originating from a pool using weak-reference tracking
 --  @param asset Asset instance to tag (any type)
+--  @param key   Optional pool key (non-empty string, no leading/trailing whitespace)
 --
 --  @return The asset instance (for chaining)
 
-function Registry.markFromPool(asset)
-  if asset then poolTag[asset] = true end
+function Registry.markFromPool(asset, key)
+  if not asset then return asset end
+
+  local existing = poolTag[asset]
+
+  if key == nil then
+    if existing == nil then
+      poolTag[asset] = true
+    end
+    return asset
+  end
+
+  if not isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.markFromPool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return asset
+  end
+
+  poolTag[asset] = key
   return asset
 end
 
@@ -58,7 +99,23 @@ end
 --  @return Boolean true if asset came from a pool
 
 function Registry.isFromPool(asset)
-  return asset and poolTag[asset] or false
+  return asset and poolTag[asset] ~= nil or false
+end
+
+-- ! Get Pool Key
+-- Returns the owned pool key for an asset (if available)
+--  @param asset Asset instance to check (any type)
+--
+--  @return String pool key or nil if untagged/legacy-tagged
+
+function Registry.getPoolKey(asset)
+  if not asset then return nil end
+
+  local tag = poolTag[asset]
+  if type(tag) == "string" then
+    return tag
+  end
+  return nil
 end
 
 -- ! Clear From Pool
@@ -74,13 +131,18 @@ end
 
 -- ! Register
 -- Registers a pool for any asset type if not already registered
---  @param key    Unique identifier string for the pool
+--  @param key    Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param loader Function that returns a new asset instance
 --  @param opts   Optional table with pool options (initialCount, maxSize, growthFactor)
 --
---  @return The pool key string (for chaining)
+--  @return The pool key string, or nil on invalid key
 
 function Registry.register(key, loader, opts)
+  if not isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.register] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return nil
+  end
+
   if not getIsPoolRegistered(key) then
     local initialCount = (opts and opts.initialCount) or 1
     registerPool(key, initialCount, loader, opts)
@@ -90,14 +152,19 @@ end
 
 -- ! Ensure Pool
 -- Returns the pool key if it exists, or registers it on-demand
---  @param key          Unique identifier string for the pool
+--  @param key          Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param initialCount Initial number of assets to pre-allocate (defaults to 1)
 --  @param loader       Function that returns a new asset instance
 --  @param options      Optional table with pool options (maxSize, growthFactor)
 --
---  @return The pool key string
+--  @return The pool key string, or nil on invalid key
 
 function Registry.ensurePool(key, initialCount, loader, options)
+  if not isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.ensurePool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return nil
+  end
+
   if not getIsPoolRegistered(key) then
     registerPool(key, initialCount or 1, loader, options)
   end
@@ -106,12 +173,12 @@ end
 
 -- ! Ensure For Path
 -- Convenience wrapper for path-based asset pools (images, sounds, etc)
---  @param key         Unique identifier string for the pool
+--  @param key         Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param assetPath   File path to the asset resource
 --  @param constructor Function that creates the asset (e.g., playdate.graphics.image.new)
 --  @param opts        Optional table with pool options (initialCount, maxSize, growthFactor)
 --
---  @return The pool key string
+--  @return The pool key string, or nil on invalid key
 
 function Registry.ensureForPath(key, assetPath, constructor, opts)
   return Registry.register(
@@ -123,11 +190,11 @@ end
 
 -- ! Ensure For Object
 -- Convenience wrapper for fixed object pools (caches a single object instance)
---  @param key    Unique identifier string for the pool
+--  @param key    Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param object The object instance to cache
 --  @param opts   Optional table with pool options (initialCount, maxSize, growthFactor)
 --
---  @return The pool key string
+--  @return The pool key string, or nil on invalid key
 
 function Registry.ensureForObject(key, object, opts)
   return Registry.register(

--- a/core/modules/AssetPoolRegistry.lua
+++ b/core/modules/AssetPoolRegistry.lua
@@ -129,6 +129,55 @@ function Registry.clearFromPool(asset)
   return asset
 end
 
+--------------------------------------------------------------------------------
+-- Internal API (pre-validated fast paths)
+--------------------------------------------------------------------------------
+--
+-- Used only by roxy.Assets. External code should use the public API above.
+--
+
+-- ! Mark From Pool Direct
+-- Fast-path pool tagging. Skips all validation.
+-- Caller contract: asset ~= nil, key is a validated non-empty string.
+--  @param asset Asset instance to tag
+--  @param key   Validated pool key string
+--
+--  @return The asset instance
+
+function Registry.markFromPoolDirect(asset, key)
+  poolTag[asset] = key
+  return asset
+end
+
+-- ! Get Origin Key
+-- Single-lookup ownership query. Replaces isFromPool + getPoolKey sequence.
+--  @param asset Asset instance to check
+--
+--  @return originKey, isPooled (two values)
+--    (string, true)  — asset is owned by the named pool
+--    (nil,    true)  — asset has a legacy pool tag (no key)
+--    (nil,    false) — asset is not tagged at all
+
+function Registry.getOriginKey(asset)
+  local tag = poolTag[asset]
+  if tag == nil then return nil, false end
+  if type(tag) == "string" then return tag, true end
+  return nil, true
+end
+
+-- ! Clear From Pool Direct
+-- Fast-path tag removal. Skips nil-asset guard.
+-- Caller contract: asset ~= nil.
+--  @param asset Asset instance to untag
+
+function Registry.clearFromPoolDirect(asset)
+  poolTag[asset] = nil
+end
+
+--------------------------------------------------------------------------------
+-- Pool Registration API
+--------------------------------------------------------------------------------
+
 -- ! Register
 -- Registers a pool for any asset type if not already registered
 --  @param key    Non-empty string key for the pool (no leading/trailing whitespace)

--- a/core/modules/AssetPoolRegistry.lua
+++ b/core/modules/AssetPoolRegistry.lua
@@ -49,11 +49,11 @@ local poolTag = setmetatable({}, { __mode = "k" })
 -- Helpers
 --------------------------------------------------------------------------------
 
-local function formatPoolKeyValue(key)
+local function _formatPoolKeyValue(key)
   return stringFormat("%q", tostring(key))
 end
 
-local function isValidPoolKey(key)
+local function _isValidPoolKey(key)
   if type(key) ~= "string" then return false end
   if not key:match("%S") then return false end
   if key:match("^%s") or key:match("%s$") then return false end
@@ -83,8 +83,8 @@ function Registry.markFromPool(asset, key)
     return asset
   end
 
-  if not isValidPoolKey(key) then
-    Log.warn("[AssetPoolRegistry.markFromPool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.markFromPool] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return asset
   end
 
@@ -138,8 +138,8 @@ end
 --  @return The pool key string, or nil on invalid key
 
 function Registry.register(key, loader, opts)
-  if not isValidPoolKey(key) then
-    Log.warn("[AssetPoolRegistry.register] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.register] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return nil
   end
 
@@ -160,8 +160,8 @@ end
 --  @return The pool key string, or nil on invalid key
 
 function Registry.ensurePool(key, initialCount, loader, options)
-  if not isValidPoolKey(key) then
-    Log.warn("[AssetPoolRegistry.ensurePool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[AssetPoolRegistry.ensurePool] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return nil
   end
 

--- a/core/modules/AssetPoolRegistry.lua
+++ b/core/modules/AssetPoolRegistry.lua
@@ -41,8 +41,8 @@ local stringFormat        <const> = string.format
 -- Local State Variables
 --------------------------------------------------------------------------------
 
--- Weak-key map to remember pooled state and origin pool ownership
--- value: string pool key (owned) | true (legacy pooled tag)
+-- Weak-key map to remember pooled ownership by origin pool key.
+-- value: string pool key (owned)
 local poolTag = setmetatable({}, { __mode = "k" })
 
 --------------------------------------------------------------------------------
@@ -67,21 +67,12 @@ end
 -- ! Mark From Pool
 -- Tags an asset as originating from a pool using weak-reference tracking
 --  @param asset Asset instance to tag (any type)
---  @param key   Optional pool key (non-empty string, no leading/trailing whitespace)
+--  @param key   Pool key (non-empty string, no leading/trailing whitespace)
 --
 --  @return The asset instance (for chaining)
 
 function Registry.markFromPool(asset, key)
   if not asset then return asset end
-
-  local existing = poolTag[asset]
-
-  if key == nil then
-    if existing == nil then
-      poolTag[asset] = true
-    end
-    return asset
-  end
 
   if not _isValidPoolKey(key) then
     Log.warn("[AssetPoolRegistry.markFromPool] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
@@ -99,14 +90,14 @@ end
 --  @return Boolean true if asset came from a pool
 
 function Registry.isFromPool(asset)
-  return asset and poolTag[asset] ~= nil or false
+  return asset and type(poolTag[asset]) == "string" or false
 end
 
 -- ! Get Pool Key
 -- Returns the owned pool key for an asset (if available)
 --  @param asset Asset instance to check (any type)
 --
---  @return String pool key or nil if untagged/legacy-tagged
+--  @return String pool key or nil if untagged
 
 function Registry.getPoolKey(asset)
   if not asset then return nil end
@@ -145,6 +136,13 @@ end
 --  @return The asset instance
 
 function Registry.markFromPoolDirect(asset, key)
+  --#DEBUG START
+  if type(key) ~= "string" then
+    Log.warn("[AssetPoolRegistry.markFromPoolDirect] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
+    return asset
+  end
+  --#DEBUG END
+
   poolTag[asset] = key
   return asset
 end
@@ -155,14 +153,12 @@ end
 --
 --  @return originKey, isPooled (two values)
 --    (string, true)  — asset is owned by the named pool
---    (nil,    true)  — asset has a legacy pool tag (no key)
 --    (nil,    false) — asset is not tagged at all
 
 function Registry.getOriginKey(asset)
   local tag = poolTag[asset]
-  if tag == nil then return nil, false end
   if type(tag) == "string" then return tag, true end
-  return nil, true
+  return nil, false
 end
 
 -- ! Clear From Pool Direct

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -242,12 +242,12 @@ function Assets.recycleAsset(key, asset)
   -- Prevent double-recycle and foreign assets from entering the wrong pool.
   -- INTERNAL: single-lookup replaces isFromPool + getPoolKey + clearFromPool sequence
   local originKey, isPooled = roxy.AssetPoolRegistry.getOriginKey(asset)
-  if not isPooled then
+  if not isPooled or originKey == nil then
     Log.warn("[Assets.recycleAsset] Attempted to recycle a non-pooled asset to pool: " .. tostring(key)) --#DEBUG
     return false
   end
 
-  if originKey ~= nil and originKey ~= key then
+  if originKey ~= key then
     Log.warn("[Assets.recycleAsset] Attempted to recycle asset owned by pool '" .. tostring(originKey) .. "' into pool: " .. tostring(key)) --#DEBUG
     return false
   end

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -287,3 +287,64 @@ end
 -- Asset Pool Registry helper
 import "libraries/roxy/core/modules/AssetPoolRegistry"
 Registry = roxy.AssetPoolRegistry
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Assets provides reusable object pools with lazy growth and ownership checks.
+
+-- Register and Reuse a Pool
+Assets.registerPool("particles/smoke", 2, function()
+  return playdate.graphics.image.new("images/particle-smoke")
+end, {
+  maxSize = 6,
+  growthFactor = 2,
+})
+
+local smokeA = Assets.getAsset("particles/smoke")
+local smokeB = Assets.getAsset("particles/smoke")
+Assets.recycleAsset("particles/smoke", smokeA)
+Assets.recycleAsset("particles/smoke", smokeB)
+
+-- Growth and Exhaustion
+Assets.registerPool("enemies/basic", 1, function()
+  return playdate.graphics.image.new("images/enemy")
+end, {
+  maxSize = 2,
+  growthFactor = 1,
+})
+
+local enemyA = Assets.getAsset("enemies/basic")
+local enemyB = Assets.getAsset("enemies/basic") -- Pool grows to maxSize
+local enemyC = Assets.getAsset("enemies/basic") -- nil once pool is exhausted
+
+-- Scene Lifecycle
+function CombatScene:init()
+  if not Assets.getIsPoolRegistered("combat/hit-flash") then
+    Assets.registerPool("combat/hit-flash", 2, function()
+      return playdate.graphics.image.new("images/hit-flash")
+    end, {
+      maxSize = 4,
+      growthFactor = 1,
+    })
+  end
+
+  self.hitFlash = Assets.getAsset("combat/hit-flash")
+end
+
+function CombatScene:cleanup()
+  if self.hitFlash then
+    Assets.recycleAsset("combat/hit-flash", self.hitFlash)
+    self.hitFlash = nil
+  end
+end
+
+-- Ownership Safety
+local pooledSmoke = Assets.getAsset("particles/smoke")
+local recycledWrongPool = Assets.recycleAsset("enemies/basic", pooledSmoke) -- false
+local recycledRightPool = Assets.recycleAsset("particles/smoke", pooledSmoke)
+
+--]]

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -180,7 +180,7 @@ function Assets.getAsset(key)
     assets[i] = nil
 
     pool.availableCount -= 1
-    return roxy.AssetPoolRegistry.markFromPool(asset, key)
+    return roxy.AssetPoolRegistry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
   else
     -- Pool exhausted, attempt to grow if under max capacity
     if pool.totalSize < pool.maxSize then
@@ -204,7 +204,7 @@ function Assets.getAsset(key)
         assets[i] = nil
 
         pool.availableCount -= 1
-        return roxy.AssetPoolRegistry.markFromPool(asset, key)
+        return roxy.AssetPoolRegistry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
       else
         Log.warn("[Assets.getAsset] Pool '" .. tostring(key) .. "' is empty after attempting to grow.") --#DEBUG
         return nil
@@ -240,18 +240,19 @@ function Assets.recycleAsset(key, asset)
     return false
   end
   -- Prevent double-recycle and foreign assets from entering the wrong pool.
-  if not roxy.AssetPoolRegistry.isFromPool(asset) then
+  -- INTERNAL: single-lookup replaces isFromPool + getPoolKey + clearFromPool sequence
+  local originKey, isPooled = roxy.AssetPoolRegistry.getOriginKey(asset)
+  if not isPooled then
     Log.warn("[Assets.recycleAsset] Attempted to recycle a non-pooled asset to pool: " .. tostring(key)) --#DEBUG
     return false
   end
 
-  local originKey = roxy.AssetPoolRegistry.getPoolKey(asset)
   if originKey ~= key then
     Log.warn("[Assets.recycleAsset] Attempted to recycle asset owned by pool '" .. tostring(originKey) .. "' into pool: " .. tostring(key)) --#DEBUG
     return false
   end
 
-  roxy.AssetPoolRegistry.clearFromPool(asset)
+  roxy.AssetPoolRegistry.clearFromPoolDirect(asset)
 
   local assets = pool.assets
   assets[#assets + 1] = asset

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -22,6 +22,10 @@
 --  3. Use asset in game logic
 --  4. Return asset with Assets.recycleAsset(key, asset)
 --
+-- Pool Key Contract:
+--  - key must be a non-empty string
+--  - key cannot have leading/trailing whitespace
+--
 --------------------------------------------------------------------------------
 
 roxy = roxy or {}
@@ -35,6 +39,9 @@ local Assets <const> = roxy.Assets
 -- Math functions
 local min <const> = math.min
 
+-- String functions
+local stringFormat <const> = string.format
+
 --------------------------------------------------------------------------------
 -- Local State Variables
 --------------------------------------------------------------------------------
@@ -43,19 +50,39 @@ local min <const> = math.min
 local pools = {}
 
 --------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+local function formatPoolKeyValue(key)
+  return stringFormat("%q", tostring(key))
+end
+
+local function isValidPoolKey(key)
+  if type(key) ~= "string" then return false end
+  if not key:match("%S") then return false end
+  if key:match("^%s") or key:match("%s$") then return false end
+  return true
+end
+
+--------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
 
 -- ! Register Pool
 -- Registers a new asset pool with initial allocation and growth configuration
---  @param key            Unique identifier for this pool
+--  @param key            Non-empty string key (no leading/trailing whitespace)
 --  @param initialCount   Number of assets to pre-allocate (default 1)
 --  @param loaderFunction Function that creates and returns a new asset instance
 --  @param options        Optional table with maxSize and growthFactor fields
 --
---  @return Boolean true if registration succeeded, false if pool already exists or loader invalid
+--  @return Boolean true if registration succeeded, false on invalid key/duplicate/invalid loader
 
 function Assets.registerPool(key, initialCount, loaderFunction, options)
+  if not isValidPoolKey(key) then
+    Log.warn("[Assets.registerPool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return false
+  end
+
   if type(loaderFunction) ~= "function" then
     Log.warn("[Assets.registerPool] loaderFunction is not callable for key '" .. tostring(key) .. "'. Expected a function.") --#DEBUG
     return false
@@ -128,11 +155,16 @@ end
 
 -- ! Get Asset
 -- Retrieves an available asset from the pool, growing the pool if needed
---  @param key Unique identifier for the pool
+--  @param key Non-empty string key for the pool (no leading/trailing whitespace)
 --
---  @return Asset instance if available, nil if pool exhausted or unregistered
+--  @return Asset instance if available, nil if key invalid/pool exhausted/unregistered
 
 function Assets.getAsset(key)
+  if not isValidPoolKey(key) then
+    Log.warn("[Assets.getAsset] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return nil
+  end
+
   local pool = pools[key]
   if not pool then
     Log.warn("[Assets.getAsset] Attempted to get asset from unregistered pool: " .. tostring(key)) --#DEBUG
@@ -148,7 +180,7 @@ function Assets.getAsset(key)
     assets[i] = nil
 
     pool.availableCount -= 1
-    return roxy.AssetPoolRegistry.markFromPool(asset)
+    return roxy.AssetPoolRegistry.markFromPool(asset, key)
   else
     -- Pool exhausted, attempt to grow if under max capacity
     if pool.totalSize < pool.maxSize then
@@ -172,7 +204,7 @@ function Assets.getAsset(key)
         assets[i] = nil
 
         pool.availableCount -= 1
-        return roxy.AssetPoolRegistry.markFromPool(asset)
+        return roxy.AssetPoolRegistry.markFromPool(asset, key)
       else
         Log.warn("[Assets.getAsset] Pool '" .. tostring(key) .. "' is empty after attempting to grow.") --#DEBUG
         return nil
@@ -186,12 +218,17 @@ end
 
 -- ! Recycle Asset
 -- Returns an asset to the pool for reuse
---  @param key   Unique identifier for the pool
+--  @param key   Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param asset Asset instance to return to the pool
 --
---  @return Boolean true if recycled successfully, false if pool unregistered or asset nil
+--  @return Boolean true if recycled successfully, false on invalid key/reject conditions
 
 function Assets.recycleAsset(key, asset)
+  if not isValidPoolKey(key) then
+    Log.warn("[Assets.recycleAsset] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+    return false
+  end
+
   local pool = pools[key]
   if not pool then
     Log.warn("[Assets.recycleAsset] Attempted to recycle asset to unregistered pool: " .. tostring(key)) --#DEBUG
@@ -202,11 +239,18 @@ function Assets.recycleAsset(key, asset)
     Log.warn("[Assets.recycleAsset] Attempted to recycle a nil asset to pool: " .. tostring(key)) --#DEBUG
     return false
   end
-  -- Prevent double-recycle and foreign assets from entering the pool.
+  -- Prevent double-recycle and foreign assets from entering the wrong pool.
   if not roxy.AssetPoolRegistry.isFromPool(asset) then
     Log.warn("[Assets.recycleAsset] Attempted to recycle a non-pooled asset to pool: " .. tostring(key)) --#DEBUG
     return false
   end
+
+  local originKey = roxy.AssetPoolRegistry.getPoolKey(asset)
+  if originKey ~= key then
+    Log.warn("[Assets.recycleAsset] Attempted to recycle asset owned by pool '" .. tostring(originKey) .. "' into pool: " .. tostring(key)) --#DEBUG
+    return false
+  end
+
   roxy.AssetPoolRegistry.clearFromPool(asset)
 
   local assets = pool.assets
@@ -217,7 +261,7 @@ end
 
 -- ! Get Is Pool Registered
 -- Checks if a pool with the given key exists
---  @param key Unique identifier for the pool
+--  @param key Non-empty string key for the pool (no leading/trailing whitespace)
 --
 --  @return Boolean true if pool is registered, false otherwise
 

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -53,11 +53,11 @@ local pools = {}
 -- Helpers
 --------------------------------------------------------------------------------
 
-local function formatPoolKeyValue(key)
+local function _formatPoolKeyValue(key)
   return stringFormat("%q", tostring(key))
 end
 
-local function isValidPoolKey(key)
+local function _isValidPoolKey(key)
   if type(key) ~= "string" then return false end
   if not key:match("%S") then return false end
   if key:match("^%s") or key:match("%s$") then return false end
@@ -78,8 +78,8 @@ end
 --  @return Boolean true if registration succeeded, false on invalid key/duplicate/invalid loader
 
 function Assets.registerPool(key, initialCount, loaderFunction, options)
-  if not isValidPoolKey(key) then
-    Log.warn("[Assets.registerPool] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[Assets.registerPool] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return false
   end
 
@@ -160,8 +160,8 @@ end
 --  @return Asset instance if available, nil if key invalid/pool exhausted/unregistered
 
 function Assets.getAsset(key)
-  if not isValidPoolKey(key) then
-    Log.warn("[Assets.getAsset] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[Assets.getAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return nil
   end
 
@@ -224,8 +224,8 @@ end
 --  @return Boolean true if recycled successfully, false on invalid key/reject conditions
 
 function Assets.recycleAsset(key, asset)
-  if not isValidPoolKey(key) then
-    Log.warn("[Assets.recycleAsset] invalid pool key: " .. formatPoolKeyValue(key)) --#DEBUG
+  if not _isValidPoolKey(key) then
+    Log.warn("[Assets.recycleAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return false
   end
 

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -247,7 +247,7 @@ function Assets.recycleAsset(key, asset)
     return false
   end
 
-  if originKey ~= key then
+  if originKey ~= nil and originKey ~= key then
     Log.warn("[Assets.recycleAsset] Attempted to recycle asset owned by pool '" .. tostring(originKey) .. "' into pool: " .. tostring(key)) --#DEBUG
     return false
   end

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -25,6 +25,8 @@
 -- Pool Key Contract:
 --  - key must be a non-empty string
 --  - key cannot have leading/trailing whitespace
+--  - key-shape validation in getAsset/recycleAsset is debug-only in stripped
+--    release builds; production still fails soft via pool lookup/ownership checks
 --
 --------------------------------------------------------------------------------
 
@@ -48,6 +50,10 @@ local stringFormat <const> = string.format
 
 -- Asset pool registry (indexed by pool key)
 local pools = {}
+-- Static alias for hot paths. Tradeoff: does not see full table replacement of
+-- roxy.AssetPoolRegistry after module load, but does see method monkey-patching
+-- on the same table.
+local Registry
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -160,10 +166,12 @@ end
 --  @return Asset instance if available, nil if key invalid/pool exhausted/unregistered
 
 function Assets.getAsset(key)
+  --#DEBUG START
   if not _isValidPoolKey(key) then
     Log.warn("[Assets.getAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return nil
   end
+  --#DEBUG END
 
   local pool = pools[key]
   if not pool then
@@ -180,7 +188,7 @@ function Assets.getAsset(key)
     assets[i] = nil
 
     pool.availableCount -= 1
-    return roxy.AssetPoolRegistry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
+    return Registry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
   else
     -- Pool exhausted, attempt to grow if under max capacity
     if pool.totalSize < pool.maxSize then
@@ -204,7 +212,7 @@ function Assets.getAsset(key)
         assets[i] = nil
 
         pool.availableCount -= 1
-        return roxy.AssetPoolRegistry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
+        return Registry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
       else
         Log.warn("[Assets.getAsset] Pool '" .. tostring(key) .. "' is empty after attempting to grow.") --#DEBUG
         return nil
@@ -224,10 +232,12 @@ end
 --  @return Boolean true if recycled successfully, false on invalid key/reject conditions
 
 function Assets.recycleAsset(key, asset)
+  --#DEBUG START
   if not _isValidPoolKey(key) then
     Log.warn("[Assets.recycleAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
     return false
   end
+  --#DEBUG END
 
   local pool = pools[key]
   if not pool then
@@ -241,7 +251,7 @@ function Assets.recycleAsset(key, asset)
   end
   -- Prevent double-recycle and foreign assets from entering the wrong pool.
   -- INTERNAL: single-lookup replaces isFromPool + getPoolKey + clearFromPool sequence
-  local originKey, isPooled = roxy.AssetPoolRegistry.getOriginKey(asset)
+  local originKey, isPooled = Registry.getOriginKey(asset)
   if not isPooled or originKey == nil then
     Log.warn("[Assets.recycleAsset] Attempted to recycle a non-pooled asset to pool: " .. tostring(key)) --#DEBUG
     return false
@@ -252,7 +262,7 @@ function Assets.recycleAsset(key, asset)
     return false
   end
 
-  roxy.AssetPoolRegistry.clearFromPoolDirect(asset)
+  Registry.clearFromPoolDirect(asset)
 
   local assets = pool.assets
   assets[#assets + 1] = asset
@@ -276,3 +286,4 @@ end
 
 -- Asset Pool Registry helper
 import "libraries/roxy/core/modules/AssetPoolRegistry"
+Registry = roxy.AssetPoolRegistry

--- a/core/modules/TilemapPerf.lua
+++ b/core/modules/TilemapPerf.lua
@@ -1,0 +1,174 @@
+-- core/modules/TilemapPerf.lua
+
+roxy = roxy or {}
+roxy.TilemapPerf = roxy.TilemapPerf or {}
+local TilemapPerf <const> = roxy.TilemapPerf
+
+local pd <const> = playdate
+
+local formatString  <const> = string.format
+local tablePack     <const> = table.pack
+local tableInsert   <const> = table.insert
+local tableSort     <const> = table.sort
+local tableUnpack   <const> = table.unpack
+
+local clock             <const> = os and os.clock or nil
+local resetElapsedTime  <const> = pd and pd.resetElapsedTime or nil
+local getElapsedTime    <const> = pd and pd.getElapsedTime or nil
+
+local samples = {}
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Get Memory KB
+local function getMemoryKB()
+  if type(collectgarbage) ~= "function" then return nil end
+
+  local ok, value = pcall(collectgarbage, "count")
+  if ok and type(value) == "number" then
+    return value
+  end
+  return nil
+end
+
+-- ! Measure Seconds
+local function measureSeconds(fn)
+  if type(resetElapsedTime) == "function" and type(getElapsedTime) == "function" then
+    resetElapsedTime()
+    local results = tablePack(fn())
+    return getElapsedTime(), results
+  end
+
+  if type(clock) == "function" then
+    local started = clock()
+    local results = tablePack(fn())
+    return clock() - started, results
+  end
+
+  local results = tablePack(fn())
+  return 0, results
+end
+
+-- ! Format MS
+local function formatMS(seconds)
+  return formatString("%.3fms", (seconds or 0) * 1000)
+end
+
+-- ! Format Memory
+local function formatMemory(delta)
+  if type(delta) ~= "number" then return "N/A" end
+  return formatString("%.1fKB", delta)
+end
+
+-- ! Sorted Labels
+local function sortedLabels()
+  local labels = {}
+  for label, _ in pairs(samples) do
+    tableInsert(labels, label)
+  end
+  tableSort(labels)
+  return labels
+end
+
+--------------------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------------------
+
+-- ! Reset
+function TilemapPerf.reset()
+  samples = {}
+end
+
+-- ! Record
+function TilemapPerf.record(label, seconds, memoryDeltaKB)
+  if type(label) ~= "string" or label == "" then return nil end
+
+  seconds = tonumber(seconds) or 0
+  local sample = samples[label]
+  if not sample then
+    sample = {
+      count = 0,
+      total = 0,
+      min = seconds,
+      max = seconds,
+      last = seconds,
+      memoryDeltaKB = memoryDeltaKB,
+    }
+    samples[label] = sample
+  end
+
+  sample.count += 1
+  sample.total += seconds
+  sample.last = seconds
+  if seconds < sample.min then sample.min = seconds end
+  if seconds > sample.max then sample.max = seconds end
+  sample.memoryDeltaKB = memoryDeltaKB
+
+  return sample
+end
+
+-- ! Measure
+function TilemapPerf.measure(label, fn)
+  if type(fn) ~= "function" then return nil end
+
+  local memoryBefore = getMemoryKB()
+  local elapsed, results = measureSeconds(fn)
+  local memoryAfter = getMemoryKB()
+  local memoryDelta = nil
+  if memoryBefore and memoryAfter then
+    memoryDelta = memoryAfter - memoryBefore
+  end
+
+  TilemapPerf.record(label, elapsed, memoryDelta)
+  return tableUnpack(results, 1, results.n)
+end
+
+-- ! Snapshot
+function TilemapPerf.snapshot()
+  local snapshot = {}
+  for label, sample in pairs(samples) do
+    snapshot[label] = {
+      count = sample.count,
+      min = sample.min,
+      max = sample.max,
+      average = sample.count > 0 and (sample.total / sample.count) or 0,
+      last = sample.last,
+      memoryDeltaKB = sample.memoryDeltaKB,
+    }
+  end
+  return snapshot
+end
+
+-- ! Report Lines
+function TilemapPerf.reportLines()
+  local lines = {
+    "TilemapPerf",
+    "label | count | min | max | avg | last | memory",
+  }
+
+  local snapshot = TilemapPerf.snapshot()
+  for _, label in ipairs(sortedLabels()) do
+    local sample = snapshot[label]
+    tableInsert(lines, formatString(
+      "%s | %d | %s | %s | %s | %s | %s",
+      label,
+      sample.count,
+      formatMS(sample.min),
+      formatMS(sample.max),
+      formatMS(sample.average),
+      formatMS(sample.last),
+      formatMemory(sample.memoryDeltaKB)
+    ))
+  end
+
+  return lines
+end
+
+-- ! Print Report
+function TilemapPerf.printReport()
+  for _, line in ipairs(TilemapPerf.reportLines()) do
+    print(line)
+  end
+end

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -4,8 +4,8 @@ roxy = roxy or {}
 roxy.Transition = roxy.Transition or {}
 
 if roxy.Transition.STACK_OP_REPLACE == nil then roxy.Transition.STACK_OP_REPLACE = 0 end
-if roxy.Transition.STACK_OP_PUSH == nil then roxy.Transition.STACK_OP_PUSH = 1 end
-if roxy.Transition.STACK_OP_POP == nil then roxy.Transition.STACK_OP_POP = 2 end
+if roxy.Transition.STACK_OP_PUSH    == nil then roxy.Transition.STACK_OP_PUSH    = 1 end
+if roxy.Transition.STACK_OP_POP     == nil then roxy.Transition.STACK_OP_POP     = 2 end
 
 import "libraries/roxy/core/transitions/RoxyTransition"
 import "libraries/roxy/core/transitions/Cut"
@@ -38,7 +38,7 @@ local getDrawMode       <const> = Graphics.getImageDrawMode
 local setDrawMode       <const> = Graphics.setImageDrawMode
 local redrawBackground  <const> = Graphics.sprite.redrawBackground
 
-local EMPTY_TABLE   <const> = {}
+local EMPTY_TABLE <const> = {}
 
 local COLOR_WHITE     <const> = Graphics.kColorWhite
 local DRAW_MODE_COPY  <const> = Graphics.kDrawModeCopy
@@ -46,9 +46,9 @@ local DRAW_MODE_COPY  <const> = Graphics.kDrawModeCopy
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 
-local STACK_OP_REPLACE <const> = 0
-local STACK_OP_PUSH    <const> = 1
-local STACK_OP_POP     <const> = 2
+local STACK_OP_REPLACE  <const> = 0
+local STACK_OP_PUSH     <const> = 1
+local STACK_OP_POP      <const> = 2
 
 local TRANSITION_DEFAULT          <const> = "Cut"
 local TRANSITION_DURATION_DEFAULT <const> = 1.5
@@ -390,3 +390,65 @@ function Transition.executeTransitionDrawing()
     setDrawMode(prevMode)
   end
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Transition coordinates scene swaps, stack operations, and render hooks.
+
+-- Basic Scene Changes
+Transition.init()
+Transition.replaceScene(TitleScene) -- Uses the configured default transition or Cut
+Transition.replaceScene(GameplayScene, "FadeToColor", {
+  duration = 0.4,
+  holdTime = 0.1,
+  captureScreenshot = true,
+})
+
+-- Push / Pop Flow
+Transition.pushScene(PauseScene, "CrossDissolve", {
+  duration = 0.25,
+  dither = playdate.graphics.image.kDitherTypeBayer4x4,
+})
+Transition.popScene("CrossDissolve", { duration = 0.25 })
+
+-- Register a Custom Transition
+Transition.loadTransitions({
+  Spotlight = Spotlight,
+})
+Transition.replaceScene(BossScene, "Spotlight", {
+  duration = 0.6,
+})
+
+-- Refresh Config-Driven Defaults
+Config.applyOverrides({
+  transitions = {
+    defaultTransition = "FadeToColor",
+    duration = 0.5,
+    holdTime = 0.1,
+    overrides = {
+      ImageTable = {
+        duration = 0.8,
+        imageTable = playdate.graphics.imagetable.new("images/transitions/curtain"),
+        reverseExit = false,
+      },
+    },
+  },
+})
+Transition.reloadTransitionsWithNewConfig()
+
+-- Manual Render Loop Integration
+if Transition.isTransitioning then
+  Transition.prepareTransitionScreenshot()
+end
+
+playdate.graphics.sprite.update()
+
+if Transition.isTransitioning then
+  Transition.executeTransitionDrawing()
+end
+
+--]]

--- a/core/modules/Transition.lua
+++ b/core/modules/Transition.lua
@@ -85,6 +85,28 @@ local function _resetBusyWarnState()
   activeTransitionKey = nil
 end
 
+local function _asNonEmptyLabel(value)
+  if type(value) ~= "string" or value == "" then
+    return nil
+  end
+  return value
+end
+
+local function _resolveBusyTransitionLabel(completedName)
+  local label = _asNonEmptyLabel(completedName)
+  if label then return label end
+
+  label = _asNonEmptyLabel(activeTransitionKey)
+  if label then return label end
+
+  local currentTransition = Transition.currentTransition
+  if type(currentTransition) ~= "table" then
+    return nil
+  end
+
+  return _asNonEmptyLabel(currentTransition.name)
+end
+
 -- ! Helper: Foce Scene Tilemaps Redraw
 -- Nudge all tilemaps in a scene to repaint for a few frames
 local function _forceSceneTilemapsRedraw(scene, frames)
@@ -104,12 +126,19 @@ end
 
 function Transition._flushBusyTransitionSummary(completedName)
   local suppressedCount = busySuppressedCount
-  local transitionName = completedName or activeTransitionKey or "unknown"
+  local transitionName = _resolveBusyTransitionLabel(completedName)
   _resetBusyWarnState()
 
   --#DEBUG START
   if suppressedCount > 0 then
-    Log.warn("[Transition.transitionToScene] Suppressed " .. suppressedCount .. " additional transition request(s) while '" .. tostring(transitionName) .. "' was in progress.")
+    if transitionName then
+      Log.warn("[Transition.transitionToScene] Suppressed %d additional transition request(s) while '%s' was in progress.",
+               suppressedCount,
+               transitionName)
+    else
+      Log.warn("[Transition.transitionToScene] Suppressed %d additional transition request(s) while a transition was in progress.",
+               suppressedCount)
+    end
   end
   --#DEBUG END
 end
@@ -231,8 +260,13 @@ function Transition.transitionToScene(newSceneClass, transitionName, opts)
   if Transition.isTransitioning then
     if not busyWarnedOnce then
       --#DEBUG START
-      local transitionNameInProgress = activeTransitionKey or "unknown"
-      Log.warn("[Transition.transitionToScene] Transition '" .. tostring(transitionNameInProgress) .. "' already in progress; suppressing repeated warnings until completion.")
+      local transitionNameInProgress = _resolveBusyTransitionLabel(nil)
+      if transitionNameInProgress then
+        Log.warn("[Transition.transitionToScene] Transition '%s' already in progress; suppressing repeated warnings until completion.",
+                 transitionNameInProgress)
+      else
+        Log.warn("[Transition.transitionToScene] A transition is already in progress; suppressing repeated warnings until completion.")
+      end
       --#DEBUG END
       busyWarnedOnce = true
     else

--- a/core/transitions/CrossDissolve.lua
+++ b/core/transitions/CrossDissolve.lua
@@ -20,7 +20,6 @@ local getTransitionConfig <const> = Config.getTransitionConfig
 local getAsset      <const> = Assets.getAsset
 local recycleAsset  <const> = Assets.recycleAsset
 local ensurePool    <const> = Registry.ensurePool
-local markFromPool  <const> = Registry.markFromPool
 local isFromPool    <const> = Registry.isFromPool
 
 -- Math
@@ -216,8 +215,8 @@ end
 function CrossDissolve:_acquireSequence()
   if self.sequence then return end
 
-  -- Pull from pool (tagged), or nil if empty
-  local sequence = markFromPool(getAsset(SEQUENCE_POOL_KEY))
+  -- Pull from pool, or nil if empty
+  local sequence = getAsset(SEQUENCE_POOL_KEY)
   if not sequence then
     sequence = RoxySequence() -- Fallback
   end

--- a/core/transitions/FadeToColor.lua
+++ b/core/transitions/FadeToColor.lua
@@ -19,7 +19,6 @@ local getTransitionConfig <const> = Config.getTransitionConfig
 local getAsset      <const> = Assets.getAsset
 local recycleAsset  <const> = Assets.recycleAsset
 local ensurePool    <const> = Registry.ensurePool
-local markFromPool  <const> = Registry.markFromPool
 local isFromPool    <const> = Registry.isFromPool
 
 -- Math
@@ -204,8 +203,8 @@ end
 function FadeToColor:_acquireSequence()
   if self.sequence then return end
 
-  -- Pull from pool (tagged), or nil if empty
-  local sequence = markFromPool(getAsset(SEQUENCE_POOL_KEY))
+  -- Pull from pool, or nil if empty
+  local sequence = getAsset(SEQUENCE_POOL_KEY)
   if not sequence then
     sequence = RoxySequence() -- Fallback
   end

--- a/core/transitions/ImageTable.lua
+++ b/core/transitions/ImageTable.lua
@@ -18,8 +18,7 @@ local getTransitionConfig <const> = Config.getTransitionConfig
 local getAsset      <const> = Assets.getAsset
 local recycleAsset  <const> = Assets.recycleAsset
 local ensurePool    <const> = Registry.ensurePool
-local isFromPool    <const> = Registry.isFromPool
-local getPoolKey    <const> = Registry.getPoolKey
+local getOriginKey  <const> = Registry.getOriginKey
 
 -- Graphics
 local newImageTable <const> = Graphics.imagetable.new
@@ -106,10 +105,14 @@ local function initializeAssetPool(userImageTableEnter, userImageTableExit)
 end
 
 -- ! Recycle To Origin Pool
--- Recycles a pooled asset back to its owner key, with a fallback for legacy tags.
-local function recycleToOriginPool(asset, fallbackKey)
-  if not asset or not isFromPool(asset) then return end
-  recycleAsset(getPoolKey(asset) or fallbackKey, asset)
+-- Recycles a pooled asset back to its explicit owner key.
+local function recycleToOriginPool(asset)
+  if not asset then return end
+
+  local originKey, isPooled = getOriginKey(asset)
+  if not isPooled or originKey == nil then return end
+
+  recycleAsset(originKey, asset)
 end
 
 --------------------------------------------------------------------------------
@@ -267,7 +270,7 @@ function ImageTable:_releaseImageTableEnter()
   local imageTableEnter = self.imageTableEnter
   if not imageTableEnter then return end
 
-  recycleToOriginPool(imageTableEnter, IMAGETABLE_ENTER_POOL_KEY)
+  recycleToOriginPool(imageTableEnter)
 
   self.imageTableEnter = nil
 end
@@ -299,7 +302,7 @@ function ImageTable:_releaseImageTableExit()
   local imageTableExit = self.imageTableExit
   if not imageTableExit then return end
 
-  recycleToOriginPool(imageTableExit, IMAGETABLE_EXIT_POOL_KEY)
+  recycleToOriginPool(imageTableExit)
 
   self.imageTableExit = nil
 end
@@ -326,7 +329,7 @@ function ImageTable:_releaseSequence()
 
   sequence:clear(true)
 
-  recycleToOriginPool(sequence, SEQUENCE_POOL_KEY)
+  recycleToOriginPool(sequence)
 
   self.sequence = nil
 end

--- a/core/transitions/ImageTable.lua
+++ b/core/transitions/ImageTable.lua
@@ -19,6 +19,7 @@ local getAsset      <const> = Assets.getAsset
 local recycleAsset  <const> = Assets.recycleAsset
 local ensurePool    <const> = Registry.ensurePool
 local isFromPool    <const> = Registry.isFromPool
+local getPoolKey    <const> = Registry.getPoolKey
 
 -- Graphics
 local newImageTable <const> = Graphics.imagetable.new
@@ -102,6 +103,13 @@ local function initializeAssetPool(userImageTableEnter, userImageTableExit)
       maxSize = 4,
       growthFactor = 1
     })
+end
+
+-- ! Recycle To Origin Pool
+-- Recycles a pooled asset back to its owner key, with a fallback for legacy tags.
+local function recycleToOriginPool(asset, fallbackKey)
+  if not asset or not isFromPool(asset) then return end
+  recycleAsset(getPoolKey(asset) or fallbackKey, asset)
 end
 
 --------------------------------------------------------------------------------
@@ -259,10 +267,7 @@ function ImageTable:_releaseImageTableEnter()
   local imageTableEnter = self.imageTableEnter
   if not imageTableEnter then return end
 
-  -- Only recycle if it came from the pool
-  if isFromPool(imageTableEnter) then
-    recycleAsset(IMAGETABLE_ENTER_POOL_KEY, imageTableEnter)
-  end
+  recycleToOriginPool(imageTableEnter, IMAGETABLE_ENTER_POOL_KEY)
 
   self.imageTableEnter = nil
 end
@@ -294,10 +299,7 @@ function ImageTable:_releaseImageTableExit()
   local imageTableExit = self.imageTableExit
   if not imageTableExit then return end
 
-  -- Only recycle if it came from the pool
-  if isFromPool(imageTableExit) then
-    recycleAsset(IMAGETABLE_EXIT_POOL_KEY, imageTableExit)
-  end
+  recycleToOriginPool(imageTableExit, IMAGETABLE_EXIT_POOL_KEY)
 
   self.imageTableExit = nil
 end
@@ -324,10 +326,7 @@ function ImageTable:_releaseSequence()
 
   sequence:clear(true)
 
-  -- Only recycle if it came from the pool
-  if isFromPool(sequence) then
-    recycleAsset(SEQUENCE_POOL_KEY, sequence)
-  end
+  recycleToOriginPool(sequence, SEQUENCE_POOL_KEY)
 
   self.sequence = nil
 end

--- a/core/transitions/ImageTable.lua
+++ b/core/transitions/ImageTable.lua
@@ -18,7 +18,6 @@ local getTransitionConfig <const> = Config.getTransitionConfig
 local getAsset      <const> = Assets.getAsset
 local recycleAsset  <const> = Assets.recycleAsset
 local ensurePool    <const> = Registry.ensurePool
-local markFromPool  <const> = Registry.markFromPool
 local isFromPool    <const> = Registry.isFromPool
 
 -- Graphics
@@ -242,8 +241,8 @@ function ImageTable:_acquireImageTableEnter(userImageTableEnter)
   if userImageTableEnter then
     imageTableEnter = userImageTableEnter -- One-off or caller-managed
   else
-    -- Pull from pool (tagged), or nil if empty
-    imageTableEnter = markFromPool(getAsset(IMAGETABLE_ENTER_POOL_KEY))
+    -- Pull from pool, or nil if empty
+    imageTableEnter = getAsset(IMAGETABLE_ENTER_POOL_KEY)
   end
 
   if not imageTableEnter then
@@ -277,8 +276,8 @@ function ImageTable:_acquireImageTableExit(userImageTableExit)
   if userImageTableExit then
     imageTableExit = userImageTableExit -- One-off or caller-managed
   else
-    -- Pull from pool (tagged), or nil if empty
-    imageTableExit = markFromPool(getAsset(IMAGETABLE_EXIT_POOL_KEY))
+    -- Pull from pool, or nil if empty
+    imageTableExit = getAsset(IMAGETABLE_EXIT_POOL_KEY)
   end
 
   if not imageTableExit then
@@ -308,8 +307,8 @@ end
 function ImageTable:_acquireSequence()
   if self.sequence then return end
 
-  -- Pull from pool (tagged), or nil if empty
-  local sequence = markFromPool(getAsset(SEQUENCE_POOL_KEY))
+  -- Pull from pool, or nil if empty
+  local sequence = getAsset(SEQUENCE_POOL_KEY)
   if not sequence then
     sequence = RoxySequence() -- Fallback
   end

--- a/roxy.lua
+++ b/roxy.lua
@@ -20,6 +20,7 @@ import "CoreLibs/ui/gridview"
 -- Logging and debugging
 import "libraries/roxy/core/modules/Log"
 import "libraries/roxy/core/modules/Debug" --#DEBUG
+import "libraries/roxy/core/modules/TilemapPerf" --#DEBUG
 
 -- Utilities
 import "libraries/roxy/utilities/Table"


### PR DESCRIPTION
### Overview
This release hardens asset pool ownership rules, fixes transition recycling paths, and adds debug-only tilemap performance probes for Phase 0 baseline work.

### Key Changes
- Enforced string-only asset pool keys across asset registration, checkout, and recycle paths
- Rejected cross-pool recycling so assets can only return to their recorded origin pool
- Updated transition imagetable and sequence cleanup to recycle pooled assets to their origin pool
- Trimmed repeated asset key checks from release hot paths while keeping ownership guards intact
- Added usage examples for asset pools and scene transitions
- Added debug-only `TilemapPerf` probes for timing, memory deltas, and smoke-run reports

### Breaking Changes
- Asset pool keys are now string-only for `Assets.registerPool`, `Assets.getAsset`, `Assets.recycleAsset`, `AssetPoolRegistry.register`, and `AssetPoolRegistry.ensurePool`
- `AssetPoolRegistry.markFromPool(asset)` without a valid string key no longer tags pooled state and now warns
- `AssetPoolRegistry.isFromPool(asset)` is keyed-only and returns true only for explicit string pool ownership
- `Assets.recycleAsset` now requires matching origin-key ownership and no longer supports legacy or fallback recycle paths

### Challenges/Notes
- Replace numeric, table, or function pool keys with stable strings such as `"tilemap/main"`
- Ensure `view.poolKey` and `RoxyAnimation.fromPool(poolKey)` inputs are strings
- `TilemapPerf` is debug-only and should be stripped from release builds