### PR TITLE
[0.16.0] - Add Load-Only Tilemaps and Faster Native Sync

### DIFF
--- a/core/modules/TilemapPerf.lua
+++ b/core/modules/TilemapPerf.lua
@@ -16,7 +16,8 @@ local clock             <const> = os and os.clock or nil
 local resetElapsedTime  <const> = pd and pd.resetElapsedTime or nil
 local getElapsedTime    <const> = pd and pd.getElapsedTime or nil
 
-local samples = {}
+local samples   = {}
+local counters  = {}
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -72,6 +73,16 @@ local function sortedLabels()
   return labels
 end
 
+-- ! Sorted Counter Labels
+local function sortedCounterLabels()
+  local labels = {}
+  for label, _ in pairs(counters) do
+    tableInsert(labels, label)
+  end
+  tableSort(labels)
+  return labels
+end
+
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
@@ -79,6 +90,7 @@ end
 -- ! Reset
 function TilemapPerf.reset()
   samples = {}
+  counters = {}
 end
 
 -- ! Record
@@ -107,6 +119,14 @@ function TilemapPerf.record(label, seconds, memoryDeltaKB)
   sample.memoryDeltaKB = memoryDeltaKB
 
   return sample
+end
+
+-- ! Count
+function TilemapPerf.count(label, amount)
+  if type(label) ~= "string" or label == "" then return nil end
+  amount = tonumber(amount) or 1
+  counters[label] = (counters[label] or 0) + amount
+  return counters[label]
 end
 
 -- ! Measure
@@ -141,6 +161,15 @@ function TilemapPerf.snapshot()
   return snapshot
 end
 
+-- ! Counter Snapshot
+function TilemapPerf.counterSnapshot()
+  local snapshot = {}
+  for label, value in pairs(counters) do
+    snapshot[label] = value
+  end
+  return snapshot
+end
+
 -- ! Report Lines
 function TilemapPerf.reportLines()
   local lines = {
@@ -161,6 +190,15 @@ function TilemapPerf.reportLines()
       formatMS(sample.last),
       formatMemory(sample.memoryDeltaKB)
     ))
+  end
+
+  local counterLabels = sortedCounterLabels()
+  if #counterLabels > 0 then
+    tableInsert(lines, "TilemapPerfCounters")
+    tableInsert(lines, "label | count")
+    for _, label in ipairs(counterLabels) do
+      tableInsert(lines, formatString("%s | %d", label, counters[label]))
+    end
   end
 
   return lines

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -27,13 +27,23 @@ local pauseHandler  <const> = Input.pause
 local resumeHandler <const> = Input.resume
 local removeHandler <const> = Input.removeHandler
 
-local resetCamera <const> = Camera.reset
+local resetCamera           <const> = Camera.reset
+local setCameraBounds       <const> = Camera.setBounds
+local clearCameraBounds     <const> = Camera.clearBounds
+local setCameraPosition     <const> = Camera.setPosition
+local setCameraTarget       <const> = Camera.setTarget
+local setCameraSmoothing    <const> = Camera.setSmoothing
+local setCameraPanVelocity  <const> = Camera.setPanVelocity
+local setCameraDeadZone     <const> = Camera.setDeadZone
+local setCameraFriction     <const> = Camera.setFriction
+local setCameraBias         <const> = Camera.setBias
+local setCameraMode         <const> = Camera.setMode
 
 local COLOR_WHITE <const> = Graphics.kColorWhite
 local COLOR_BLACK <const> = Graphics.kColorBlack
 local CLEAR_COLOR <const> = COLOR_WHITE
 
-local UNFLIPPED     <const> = Graphics.kImageUnflipped
+local UNFLIPPED <const> = Graphics.kImageUnflipped
 
 local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
@@ -68,6 +78,23 @@ local function _hasItem(array, item)
     if array[i] == item then return true end
   end
   return false
+end
+
+-- ! Helper: Is Bounds Table
+-- Returns true for camera bounds tables accepted by Camera.setBounds.
+local function _isBoundsTable(bounds)
+  return type(bounds) == "table"
+     and type(bounds.x1) == "number"
+     and type(bounds.y1) == "number"
+     and type(bounds.x2) == "number"
+     and type(bounds.y2) == "number"
+end
+
+-- ! Helper: Read XY Pair
+-- Reads either { x, y } or array-style { x, y } option pairs.
+local function _readXYPair(value)
+  if type(value) ~= "table" then return nil, nil end
+  return value.x or value[1], value.y or value[2]
 end
 
 -- ! Helper: Get Color Callback
@@ -107,6 +134,7 @@ end
 
 class("RoxyScene").extends(Object)
 
+-- ! Initialize
 function RoxyScene:init(background)
   self.name = self.className or "RoxyScene"
   Log.debug("[RoxyScene:init] Initializing Scene: " .. self.name) --#DEBUG
@@ -153,6 +181,14 @@ function RoxyScene:enter()
   end
   self._spriteAutoAddQueue = {}
 
+  -- Activate tilemap resources that cannot be created detached from display.
+  for i = 1, #self.tilemaps do
+    local tilemap = self.tilemaps[i]
+    if tilemap and tilemap.sceneDidEnter then
+      tilemap:sceneDidEnter(self)
+    end
+  end
+
   -- Flush any queued sequence auto-starts
   local sequenceQueue = self._sequenceAutoStartQueue
   for i = 1, #sequenceQueue do
@@ -168,6 +204,72 @@ function RoxyScene:start()
   self._didStart = true
 
   self:addHandler()
+end
+
+-- ! Activate Camera
+-- Opt-in scene camera setup. Scenes that do not use Camera pay no enter cost.
+function RoxyScene:activateCamera(opts)
+  opts = opts or {}
+
+  --#DEBUG START
+  if opts.cameraBounds ~= nil then
+    error("[RoxyScene:activateCamera] Use tilemap = map for tilemap bounds or bounds = { x1, y1, x2, y2 } for raw bounds", 2)
+  end
+  if opts.map ~= nil then
+    error("[RoxyScene:activateCamera] Use tilemap = map for tilemap bounds", 2)
+  end
+  --#DEBUG END
+
+  if opts.reset ~= false then
+    resetCamera()
+  end
+
+  if opts.mode then setCameraMode(opts.mode) end
+  if opts.friction ~= nil then setCameraFriction(opts.friction) end
+  if opts.smoothing ~= nil then setCameraSmoothing(opts.smoothing) end
+
+  local deadZoneX, deadZoneY = _readXYPair(opts.deadZone)
+  if deadZoneX and deadZoneY then setCameraDeadZone(deadZoneX, deadZoneY) end
+
+  local biasX, biasY = _readXYPair(opts.bias)
+  if biasX and biasY then setCameraBias(biasX, biasY) end
+
+  local rawBounds = opts.bounds
+  if opts.clearBounds or rawBounds == false then
+    clearCameraBounds()
+  elseif rawBounds ~= nil then
+    if _isBoundsTable(rawBounds) then
+      setCameraBounds(rawBounds)
+    else --#DEBUG
+      error("[RoxyScene:activateCamera] Expected bounds = { x1, y1, x2, y2 }; use tilemap = map for tilemap bounds", 2) --#DEBUG
+    end
+  elseif opts.tilemap ~= nil then
+    local tilemap = opts.tilemap
+    local didApply = false
+    if type(tilemap) == "table" and type(tilemap.applyCameraBounds) == "function" then
+      didApply = tilemap:applyCameraBounds() == true
+    end
+    if not didApply and type(tilemap) == "table" and type(tilemap.getCameraBounds) == "function" then
+      local bounds = tilemap:getCameraBounds()
+      if bounds then setCameraBounds(bounds) end
+    end
+  end
+
+  local positionX, positionY = _readXYPair(opts.position)
+  if positionX and positionY then
+    setCameraPosition(positionX, positionY)
+  elseif opts.x ~= nil and opts.y ~= nil then
+    setCameraPosition(opts.x, opts.y)
+  end
+
+  if opts.target ~= nil then
+    setCameraTarget(opts.target ~= false and opts.target or nil, opts.targetSmoothing or opts.smoothing)
+  elseif opts.panVelocity then
+    local velocityX, velocityY = _readXYPair(opts.panVelocity)
+    setCameraPanVelocity(velocityX, velocityY)
+  end
+
+  return true
 end
 
 -- ! Update
@@ -257,7 +359,6 @@ function RoxyScene:cleanup()
 
   self._spriteAutoAddQueue = {}
   self._sequenceAutoStartQueue = {}
-  self._tilemapActivateQueue = {}
 
   self.backgroundColor = nil
   self.backgroundImage = nil
@@ -444,39 +545,58 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Add Tilemap
+-- Attaches a load-only tilemap to this scene.
 function RoxyScene:addTilemap(tilemap)
-  if not tilemap then return end
+  if not tilemap then return false end
 
   for i = 1, #self.tilemaps do
-    if self.tilemaps[i] == tilemap then return end
+    if self.tilemaps[i] == tilemap then return true end
+  end
+
+  if type(tilemap.attachToScene) ~= "function" then
+    Log.warn("[RoxyScene:addTilemap] Expected tilemap with attachToScene") --#DEBUG
+    return false
+  end
+
+  if not tilemap:attachToScene(self) then
+    return false
   end
 
   tableInsert(self.tilemaps, tilemap)
-
-  -- Give the tilemap a back-pointer so it can self-remove later
-  tilemap.scene = self
-
-  -- Set the layer manager's scene so callers don't have to
-  local layerManager = tilemap.layerManager
-  if layerManager then
-    layerManager:setScene(self)
-  end
+  return true
 end
 
 -- ! Remove Tilemap
+-- Destroys a tilemap and unregisters it from this scene.
 function RoxyScene:removeTilemap(tilemap)
-  if not tilemap then return end
-  if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return end
+  if not tilemap then return false end
+  if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
 
-  if tilemap.destroy then
-    tilemap:destroy()
-  else
-    self:_unregisterTilemap(tilemap)
+  if type(tilemap.destroy) ~= "function" then
+    Log.warn("[RoxyScene:removeTilemap] Expected tilemap with destroy") --#DEBUG
+    return false
   end
+
+  tilemap:destroy()
+  return true
+end
+
+-- ! Detach Tilemap
+-- Detaches scene/display state while preserving pooled tilemap resources.
+function RoxyScene:detachTilemap(tilemap)
+  if not tilemap then return false end
+  if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
+
+  if type(tilemap.detachFromScene) ~= "function" then
+    Log.warn("[RoxyScene:detachTilemap] Expected tilemap with detachFromScene") --#DEBUG
+    return false
+  end
+
+  return tilemap:detachFromScene()
 end
 
 -- ! Unregister Tilemap
--- Private cleanup path; never calls tilemap:destroy().
+-- Removes a tilemap from scene ownership without destroying it.
 function RoxyScene:_unregisterTilemap(tilemap)
   if not tilemap then return end
 
@@ -499,17 +619,18 @@ function RoxyScene:removeAllTilemaps()
 
   for i = #tilemaps, 1, -1 do
     local tilemap = tilemaps[i]
-    if tilemap.destroy then
+    if type(tilemap.destroy) == "function" then
       tilemap:destroy()
-    else
-      self:_unregisterTilemap(tilemap)
     end
   end
 end
 
 -- ! Spawn Tilemap
+-- Convenience helper that creates and attaches an orthogonal tilemap.
 function RoxyScene:spawnTilemap(path, tilemapOpts)
-  return RoxyOrthoTilemap(path, tilemapOpts, self)
+  local tilemap = RoxyOrthoTilemap(path, tilemapOpts)
+  self:addTilemap(tilemap)
+  return tilemap
 end
 
 --------------------------------------------------------------------------------
@@ -619,9 +740,15 @@ function GameplayScene:start()
 
   self.player = RoxySprite({ name = "player" }, self)
   self.map = self:spawnTilemap("assets/maps/level-01.json", {
+    cameraBounds = true,
     layerOptions = {
       Walls = { collidable = true },
     },
+  })
+  self:activateCamera({
+    tilemap = self.map,
+    target = self.player,
+    smoothing = 0.2,
   })
 
   self.fadeIn = RoxySequence(self):from(0):to(1, 0.25):play()
@@ -650,6 +777,8 @@ local player = RoxySprite({ name = "player" }, scene)
 local map = scene:spawnTilemap("assets/maps/level-01.json")
 
 scene:removeSprite(player)
+scene:detachTilemap(map)
+scene:addTilemap(map)
 scene:removeTilemap(map)
 scene:cleanup()
 

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -29,9 +29,9 @@ local removeHandler <const> = Input.removeHandler
 
 local resetCamera <const> = Camera.reset
 
-local COLOR_WHITE   <const> = Graphics.kColorWhite
-local COLOR_BLACK   <const> = Graphics.kColorBlack
-local CLEAR_COLOR   <const> = COLOR_WHITE
+local COLOR_WHITE <const> = Graphics.kColorWhite
+local COLOR_BLACK <const> = Graphics.kColorBlack
+local CLEAR_COLOR <const> = COLOR_WHITE
 
 local UNFLIPPED     <const> = Graphics.kImageUnflipped
 
@@ -43,6 +43,32 @@ local _imageCallbacks = setmetatable({}, { __mode = "k" }) -- Cache: image --> f
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
+
+-- ! Helper: Remove Item From Array
+-- Removes every matching item and returns whether the array changed.
+local function _removeItem(array, item)
+  if not array or not item then return false end
+
+  local removed = false
+  for i = #array, 1, -1 do
+    if array[i] == item then
+      tableRemove(array, i)
+      removed = true
+    end
+  end
+  return removed
+end
+
+-- ! Helper: Has Item In Array
+-- Returns true when the array contains the given item.
+local function _hasItem(array, item)
+  if not array or not item then return false end
+
+  for i = 1, #array do
+    if array[i] == item then return true end
+  end
+  return false
+end
 
 -- ! Helper: Get Color Callback
 -- Builds (and returns) a drawing callback for a solid color.
@@ -297,6 +323,7 @@ end
 -- ! Add Sprite
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
+  if sprite.scene == self then return end
 
   -- Avoid duplicates
   for i = 1, #self.sprites do
@@ -319,14 +346,76 @@ end
 
 -- ! Remove Sprite
 function RoxyScene:removeSprite(sprite)
+  self:_unregisterSprite(sprite, true)
+end
+
+-- ! Unregister Sprite
+-- Private cleanup path used by tilemaps and direct scene sprite removal.
+function RoxyScene:_unregisterSprite(sprite, removeFromDisplay)
   if not sprite then return end
 
-  for i = #self.sprites, 1, -1 do
-    if self.sprites[i] == sprite then
+  -- Remove from active scene list and pre-enter auto-add queue
+  local wasManaged = _removeItem(self.sprites, sprite)
+  wasManaged = _removeItem(self._spriteAutoAddQueue, sprite) or wasManaged
+  wasManaged = (sprite.scene == self) or wasManaged
+
+  if sprite.scene == self then
+    sprite.scene = nil -- Clear back-pointer
+  end
+
+  if removeFromDisplay ~= false and wasManaged then
+    sprite:remove()
+  end
+end
+
+-- ! Unregister Sprites
+-- Private batch cleanup path used by tilemap teardown.
+-- Removes many scene-managed sprites without rescanning scene lists per sprite.
+function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
+  if not sprites then return end
+
+  -- Build a lookup set so scene lists only need one pass each
+  local targets = nil
+  for i = 1, #sprites do
+    local sprite = sprites[i]
+    if sprite then
+      targets = targets or {}
+      targets[sprite] = true
+    end
+  end
+  if not targets then return end
+
+  local managed = {}
+
+  -- Remove from active scene list
+  local sceneSprites = self.sprites
+  for i = #sceneSprites, 1, -1 do
+    local sprite = sceneSprites[i]
+    if targets[sprite] then
+      tableRemove(sceneSprites, i)
+      managed[sprite] = true
+    end
+  end
+
+  -- Remove from pre-enter auto-add queue
+  local spriteQueue = self._spriteAutoAddQueue
+  for i = #spriteQueue, 1, -1 do
+    local sprite = spriteQueue[i]
+    if targets[sprite] then
+      tableRemove(spriteQueue, i)
+      managed[sprite] = true
+    end
+  end
+
+  local shouldRemove = removeFromDisplay ~= false
+  for sprite, _ in pairs(targets) do
+    if sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
+      managed[sprite] = true
+    end
+
+    if shouldRemove and managed[sprite] then
       sprite:remove()
-      tableRemove(self.sprites, i)
-      return
     end
   end
 end
@@ -336,10 +425,13 @@ function RoxyScene:removeAllSprites()
   local sprites = self.sprites
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
-    sprite.scene = nil -- Clear back-pointer
+    if sprite.scene == self then
+      sprite.scene = nil -- Clear back-pointer
+    end
     sprite:remove()
   end
   self.sprites = {}
+  self._spriteAutoAddQueue = {}
 end
 
 -- ! Spawn Sprite
@@ -374,41 +466,45 @@ end
 -- ! Remove Tilemap
 function RoxyScene:removeTilemap(tilemap)
   if not tilemap then return end
-  for i = #self.tilemaps, 1, -1 do
-    if self.tilemaps[i] == tilemap then
-      -- Detach layer sprites first (defensive; layerManager:destroy usually does this)
-      local layerManager = tilemap.layerManager
-      if layerManager and layerManager.detachSprites then layerManager:detachSprites() end
+  if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return end
 
-      -- Clear wiring
-      if layerManager and layerManager.setScene then
-        layerManager:setScene(nil)
-      end
-      tilemap.scene = nil -- Clear back-pointer
+  if tilemap.destroy then
+    tilemap:destroy()
+  else
+    self:_unregisterTilemap(tilemap)
+  end
+end
 
-      -- Destroy the tilemap object
-      if tilemap.destroy then tilemap:destroy() end
+-- ! Unregister Tilemap
+-- Private cleanup path; never calls tilemap:destroy().
+function RoxyScene:_unregisterTilemap(tilemap)
+  if not tilemap then return end
 
-      -- Remove from the scene list
-      tableRemove(self.tilemaps, i)
+  _removeItem(self.tilemaps, tilemap)
 
-      return
-    end
+  if tilemap.scene == self then
+    tilemap.scene = nil
+  end
+
+  local layerManager = tilemap.layerManager
+  if layerManager and layerManager.scene == self and layerManager.setScene then
+    layerManager:setScene(nil)
   end
 end
 
 -- ! Remove All Tilemaps
 function RoxyScene:removeAllTilemaps()
   local tilemaps = self.tilemaps
+  self.tilemaps = {}
+
   for i = #tilemaps, 1, -1 do
     local tilemap = tilemaps[i]
-    local layerManager = tilemap.layerManager
-    if layerManager and layerManager.detachSprites then layerManager:detachSprites() end
-    tilemap.scene = nil -- Clear back-pointer
-    if layerManager and layerManager.setScene then layerManager:setScene(nil) end
-    if tilemap.destroy then tilemap:destroy() end
+    if tilemap.destroy then
+      tilemap:destroy()
+    else
+      self:_unregisterTilemap(tilemap)
+    end
   end
-  self.tilemaps = {}
 end
 
 -- ! Spawn Tilemap
@@ -423,6 +519,7 @@ end
 -- ! Add Sequence
 function RoxyScene:addSequence(sequence)
   if not sequence then return end
+  if sequence.scene == self then return end
 
   for i = 1, #self.sequences do
     if self.sequences[i] == sequence then return end
@@ -492,3 +589,68 @@ end
 function RoxyScene:clearScreen()
   clearScreen(CLEAR_COLOR)
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local Graphics <const> = playdate.graphics
+
+local COLOR_WHITE <const> = Graphics.kColorWhite
+local COLOR_BLACK <const> = Graphics.kColorBlack
+
+-- Basic Scene Subclass
+class("GameplayScene").extends(RoxyScene)
+
+function GameplayScene:init()
+  GameplayScene.super.init(self, COLOR_WHITE)
+
+  self.inputHandler = {
+    BButtonDown = function()
+      roxy.Scene.popScene()
+    end,
+  }
+end
+
+function GameplayScene:start()
+  GameplayScene.super.start(self)
+
+  self.player = RoxySprite({ name = "player" }, self)
+  self.map = self:spawnTilemap("assets/maps/level-01.json", {
+    layerOptions = {
+      Walls = { collidable = true },
+    },
+  })
+
+  self.fadeIn = RoxySequence(self):from(0):to(1, 0.25):play()
+end
+
+function GameplayScene:update(dt)
+  -- Game logic here.
+end
+
+function GameplayScene:cleanup()
+  GameplayScene.super.cleanup(self)
+  self.player = nil
+  self.map = nil
+  self.fadeIn = nil
+end
+
+-- Backgrounds and Draw Stack Behavior
+local pauseScene = RoxyScene(COLOR_BLACK)
+pauseScene.isVisible = true
+pauseScene.blocksLowerDraw = false
+pauseScene.updateBackground = true
+
+-- Manual Ownership Cleanup
+local scene = RoxyScene()
+local player = RoxySprite({ name = "player" }, scene)
+local map = scene:spawnTilemap("assets/maps/level-01.json")
+
+scene:removeSprite(player)
+scene:removeTilemap(map)
+scene:cleanup()
+
+]]

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -1,73 +1,58 @@
--- libraries/roxy/core/sprites/RoxySprite.lua
-
---------------------------------------------------------------------------------
--- Standard Lua Function Aliases
---------------------------------------------------------------------------------
+-- core/sprites/RoxySprite.lua
 
 local floor <const> = math.floor
-
---------------------------------------------------------------------------------
--- Playdate SDK Imports and Aliases
---------------------------------------------------------------------------------
 
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
--- Playdate SDK Function Aliases
 local performAfterDelay <const> = pd.timer.performAfterDelay
 local newImage          <const> = Graphics.image.new
 local newImageTable     <const> = Graphics.imagetable.new
-
---------------------------------------------------------------------------------
--- Roxy Framework Imports and Aliases
---------------------------------------------------------------------------------
 
 local r       <const> = roxy
 local Assets  <const> = r.Assets
 local Camera  <const> = r.Camera
 
--- Roxy Utilities
 local round <const> = r.Math.round
 
--- Roxy Framework Function Aliases
 local getAsset      <const> = Assets.getAsset
 local getPosition   <const> = Camera.getPosition
 local worldToScreen <const> = Camera.worldToScreen
-
---------------------------------------------------------------------------------
--- Graphics Constants
---------------------------------------------------------------------------------
 
 local UNFLIPPED   <const> = Graphics.kImageUnflipped
 local FLIPPED_X   <const> = Graphics.kImageFlippedX
 local FLIPPED_Y   <const> = Graphics.kImageFlippedY
 local FLIPPED_X_Y <const> = Graphics.kImageFlippedXY
 
---------------------------------------------------------------------------------
--- Time Constants
---------------------------------------------------------------------------------
-
 local MS_PER_SECOND <const> = 1000
 
---------------------------------------------------------------------------------
--- Default Values
---------------------------------------------------------------------------------
-
 local DELAY_DEFAULT <const> = 1 -- Seconds
-
---------------------------------------------------------------------------------
--- Display Constants (Cached for Performance)
---------------------------------------------------------------------------------
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 
--- Screen bounds constants for isOnScreen optimization
 local SCREEN_LEFT_LIMIT   <const> = 0
 local SCREEN_TOP_LIMIT    <const> = 0
 local SCREEN_RIGHT_LIMIT  <const> = DISPLAY_WIDTH
 local SCREEN_BOTTOM_LIMIT <const> = DISPLAY_HEIGHT
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Helper: Has Parallax
+-- Returns true when the sprite needs camera-relative parallax updates.
+local function _hasParallax(sprite)
+  return sprite.parallaxX ~= nil or sprite.parallaxY ~= nil
+end
+
+-- ! Helper: Set Collisions Active
+-- Toggles the Playdate collision system without changing Roxy's desired state.
+local function _setCollisionsActive(sprite, flag)
+  sprite._collisionsActive = flag == true
+  RoxySprite.super.setCollisionsEnabled(sprite, flag)
+end
 
 --------------------------------------------------------------------------------
 -- Class Definition and Init
@@ -80,17 +65,20 @@ function RoxySprite:init(options, scene)
   options = options or {}
   RoxySprite.super.init(self)
 
-  self.name               = options.name or "RoxySprite"
-  self.isRoxySprite       = true
-  self._added             = false
-  self.isPaused           = true
-  self.flip               = UNFLIPPED
-  self.animation          = nil
-  self._animationRetained = false -- Track if we retained the current animation
-  self.simpleAnimation    = nil
-  self._drawFn            = nil
-  self._ignoresDrawOffset = false
-  self._destroyed         = false -- Prevent use-after-destroy
+  self.name                     = options.name or "RoxySprite"
+  self.isRoxySprite             = true
+  self._added                   = false
+  self.isPaused                 = true
+  self.flip                     = UNFLIPPED
+  self.animation                = nil
+  self._animationRetained       = false -- Track if we retained the current animation
+  self.simpleAnimation          = nil
+  self._drawFn                  = nil
+  self._ignoresDrawOffset       = false
+  self._collisionsEnabled       = true
+  self._collisionsActive        = true
+  self._restoreCollisionsOnAdd  = false
+  self._destroyed               = false -- Prevent use-after-destroy
 
   -- Parallax (optional; only active if configured)
   self.worldX, self.worldY        = nil, nil
@@ -136,6 +124,19 @@ function RoxySprite:setIgnoresDrawOffset(flag)
 
   self._ignoresDrawOffset = flag
   RoxySprite.super.setIgnoresDrawOffset(self, flag)
+  return self
+end
+
+-- ! Set Collisions Enabled
+-- Sets the desired collision state and applies it immediately.
+function RoxySprite:setCollisionsEnabled(flag)
+  assert(type(flag) == "boolean", "[RoxySprite:setCollisionsEnabled] Expected boolean, got " .. tostring(type(flag)))
+
+  self._collisionsEnabled = flag
+  if flag == false then
+    self._restoreCollisionsOnAdd = false
+  end
+  _setCollisionsActive(self, flag)
   return self
 end
 
@@ -228,7 +229,7 @@ end
 
 -- ! Parallax enabled?
 function RoxySprite:isParallaxEnabled()
-  return self.parallaxX ~= nil or self.parallaxY ~= nil
+  return _hasParallax(self)
 end
 
 --------------------------------------------------------------------------------
@@ -460,22 +461,27 @@ function RoxySprite:setFlipState(newFlip)
   return self
 end
 
+-- ! Unflip
 function RoxySprite:unflip()
   return self:setFlipState(UNFLIPPED)
 end
 
+-- ! Flip X
 function RoxySprite:flipX()
   return self:setFlipState(FLIPPED_X)
 end
 
+-- ! Flip Y
 function RoxySprite:flipY()
   return self:setFlipState(FLIPPED_Y)
 end
 
+-- ! Flip XY
 function RoxySprite:flipXY()
   return self:setFlipState(FLIPPED_X_Y)
 end
 
+-- ! Get Orientation
 function RoxySprite:getOrientation()
   return self.flip
 end
@@ -592,7 +598,7 @@ end
 function RoxySprite:pause()
   if self.animation or self.simpleAnimation then
     self.isPaused = true
-    self:setUpdatesEnabled(false) -- Disable engine updates
+    self:setUpdatesEnabled(_hasParallax(self)) -- Parallax placement still needs updates
   end
   return self
 end
@@ -623,7 +629,7 @@ end
 function RoxySprite:stop()
   if self.animation or self.simpleAnimation then
     self.isPaused = true
-    self:setUpdatesEnabled(false)
+    self:setUpdatesEnabled(_hasParallax(self))
     if self.animation then
       self.animation:resetAnimationStart()
     elseif self.simpleAnimation then
@@ -749,7 +755,7 @@ end
 function RoxySprite:update()
   if self._destroyed then return end
 
-  local hasParallax = (self.parallaxX ~= nil) or (self.parallaxY ~= nil)
+  local hasParallax = _hasParallax(self)
   local cameraX, cameraY
 
   if hasParallax or not self._ignoresDrawOffset then
@@ -826,13 +832,25 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Add Sprite
+-- Re-adds the sprite and restores state needed by pooled scene reuse.
 function RoxySprite:add()
   RoxySprite.super.add(self)
   self._added = true
+  if self._restoreCollisionsOnAdd and self._collisionsEnabled ~= false then
+    _setCollisionsActive(self, true)
+  end
+  self._restoreCollisionsOnAdd = false
+  if _hasParallax(self) then
+    self:setIgnoresDrawOffset(true)
+    self:setUpdatesEnabled(true)
+  elseif (self.animation or self.simpleAnimation) and not self.isPaused then
+    self:setUpdatesEnabled(true)
+  end
   return self
 end
 
 -- ! Remove Sprite
+-- Removes the sprite while remembering state that should resume on add().
 function RoxySprite:remove()
   if self.isRoxySprite and (self.animation or self.simpleAnimation) then
     self:stop()
@@ -840,8 +858,9 @@ function RoxySprite:remove()
 
   -- Pause and disable sprite systems
   if self.isRoxySprite then self:pause() end
+  self._restoreCollisionsOnAdd = self._collisionsEnabled ~= false
   self:setUpdatesEnabled(false)
-  self:setCollisionsEnabled(false)
+  _setCollisionsActive(self, false)
 
   -- Automatically detach from owning scene, if any
   if self.scene then
@@ -922,9 +941,11 @@ function RoxySprite:destroy()
   self._drawFn = nil
 end
 
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
 --[[
-USAGE EXAMPLE:
-RoxySprite is the foundation sprite class with optional parallax support
 
 -- Basic sprite creation
 local sprite = RoxySprite({
@@ -987,16 +1008,26 @@ sprite:play()
 sprite:setSpeed(2.0) -- Double speed
 sprite:setFrameDuration(0.05) -- 20 FPS
 
--- Parallax control (can be added later)
+-- Parallax control can be added later
 sprite:setParallax(0.5, 0.8)
 sprite:setWorldPosition(200, 150)
 sprite:setParallaxOrigin(100, 75)
 
+-- Pooled scene reuse restores parallax updates and desired collisions on add()
+backgroundSprite:remove()
+backgroundSprite:add()
+
+sprite:setCollisionsEnabled(false)
+sprite:remove()
+sprite:add()
+
 -- Sprite management
-sprite:add()            -- Add to display list
-scene:addSprite(sprite) -- Add to scene
-sprite:remove()         -- Remove from display list
-sprite:destroy()        -- Clean up resources
+local looseSprite = RoxySprite({ name = "LooseSprite" })
+looseSprite:add()            -- Add to display list
+looseSprite:remove()         -- Remove from display list
+scene:addSprite(looseSprite) -- Add through scene ownership
+scene:removeSprite(looseSprite)
+looseSprite:destroy()        -- Clean up resources
 
 -- Utility methods
 local onScreen = sprite:isOnScreen()
@@ -1009,8 +1040,9 @@ sprite:flipY()
 sprite:flipXY()
 sprite:unflip()
 
--- Frame control (for animations)
+-- Frame control for animations
 sprite:drawSpecificFrame(5, true) -- Jump to frame 5 and pause
 sprite:stepFrame(1)               -- Step forward one frame
 sprite:stepFrame(-1)              -- Step backward one frame
+
 ]]--

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -9,7 +9,7 @@ local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
 local Camera      <const> = r.Camera
 
-local round     <const> = r.Math.round
+local round <const> = r.Math.round
 
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
@@ -27,10 +27,11 @@ local getTable  <const> = AssetStore.getImagetable
 -- ! Helper: Create Parallax Update
 -- Parallax updater (same behavior as in RoxyTilemap)
 local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY)
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
   return function(sprite)
     local cameraX, cameraY = Camera.getPosition()
-    local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
-    local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
     local screenX = round(worldX + pivotAdjustX - cameraX * parallaxX)
     local screenY = round(worldY + pivotAdjustY - cameraY * parallaxY)
@@ -38,6 +39,24 @@ local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, paral
     local currentX, currentY = sprite:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
       sprite:moveTo(screenX, screenY)
+    end
+  end
+end
+
+-- ! Helper: Remove Sprites From Scene
+-- Uses the scene batch unregister path when available; otherwise removes directly.
+local function _removeSpritesFromScene(scene, sprites)
+  if not sprites or #sprites == 0 then return end
+
+  if scene and scene._unregisterSprites then
+    scene:_unregisterSprites(sprites, true)
+  elseif scene and scene.removeSprite then
+    for i = 1, #sprites do
+      scene:removeSprite(sprites[i])
+    end
+  else
+    for i = 1, #sprites do
+      sprites[i]:remove()
     end
   end
 end
@@ -145,27 +164,29 @@ end
 -- ! Hide
 function LayerManager:hide(name)
   local layer = self.layers[name]
-  if not layer then return end
+  if not layer then return false end
 
   layer.visible = false
   if layer.sprite then layer.sprite:setVisible(false) end
+  return true
 end
 
 -- ! Show
 function LayerManager:show(name)
   local layer = self.layers[name]
-  if not layer then return end
+  if not layer then return false end
 
   layer.visible = true
   local sprite = self:ensureSprite(name)
   if sprite then sprite:setVisible(true) end
+  return true
 end
 
 -- ! Remove
 -- Remove layer + sprites + collision sprites + retained paths from swaps
 function LayerManager:remove(name)
   local layer = self.layers[name]
-  if not layer then return end
+  if not layer then return false end
 
   if layer.sprite then
     local sprite = layer.sprite
@@ -189,10 +210,11 @@ function LayerManager:remove(name)
 
   layer.tilemap, layer.imageTable, layer._imageCache, layer._offsetCache = nil, nil, nil, nil
   self.layers[name] = nil
+  return true
 end
 
 -- ! Set Image Table
--- Runtime imagetable swap with index remap and proper retention accounting
+-- Runtime image table swap with index remap and proper retention accounting
 function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   local layer = self.layers[name]
   if not layer or not layer.tilemap then return false end
@@ -211,7 +233,14 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   end
 
   if remapFn then
-    local tiles, width = layer.tilemap:getTiles()
+    local tiles, width
+    if layer.tilemap.getTiles then
+      tiles, width = layer.tilemap:getTiles()
+    end
+    if not tiles then
+      tiles = layer.tilesFlat
+      width = layer.tilesStride or layer.mapWidth
+    end
     if tiles and width then
       if type(remapFn) == "function" then
         for index = 1, #tiles do
@@ -237,6 +266,8 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
       end
 
       layer.tilemap:setTiles(tiles, width)
+      layer.tilesFlat = tiles
+      layer.tilesStride = width
     end
   end
 
@@ -298,7 +329,10 @@ function LayerManager:setOrigin(name, x, y)
   local layer = self.layers[name]
   if not layer then return false end
 
-  layer.originX, layer.originY = x or 0, y or 0
+  x, y = x or 0, y or 0
+  if layer.originX == x and layer.originY == y then return true end
+
+  layer.originX, layer.originY = x, y
   local sprite = layer.sprite
   if sprite then
     local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
@@ -323,14 +357,15 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Detach
+-- Remove layer and collision sprites without releasing retained swap paths.
 function LayerManager:detach()
+  -- Collect layer sprites so the scene can unregister them in one batch
+  local layerSprites = nil
+
   for _, layer in pairs(self.layers) do
     if layer.sprite then
-      if self.scene and self.scene.removeSprite then
-        self.scene:removeSprite(layer.sprite)
-      else
-        layer.sprite:remove()
-      end
+      layerSprites = layerSprites or {}
+      tableInsert(layerSprites, layer.sprite)
       layer.sprite = nil
     end
     if layer.collisionSprites then
@@ -338,14 +373,20 @@ function LayerManager:detach()
       layer.collisionSprites = nil
     end
   end
+
+  _removeSpritesFromScene(self.scene, layerSprites)
 end
 
 -- ! Destroy
 -- Cleanly remove all layer sprites + collisions and release swap-retained paths
 function LayerManager:destroy()
+  -- Collect layer sprites so the scene can unregister them in one batch
+  local layerSprites = nil
+
   for _, layer in pairs(self.layers) do
     if layer.sprite then
-      if self.scene and self.scene.removeSprite then self.scene:removeSprite(layer.sprite) else layer.sprite:remove() end
+      layerSprites = layerSprites or {}
+      tableInsert(layerSprites, layer.sprite)
       layer.sprite = nil
     end
     if layer.collisionSprites then
@@ -354,7 +395,66 @@ function LayerManager:destroy()
     end
     layer.tilemap, layer.imageTable, layer._imageCache, layer._offsetCache = nil, nil, nil, nil
   end
+  _removeSpritesFromScene(self.scene, layerSprites)
   for path, _ in pairs(self._retainedPaths) do release(path) end
   self._retainedPaths = {}
   self._spritesList = {}
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local Graphics <const> = playdate.graphics
+
+-- Advanced/direct usage; RoxyTilemap usually creates the manager for you.
+local scene = RoxyScene()
+local layers = {}
+local sprites = {}
+
+local manager = LayerManager({
+  wrapInSprites = true,
+  autoAddSprites = true,
+  anchor = "topLeft",
+}, scene, layers, sprites)
+
+local imageTable = Graphics.imagetable.new("images/terrain")
+local tilemap = Graphics.tilemap.new()
+tilemap:setImageTable(imageTable)
+tilemap:setTiles({
+  1, 1, 0,
+  2, 2, 1,
+}, 3)
+
+manager:addLayer({
+  name = "Ground",
+  tilemap = tilemap,
+  imageTable = imageTable,
+  tileWidth = 16,
+  tileHeight = 16,
+  originX = 0,
+  originY = 0,
+  zIndex = 0,
+  visible = true,
+  anchor = "topLeft",
+})
+
+local groundSprite = manager:ensureSprite("Ground")
+manager:hide("Ground")
+manager:show("Ground")
+manager:setOrigin("Ground", 32, 16)
+
+-- Runtime image table swap with a compact remap table
+local winterTiles = Graphics.imagetable.new("images/terrain-winter")
+manager:setImageTable("Ground", winterTiles, {
+  [1] = 2,
+  [2] = 1,
+})
+
+-- Remove one layer, or destroy the whole manager during tilemap teardown
+manager:remove("Ground")
+manager:destroy()
+
+]]

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -67,6 +67,7 @@ end
 
 class("LayerManager").extends(Object)
 
+-- ! Initialize
 function LayerManager:init(opts, scene, backingLayersTable, backingSpritesList)
   self._opts = opts or {}
   self.scene = scene
@@ -95,10 +96,17 @@ function LayerManager:addLayer(layerData)
 end
 
 -- ! Ensure Sprite
--- Create (if needed) and return the sprite for a layer
+-- Creates if needed and returns the sprite for a layer
 function LayerManager:ensureSprite(name)
   local layer = self.layers[name]; if not layer then return nil end
-  if layer.sprite or self._opts.wrapInSprites == false then return layer.sprite end
+  if self._opts.wrapInSprites == false then return layer.sprite end
+
+  if layer.sprite then
+    if self._autoAdd and self._sceneHasAdd then
+      self.scene:addSprite(layer.sprite)
+    end
+    return layer.sprite
+  end
 
   local sprite = newSprite()
   sprite:setTilemap(layer.tilemap)
@@ -119,12 +127,8 @@ function LayerManager:ensureSprite(name)
     sprite:moveTo(layer.originX or 0, layer.originY or 0)
   end
 
-  if self._autoAdd then
-    if self._sceneHasAdd then
-      self.scene:addSprite(sprite)
-    else
-      sprite:add()
-    end
+  if self._autoAdd and self._sceneHasAdd then
+    self.scene:addSprite(sprite)
   end
   sprite:setVisible(layer.visible ~= false)
 
@@ -190,8 +194,8 @@ function LayerManager:remove(name)
 
   if layer.sprite then
     local sprite = layer.sprite
-    if self.scene and self.scene.removeSprite then self.scene:removeSprite(sprite) else sprite:remove() end
-    -- remove from external list if present
+    _removeSpritesFromScene(self.scene, { sprite })
+    -- Remove from external list if present
     for i = #self._spritesList, 1, -1 do
       if self._spritesList[i] == sprite then tableRemove(self._spritesList, i); break end
     end
@@ -199,7 +203,7 @@ function LayerManager:remove(name)
   end
 
   if layer.collisionSprites then
-    for _, collisionSprite in ipairs(layer.collisionSprites) do collisionSprite:remove() end
+    _removeSpritesFromScene(self.scene, layer.collisionSprites)
     layer.collisionSprites = nil
   end
 
@@ -274,7 +278,7 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   layer.tilemap:setImageTable(newTable)
   layer.imageTable, layer._imageCache, layer._offsetCache = newTable, {}, {}
 
-  -- recompute image meta
+  -- Recompute image metadata
   local maxHeight, count = 0, newTable and newTable:getLength() or 0
   for i = 1, count do
     local img = newTable:getImage(i)
@@ -286,7 +290,7 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   end
   layer.maxImageHeight, layer.imageCount = maxHeight, count
 
-  -- update retention (for swap paths only)
+  -- Update retention for swap paths only
   if newPath then
     if not self._retainedPaths[newPath] then
       if retain(newPath, newTable) then
@@ -366,11 +370,6 @@ function LayerManager:detach()
     if layer.sprite then
       layerSprites = layerSprites or {}
       tableInsert(layerSprites, layer.sprite)
-      layer.sprite = nil
-    end
-    if layer.collisionSprites then
-      for _, sprite in ipairs(layer.collisionSprites) do sprite:remove() end
-      layer.collisionSprites = nil
     end
   end
 
@@ -378,10 +377,11 @@ function LayerManager:detach()
 end
 
 -- ! Destroy
--- Cleanly remove all layer sprites + collisions and release swap-retained paths
+-- Cleanly remove all layer sprites, collisions, and swap-retained paths
 function LayerManager:destroy()
   -- Collect layer sprites so the scene can unregister them in one batch
   local layerSprites = nil
+  local collisionSprites = nil
 
   for _, layer in pairs(self.layers) do
     if layer.sprite then
@@ -390,12 +390,16 @@ function LayerManager:destroy()
       layer.sprite = nil
     end
     if layer.collisionSprites then
-      for _, collisionSprite in ipairs(layer.collisionSprites) do collisionSprite:remove() end
+      for _, collisionSprite in ipairs(layer.collisionSprites) do
+        collisionSprites = collisionSprites or {}
+        tableInsert(collisionSprites, collisionSprite)
+      end
       layer.collisionSprites = nil
     end
     layer.tilemap, layer.imageTable, layer._imageCache, layer._offsetCache = nil, nil, nil, nil
   end
   _removeSpritesFromScene(self.scene, layerSprites)
+  _removeSpritesFromScene(self.scene, collisionSprites)
   for path, _ in pairs(self._retainedPaths) do release(path) end
   self._retainedPaths = {}
   self._spritesList = {}
@@ -453,7 +457,8 @@ manager:setImageTable("Ground", winterTiles, {
   [2] = 1,
 })
 
--- Remove one layer, or destroy the whole manager during tilemap teardown
+-- Detach for pooled scene reuse, or destroy during tilemap teardown.
+manager:detach()
 manager:remove("Ground")
 manager:destroy()
 

--- a/core/tilemaps/ObjectLayerProcessor.lua
+++ b/core/tilemaps/ObjectLayerProcessor.lua
@@ -34,6 +34,19 @@ local OBJECT_TAG <const> = 2
 local COLOR_BLACK <const> = Graphics.kColorBlack
 
 --------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+-- ! Helper: Non-Empty String
+-- Returns a string only when it contains visible text.
+local function _nonEmptyString(value)
+  if type(value) == "string" and value:match("%S") then
+    return value
+  end
+  return nil
+end
+
+--------------------------------------------------------------------------------
 -- Create Default Object Sprite
 --------------------------------------------------------------------------------
 
@@ -72,15 +85,18 @@ function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fa
 
   -- Determine image path
   local imagePath = nil
-  if objectProperties.image or objectProperties.sprite then
-    imagePath = IMAGE_PATH_PREFIX .. (objectProperties.image or objectProperties.sprite)
+  local explicitImage = _nonEmptyString(objectProperties.image) or _nonEmptyString(objectProperties.sprite)
+  if explicitImage then
+    imagePath = IMAGE_PATH_PREFIX .. explicitImage
   else
-    local baseName = object.type or object.name or "default"
-    imagePath = IMAGE_PATH_PREFIX .. baseName
+    local baseName = _nonEmptyString(object.type) or _nonEmptyString(object.name)
+    if baseName then
+      imagePath = IMAGE_PATH_PREFIX .. baseName
+    end
   end
 
   -- Try to load the image (optional)
-  local img = getImageCached(imagePath) or nil
+  local img = imagePath and getImageCached(imagePath) or nil
   local didRetain = false
   if img then
     didRetain = retain(imagePath, img)
@@ -120,7 +136,7 @@ function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fa
     end
   end
 
-  -- Track retained imagePath for cleanup
+  -- Track retained image path for cleanup
   sprite._retainedImagePath = didRetain and imagePath or nil
 
   -- Store object properties on sprite for reference
@@ -157,13 +173,13 @@ function ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, auto
     elseif layerOptions.spriteFactory and type(layerOptions.spriteFactory) == "function" then
       sprite = layerOptions.spriteFactory(object, layer, layerOptions)
     else
-      -- Default creation uses resolved layer parallax as a fallback,
-      -- but still allows object.properties to override.
+      -- Default creation uses resolved layer parallax as a fallback.
+      -- Object properties can still override it.
       sprite = ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, resolvedParallaxX, resolvedParallaxY)
     end
 
     if sprite then
-      -- Compute world position (center vs topLeft)
+      -- Compute world position from the configured anchor
       local positionX, positionY = object.x or 0, object.y or 0
       if opts.anchor == "center" then
         positionX += (object.width  or 0) * 0.5
@@ -176,7 +192,7 @@ function ObjectLayerProcessor.processObjectLayer(layer, opts, layerOptions, auto
         sprite:moveTo(positionX, positionY)
       end
 
-      -- Z-index & visibility
+      -- Z-index and visibility
       local zIndex = layerOptions.zIndex or (opts.zIndices and opts.zIndices[layer.name]) or 0
       sprite:setZIndex(zIndex)
       sprite:setVisible(layerOptions.visible ~= false)
@@ -245,3 +261,36 @@ function ObjectLayerProcessor.processObjectLayers(tilemapInstance, mapData, opts
   tilemapInstance.objectSprites = objectSprites
   return processedCount
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local scene = RoxyScene()
+
+local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
+  objectLayers = {
+    Pickups = true,
+  },
+  layerOptions = {
+    Pickups = {
+      collidable = true,
+      spriteGroup = 2,
+      collidesWithGroups = { 1 },
+      parallaxX = 1,
+      parallaxY = 1,
+    },
+  },
+})
+scene:addTilemap(map)
+
+local pickups = map:getObjectSprites("Pickups")
+local strawberry = map:findObjectSprite("Pickups", function(sprite)
+  return sprite.objectProps.kind == "strawberry"
+end)
+
+map:removeObjectLayer("Pickups")
+
+]]--

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -54,6 +54,8 @@ local sanitizeTileIndex       <const> = TilemapHelpers.sanitizeTileIndex
 local sanitizeTilesInPlace    <const> = TilemapHelpers.sanitizeTilesInPlace
 local syncNativeTiles         <const> = TilemapHelpers.syncNativeTiles
 local dequeueBestWarmJob      <const> = TilemapHelpers.dequeueBestWarmJob
+local clearChunkDrawScratch   <const> = TilemapHelpers.clearChunkDrawScratch
+local recordPerfCount         <const> = TilemapHelpers.recordPerfCount --#DEBUG
 
 -- C-side bindings
 local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
@@ -126,7 +128,8 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
   self._orderedLayers = {}
 
   self._warmQueue = {}  -- Queue of { layerConfig, chunkX, chunkY, key }
-  self._warmSet   = {}  -- Tracks keys already queued
+  self._warmSet = {}  -- Tracks keys already queued
+  self._chunkDrawScratch = { images = {}, xs = {}, ys = {} }
 
   self._didPrimeVisible = false -- One-time prime flag
   self._frameDirty = true -- Assume dirty until first frame settles
@@ -351,8 +354,9 @@ end
 -- Amortize chunk builds across frames
 function RoxyIsoTilemap:_warmSomeChunks()
   local built = 0
+  local centerCache = {}
   while built < BUILD_BUDGET and #self._warmQueue > 0 do
-    local job = dequeueBestWarmJob(self) -- Pick closest
+    local job = dequeueBestWarmJob(self, centerCache) -- Pick closest
     if not job then break end
     if not getIsAssetCached(self._globalChunkBucket, job.key) then
       local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
@@ -551,11 +555,13 @@ function RoxyIsoTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, of
 
   -- Fast path: native renderer to a real LCDBitmap
   if nativeRenderer and targetImage ~= nil then
+    recordPerfCount("tilemap.nativeBuffer.iso") --#DEBUG
     nativeRenderer:renderToBuffer(targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
     return
   end
 
   -- Fallback Lua implementation (rare in practice)
+  recordPerfCount("tilemap.luaBuffer.iso") --#DEBUG
   Log.debug("[_renderLayerToBuffer] Falling back on Lua implementation") --#DEBUG
 
   local imageTable = layerData.imageTable
@@ -659,10 +665,6 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   local imageWidth, imageHeight = layerConfig.bufferWidth, layerConfig.bufferHeight
 
   local scratch = self._chunkDrawScratch
-  if not scratch then
-    scratch = { images = {}, xs = {}, ys = {} }
-    self._chunkDrawScratch = scratch
-  end
   local images, xs, ys = scratch.images, scratch.xs, scratch.ys
   local drawCount = 0
 
@@ -672,6 +674,7 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
       local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
       local img = getCachedAsset(self._globalChunkBucket, key)
       if img then
+        recordPerfCount("tilemap.chunkHit.iso") --#DEBUG
         local dx = chunkX * size - overlap + screenX
         local dy = rowDeltaY
         -- Offscreen culling
@@ -682,6 +685,7 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
           ys[drawCount] = dy
         end
       else
+        recordPerfCount("tilemap.chunkMiss.iso") --#DEBUG
         anyMissing = true
         self:_enqueueWarm(layerConfig, chunkX, chunkY)
       end
@@ -689,9 +693,7 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   end
 
   if anyMissing then
-    for index = 1, drawCount do
-      images[index] = nil
-    end
+    clearChunkDrawScratch(scratch, drawCount)
     -- Single-pass fallback - render the layer once (native rows or Lua), not per-miss.
     -- Clip to screen to be safe.
     setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
@@ -704,8 +706,8 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   for index = 1, drawCount do
     -- The dx/dy values are already integers; removed floor() for a small win.
     images[index]:draw(xs[index], ys[index])
-    images[index] = nil
   end
+  clearChunkDrawScratch(scratch, drawCount)
 end
 
 --
@@ -978,6 +980,7 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
 
     local tr = layerData._nativeRenderer
     if tr then
+      recordPerfCount("tilemap.nativeRows.iso") --#DEBUG
       tr:drawRows(
         rowStart, rowEnd,
         minX, maxX,
@@ -996,6 +999,7 @@ function RoxyIsoTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, maxC
   --
 
   Log.debug("[drawLayerRows] Falling back on Lua implementation") --#DEBUG
+  recordPerfCount("tilemap.luaRows.iso") --#DEBUG
 
   local imageTable = layerData.imageTable
   if not imageTable then

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -147,41 +147,7 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
   for _, layerData in pairs(self.layers) do
     if layerData.tilemap then
       self:_preloadLayerCaches(layerData)
-
-      -- Create native renderer instance for this layer
-      if layerData.imageTable and newTileRenderer_C then
-        -- Sanitize tiles once on load so the native blob never sees out-of-range values
-        sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
-
-        local isIsometric = 1
-        local staggerIndexOdd = 0
-        local staggerDirectionRight = 0
-
-        --#DEBUG START
-        if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
-           or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
-          Log.error("[RoxyIsoTilemap] Invalid tile metrics; width/height/halves must be > 0")
-        end
-        --#DEBUG END
-
-        layerData._nativeRenderer = newTileRenderer_C(
-          isIsometric,
-          staggerIndexOdd,
-          staggerDirectionRight,
-          layerData.mapWidth,       -- Tiles
-          layerData.mapHeight,      -- Tiles
-          layerData.tileWidth,      -- px
-          layerData.tileHeight,     -- px
-          layerData.halfWidth,      -- px
-          layerData.halfHeight,     -- px
-          layerData.maxImageHeight, -- Tall art overdraw
-          layerData.imageTable,     -- LCDBitmapTable
-          layerData.imageCount,     -- Frames in table
-          nil                       -- Optional tiles blob
-        )
-        layerData.ownerTilemap = self
-        syncNativeTiles(layerData)
-      end
+      self:_createNativeRenderer(layerData)
     end
   end
 
@@ -191,6 +157,112 @@ end
 --------------------------------------------------------------------------------
 -- Internal API
 --------------------------------------------------------------------------------
+
+-- ! Auto Chunk Overlap
+local function _autoChunkOverlap(layer)
+  local tileWidth = layer.tileWidth or 0
+  local halfWidth = layer.halfWidth or floor(tileWidth * 0.5)
+  local tileHeight = layer.tileHeight or 0
+  local maxImageHeight = layer.maxImageHeight or tileHeight
+  local tallOverdraw = max(0, ceil(maxImageHeight - tileHeight))
+
+  return max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+end
+
+-- ! Create Native Renderer
+function RoxyIsoTilemap:_createNativeRenderer(layerData)
+  if not layerData or not layerData.imageTable or not newTileRenderer_C then return end
+
+  sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+
+  --#DEBUG START
+  if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
+     or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
+    Log.error("[RoxyIsoTilemap] Invalid tile metrics; width/height/halves must be > 0")
+  end
+  --#DEBUG END
+
+  layerData._nativeRenderer = newTileRenderer_C(
+    1,                        -- Isometric
+    0,                        -- staggerIndexOdd
+    0,                        -- staggerDirectionRight
+    layerData.mapWidth,       -- Tiles
+    layerData.mapHeight,      -- Tiles
+    layerData.tileWidth,      -- px
+    layerData.tileHeight,     -- px
+    layerData.halfWidth,      -- px
+    layerData.halfHeight,     -- px
+    layerData.maxImageHeight, -- Tall art overdraw
+    layerData.imageTable,     -- LCDBitmapTable
+    layerData.imageCount,     -- Frames in table
+    nil                       -- Optional tiles blob
+  )
+  layerData.ownerTilemap = self
+  syncNativeTiles(layerData)
+end
+
+-- ! Refresh Projection Layer Render Resources
+function RoxyIsoTilemap:_refreshProjectionLayerRenderResources(layerName, layerData)
+  if not layerData then return end
+
+  if layerData._nativeRenderer then
+    layerData._nativeRenderer:destroy()
+    layerData._nativeRenderer = nil
+  end
+
+  local layerConfig = self._staticChunkLayers and self._staticChunkLayers[layerName]
+  if layerConfig then
+    if not layerConfig._explicitOverlap then
+      layerConfig.overlap = _autoChunkOverlap(layerData)
+    end
+    layerConfig.bufferWidth = layerConfig.size + 2 * layerConfig.overlap
+    layerConfig.bufferHeight = layerConfig.bufferWidth
+    layerConfig._dirty = true
+  end
+
+  self:_preloadLayerCaches(layerData)
+  self:_createNativeRenderer(layerData)
+end
+
+-- ! Project Dirty Tile Rect
+function RoxyIsoTilemap:_projectDirtyTileRect(layerConfig, tileX, tileY, tileCountWidth, tileCountHeight)
+  local layer = layerConfig and layerConfig.layer
+  if not layer then return 0, 0, 0, 0 end
+
+  local halfWidth = layer.halfWidth or ((layer.tileWidth or 0) * 0.5)
+  local halfHeight = layer.halfHeight or ((layer.tileHeight or 0) * 0.5)
+  local tileWidth = layer.tileWidth or 0
+  local tileHeight = layer.tileHeight or 0
+  local tallOverdraw = max(0, (layer.maxImageHeight or tileHeight) - tileHeight)
+
+  local minColumn = (tileX or 1) - 1
+  local minRow = (tileY or 1) - 1
+  local maxColumn = minColumn + (tileCountWidth or 1)
+  local maxRow = minRow + (tileCountHeight or 1)
+
+  local minX, minY = math.huge, math.huge
+  local maxX, maxY = -math.huge, -math.huge
+
+  local function include(column, row)
+    local screenX = (column - row) * halfWidth
+    local screenY = (column + row) * halfHeight
+    if screenX < minX then minX = screenX end
+    if screenX > maxX then maxX = screenX end
+    if screenY < minY then minY = screenY end
+    if screenY > maxY then maxY = screenY end
+  end
+
+  include(minColumn, minRow)
+  include(maxColumn, minRow)
+  include(minColumn, maxRow)
+  include(maxColumn, maxRow)
+
+  minX -= tileWidth
+  maxX += tileWidth
+  minY -= tallOverdraw
+
+  return minX, minY, max(1, maxX - minX), max(1, maxY - minY + tallOverdraw)
+end
 
 --
 -- Static Layer Configuration
@@ -207,23 +279,20 @@ function RoxyIsoTilemap:_initializeStaticLayers(opts)
   for layerName, layer in pairs(self.layers) do
     local layerOpts = layerOptions[layerName] or {}
     if layerOpts.preRenderChunked then
-      local tileWidth = layer.tileWidth or 0
-      local halfWidth = layer.halfWidth or floor(tileWidth * 0.5)
-
-      local tallOverdraw = 0
-      if layer.maxImageHeight and layer.tileHeight then
-        tallOverdraw = max(0, ceil((layer.maxImageHeight - layer.tileHeight) * 0.5))
-      end
-
-      local overlap = layerOpts.overlapPx or max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+      local overlap = layerOpts.overlapPx or _autoChunkOverlap(layer)
+      local size = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE)
+      local bufferSize = size + 2 * overlap
 
       self._staticChunkLayers[layerName] = {
-        name      = layerName,
-        layer     = layer,
-        size      = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE),
-        overlap   = overlap,
-        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
-        _dirty    = true, -- Per-layer dirty bit
+        name         = layerName,
+        layer        = layer,
+        size         = size,
+        overlap      = overlap,
+        bufferWidth  = bufferSize,
+        bufferHeight = bufferSize,
+        keyPrefix    = "chunk:" .. (self._mapCacheId or "map") .. ":" .. tostring(layer.tiledId or layerName) .. ":",
+        _dirty       = true, -- Per-layer dirty bit
+        _explicitOverlap = layerOpts.overlapPx ~= nil,
       }
     end
   end
@@ -435,7 +504,7 @@ end
 -- ! Build Chunk
 function RoxyIsoTilemap:_buildChunk(layerConfig, chunkX, chunkY)
   local size, overlap = layerConfig.size, layerConfig.overlap
-  local width, height = size + 2 * overlap, size + 2 * overlap
+  local width, height = layerConfig.bufferWidth, layerConfig.bufferHeight
   local img = newImage(width, height)
   if not img then
     -- Low-memory guard
@@ -599,8 +668,15 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
 
   -- First pass - scan for any missing chunks and enqueue builds.
   local anyMissing = false
-  local toDraw = {} -- {img, dx, dy, imageWidth, imageHeight}
-  local imageWidth, imageHeight = size + 2 * overlap, size + 2 * overlap
+  local imageWidth, imageHeight = layerConfig.bufferWidth, layerConfig.bufferHeight
+
+  local scratch = self._chunkDrawScratch
+  if not scratch then
+    scratch = { images = {}, xs = {}, ys = {} }
+    self._chunkDrawScratch = scratch
+  end
+  local images, xs, ys = scratch.images, scratch.xs, scratch.ys
+  local drawCount = 0
 
   for chunkY = minY, maxY do
     local rowDeltaY = chunkY * size - overlap + screenY
@@ -612,7 +688,10 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
         local dy = rowDeltaY
         -- Offscreen culling
         if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
-          toDraw[#toDraw + 1] = { img = img, dx = dx, dy = dy } -- ints already
+          drawCount += 1
+          images[drawCount] = img
+          xs[drawCount] = dx
+          ys[drawCount] = dy
         end
       else
         anyMissing = true
@@ -622,6 +701,9 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   end
 
   if anyMissing then
+    for index = 1, drawCount do
+      images[index] = nil
+    end
     -- Single-pass fallback - render the layer once (native rows or Lua), not per-miss.
     -- Clip to screen to be safe.
     setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
@@ -631,10 +713,10 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
   end
 
   -- All chunks available - draw them.
-  for index = 1, #toDraw do
-    local element = toDraw[index]
+  for index = 1, drawCount do
     -- dx/dy are already integers; removed floor() for tiny win.
-    element.img:draw(element.dx, element.dy)
+    images[index]:draw(xs[index], ys[index])
+    images[index] = nil
   end
 end
 
@@ -782,11 +864,8 @@ function RoxyIsoTilemap:markTilesDirty(layerName, tileX, tileY, tileCountWidth, 
 
   self._frameDirty = true
 
-  local tileWidth, tileHeight = layerConfig.layer.tileWidth, layerConfig.layer.tileHeight
-  local pixelX = (tileX - 1) * (tileWidth * 0.5) * 2
-  local pixelY = (tileY - 1) * (tileHeight * 0.5)
-  local pixelWidth = (tileCountWidth or 1) * tileWidth
-  local pixelHeight = (tileCountHeight or 1) * (tileHeight * 0.5)
+  local pixelX, pixelY, pixelWidth, pixelHeight =
+    self:_projectDirtyTileRect(layerConfig, tileX, tileY, tileCountWidth, tileCountHeight)
 
   local minChunkX, maxChunkX, minChunkY, maxChunkY =
     chunkIndicesForRect(pixelX, pixelY, pixelWidth, pixelHeight, layerConfig.size)
@@ -804,14 +883,14 @@ end
 -- ! Draw
 -- Draw a single layer (chunked or dynamic fallback)
 function RoxyIsoTilemap:draw(layerName)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
+
   if self._staticChunkLayers[layerName] then
     self:_drawStaticLayerChunked(layerName); return
   end
 
-  -- Dynamic fallback (rare): draw only visible rows/cols with coarse margin
-  local layerData = self.layers and self.layers[layerName]
-  if not layerData or not layerData.tilemap or layerData.visible == false then return end
-
+  -- Dynamic fallback (rare): draw only visible rows and columns with coarse margin
   local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
 
   self:drawLayerRows(layerName, minTileY, maxTileY, minTileX, maxTileX)
@@ -1022,6 +1101,8 @@ end
 -- ! Destroy
 -- Clean up static layer resources
 function RoxyIsoTilemap:destroy()
+  if self._destroyed or self._destroying then return end
+
   -- Destroy native renderers first
   for _, layerData in pairs(self.layers or {}) do
     if layerData._nativeRenderer then
@@ -1040,3 +1121,58 @@ function RoxyIsoTilemap:destroy()
 
   RoxyIsoTilemap.super.destroy(self)
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local scene = RoxyScene()
+
+local map = RoxyIsoTilemap("assets/maps/isometric-test-3.json", {
+  cameraBounds = true,
+  deferCameraBounds = true,
+  wrapInSprites = false,
+  layerOptions = {
+    ground = {
+      preRenderChunked = true,
+      chunkSizePx = 96,
+      overlapPx = 32,
+    },
+    blocks = {
+      preRenderChunked = true,
+      chunkSizePx = 96,
+      overlapPx = 32,
+      zIndex = 10,
+    },
+  },
+}, scene)
+
+function scene:start()
+  map:applyCameraBounds()
+  map:forceRedraw(2)
+end
+
+function scene:draw()
+  map:drawVisible()
+end
+
+map:setTileAt("blocks", 4, 6, 2, true)
+map:markTilesDirty("blocks", 4, 6, 2, 2)
+
+local row = map:getRowFromScreen(200, 120, "blocks")
+map:drawLayerRows("blocks", 1, row, 1, 12)
+
+local previewImage, offsetX, offsetY = map:getLayerImage("ground", {
+  tileX = 1,
+  tileY = 1,
+  tileWidth = 6,
+  tileHeight = 6,
+  compositeLayers = { "blocks" },
+})
+
+map:drawVisibleInRect(0, 0, 400, 240)
+map:destroy()
+
+]]

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -79,6 +79,7 @@ local COLOR_CLEAR <const> = Graphics.kColorClear
 
 class("RoxyIsoTilemap").extends(RoxyTilemap)
 
+-- ! Initialize
 function RoxyIsoTilemap:init(jsonPath, opts, scene)
   opts = opts or {}
   opts.wrapInSprites = false
@@ -113,16 +114,9 @@ function RoxyIsoTilemap:init(jsonPath, opts, scene)
   end
   self.worldHeight = worldHeightBase + maxOverdrawPx
 
-  -- Refresh camera bounds if requested
+  -- Store camera bounds for attach/apply time; constructors are load-only
   if opts and opts.cameraBounds then
-    local x2 = max(0, self.worldWidth - DISPLAY_WIDTH)
-    local y2 = max(0, self.worldHeight - DISPLAY_HEIGHT)
-
-    if type(self.setCameraBounds) == "function" then
-      pcall(function() self:setCameraBounds(0, 0, x2, y2) end)
-    elseif Camera and type(setCameraBounds) == "function" then
-      pcall(function() setCameraBounds({ x1 = 0, y1 = 0, x2 = x2, y2 = y2 }) end)
-    end
+    self:updateCameraBounds(false)
   end
 
   self._projection = "iso"
@@ -243,6 +237,7 @@ function RoxyIsoTilemap:_projectDirtyTileRect(layerConfig, tileX, tileY, tileCou
   local minX, minY = math.huge, math.huge
   local maxX, maxY = -math.huge, -math.huge
 
+  -- ! Helper: Include Projected Tile
   local function include(column, row)
     local screenX = (column - row) * halfWidth
     local screenY = (column + row) * halfHeight
@@ -326,15 +321,7 @@ end
 -- ! Rebuild Ordered Layers
 -- Build a stable, z-sorted draw list (rarely changes)
 function RoxyIsoTilemap:_rebuildOrderedLayers()
-  local items = {}
-  for name, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
-      tableInsert(items, { layer = layer, name = name, type = renderType, z = layer.zIndex or 0 })
-    end
-  end
-  tableSort(items, function(a, b) return a.z < b.z end)
-  self._orderedLayers = items
+  RoxyTilemap._rebuildOrderedLayers(self)
 end
 
 -- ! Preload Layer Caches
@@ -396,6 +383,7 @@ function RoxyIsoTilemap:_renderLayerToImage(layerName, opts)
   local seen = {}
   local order = 0
 
+  -- ! Helper: Enqueue Layer
   local function enqueueLayer(name, layer)
     if not layer or seen[layer] then return end
 
@@ -714,7 +702,7 @@ function RoxyIsoTilemap:_drawStaticLayerChunked(layerName)
 
   -- All chunks available - draw them.
   for index = 1, drawCount do
-    -- dx/dy are already integers; removed floor() for tiny win.
+    -- The dx/dy values are already integers; removed floor() for a small win.
     images[index]:draw(xs[index], ys[index])
     images[index] = nil
   end
@@ -825,7 +813,7 @@ function RoxyIsoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
 
-  self:markLayerImageDirty(layerName)
+  self:_onLayerTilesChanged(layerName, layer)
 
   if updateSprite and layer.imageTable then
     local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
@@ -1132,7 +1120,6 @@ local scene = RoxyScene()
 
 local map = RoxyIsoTilemap("assets/maps/isometric-test-3.json", {
   cameraBounds = true,
-  deferCameraBounds = true,
   wrapInSprites = false,
   layerOptions = {
     ground = {
@@ -1147,10 +1134,11 @@ local map = RoxyIsoTilemap("assets/maps/isometric-test-3.json", {
       zIndex = 10,
     },
   },
-}, scene)
+})
+scene:addTilemap(map)
 
 function scene:start()
-  map:applyCameraBounds()
+  scene:activateCamera({ tilemap = map })
   map:forceRedraw(2)
 end
 

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -112,13 +112,18 @@ function RoxyOrthoTilemap:_initializeStaticLayers(opts)
   for layerName, layerData in pairs(self.layers) do
     local lopts = layerOptions[layerName] or {}
     if lopts.preRenderChunked then
+      local size = max(1, lopts.chunkSizePx or DEFAULT_CHUNK_SIZE)
+      local overlap = lopts.overlapPx or DEFAULT_CHUNK_OVERLAP
+      local bufferSize = size + 2 * overlap
       self._staticChunkLayers[layerName] = {
-        name      = layerName,
-        layer     = layerData,
-        size      = max(1, lopts.chunkSizePx or DEFAULT_CHUNK_SIZE),
-        overlap   = lopts.overlapPx  or DEFAULT_CHUNK_OVERLAP,
-        keyPrefix = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
-                    tostring(layerData.tiledId or layerName) .. ":",
+        name         = layerName,
+        layer        = layerData,
+        size         = size,
+        overlap      = overlap,
+        bufferWidth  = bufferSize,
+        bufferHeight = bufferSize,
+        keyPrefix    = "chunk:" .. (self._mapCacheId or "map") .. ":" ..
+                       tostring(layerData.tiledId or layerName) .. ":",
       }
     end
   end
@@ -148,7 +153,7 @@ function RoxyOrthoTilemap:_getOrBuildChunk(layerConfig, chunkX, chunkY)
   local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
   return getOrLoadAsset(self._globalChunkBucket, key, function()
     local size, overlap = layerConfig.size, layerConfig.overlap
-    local width, height = size + 2 * overlap, size + 2 * overlap
+    local width, height = layerConfig.bufferWidth, layerConfig.bufferHeight
     local img = newImage(width, height)
 
     -- Convert chunk indices to layer pixel origin for this chunk
@@ -195,7 +200,7 @@ function RoxyOrthoTilemap:_drawStaticLayerChunked(layerName)
         local destX = chunkX * size - overlap + screenX
         local destY = rowDestY
 
-        local imageWidth, imageHeight = img:getSize()
+        local imageWidth, imageHeight = config.bufferWidth, config.bufferHeight
         if not (destX >= DISPLAY_WIDTH or destY >= DISPLAY_HEIGHT
              or destX + imageWidth <= 0 or destY + imageHeight <= 0) then
           img:draw(destX, destY)
@@ -266,9 +271,9 @@ function RoxyOrthoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
   if tiles then
     local stride = layerData.tilesStride or layerData.mapWidth
     if stride and stride > 0 then
-      local idx = (y - 1) * stride + x
-      if idx >= 1 and idx <= #tiles then
-        tiles[idx] = tileIndex
+      local tileOffset = (y - 1) * stride + x
+      if tileOffset >= 1 and tileOffset <= #tiles then
+        tiles[tileOffset] = tileIndex
       end
     end
   end
@@ -457,16 +462,16 @@ end
 -- ! Draw
 -- Draw a single tile layer directly (no sprite required)
 function RoxyOrthoTilemap:draw(layerName)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
+
   if self._staticChunkLayers[layerName] then
     self:_drawStaticLayerChunked(layerName); return
   end
 
-  local layerData = self.layers and self.layers[layerName]
-  if not layerData or not layerData.tilemap or layerData.visible == false then return end
-
   -- Use base helper so tall tiles near edges are included
   local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
-  self:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+  self:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
 end
 
 -- ! Draw Visible
@@ -481,7 +486,7 @@ function RoxyOrthoTilemap:drawVisible()
       local layerData = item.layer
       if layerData.tilemap and layerData.visible ~= false then
         local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
-        self:drawLayerRegion(item.name, minTileX, maxTileX, minTileY, maxTileY)
+        self:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
       end
     end
   end
@@ -494,13 +499,15 @@ function RoxyOrthoTilemap:drawVisibleInRect(x, y, width, height)
   clearClipRect()
 end
 
--- ! Draw Layer Region
--- Region-based renderer that batches via tilemap:drawIgnoringOffset.
-function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
-  local layerData = self.layers and self.layers[layerName]
+-- ! Draw Layer Region Data
+-- Internal region renderer for callers that already have layerData.
+function RoxyOrthoTilemap:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
   if not layerData or not layerData.tilemap or layerData.visible == false then return end
 
-  local mapWidthTiles, mapHeightTiles = layerData.tilemap:getSize()
+  local mapWidthTiles, mapHeightTiles = layerData.mapWidth, layerData.mapHeight
+  if not mapWidthTiles or not mapHeightTiles then
+    mapWidthTiles, mapHeightTiles = layerData.tilemap:getSize()
+  end
   local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
 
   -- Clamp bounds
@@ -536,6 +543,13 @@ function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTile
   )
 end
 
+-- ! Draw Layer Region
+-- Region-based renderer that batches via tilemap:drawIgnoringOffset.
+function RoxyOrthoTilemap:drawLayerRegion(layerName, minTileX, maxTileX, minTileY, maxTileY)
+  local layerData = self.layers and self.layers[layerName]
+  self:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
+end
+
 --------------------------------------------------------------------------------
 -- Cleanup
 --------------------------------------------------------------------------------
@@ -543,6 +557,8 @@ end
 -- ! Destroy
 -- Clean up static layer resources and defer remainder to base class.
 function RoxyOrthoTilemap:destroy()
+  if self._destroyed or self._destroying then return end
+
   -- Clear pre-rendered chunk cache for this map
   if self._globalChunkBucket then
     clearCache(self._globalChunkBucket)
@@ -553,3 +569,54 @@ function RoxyOrthoTilemap:destroy()
 
   RoxyOrthoTilemap.super.destroy(self)
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local scene = RoxyScene()
+
+local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
+  cameraBounds = true,
+  deferCameraBounds = true,
+  wrapInSprites = false,
+  layerOptions = {
+    Ground = {
+      preRenderChunked = true,
+      chunkSizePx = 320,
+      overlapPx = 32,
+    },
+    Props = {
+      zIndex = 10,
+    },
+  },
+}, scene)
+
+function scene:start()
+  map:applyCameraBounds()
+end
+
+function scene:draw()
+  map:drawVisible()
+end
+
+map:setTileAt("Ground", 12, 8, 4, true)
+map:markTilesDirty("Ground", 10, 8, 3, 2)
+
+local row = map:getRowFromScreen(200, 120, "Ground")
+
+local previewImage, offsetX, offsetY = map:getLayerImage("Ground", {
+  tileX = 1,
+  tileY = 1,
+  tileWidth = 10,
+  tileHeight = 8,
+})
+
+map:drawVisibleInRect(0, 0, 400, 120)
+map:drawLayerRegion("Ground", 1, 20, 1, 15)
+
+map:destroy()
+
+]]

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -80,6 +80,7 @@ end
 
 class("RoxyOrthoTilemap").extends(RoxyTilemap)
 
+-- ! Initialize
 function RoxyOrthoTilemap:init(jsonPath, opts, scene)
   opts = opts or {}
   RoxyOrthoTilemap.super.init(self, jsonPath, opts, scene)
@@ -132,15 +133,7 @@ end
 -- ! Utility: Rebuild Ordered Layers
 -- Build a stable, z-sorted draw list once (rarely changes)
 function RoxyOrthoTilemap:_rebuildOrderedLayers()
-  local items = {}
-  for name, layerData in pairs(self.layers) do
-    if layerData.tilemap and layerData.visible ~= false then
-      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
-      tableInsert(items, { layer = layerData, name = name, type = renderType, z = layerData.zIndex or 0 })
-    end
-  end
-  tableSort(items, function(a, b) return a.z < b.z end)
-  self._orderedLayers = items
+  RoxyTilemap._rebuildOrderedLayers(self)
 end
 
 --------------------------------------------------------------------------------
@@ -283,7 +276,7 @@ function RoxyOrthoTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
 
-  self:markLayerImageDirty(layerName)
+  self:_onLayerTilesChanged(layerName, layerData)
 
   if updateSprite then
     local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
@@ -300,6 +293,7 @@ function RoxyOrthoTilemap:_renderLayerToImage(layerName, opts)
   local renderQueue = {}
   local order = 0
 
+  -- ! Helper: Enqueue Layer
   local function enqueueLayer(name, layer)
     if not layer then return end
 
@@ -580,7 +574,6 @@ local scene = RoxyScene()
 
 local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
   cameraBounds = true,
-  deferCameraBounds = true,
   wrapInSprites = false,
   layerOptions = {
     Ground = {
@@ -592,10 +585,11 @@ local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
       zIndex = 10,
     },
   },
-}, scene)
+})
+scene:addTilemap(map)
 
 function scene:start()
-  map:applyCameraBounds()
+  scene:activateCamera({ tilemap = map })
 end
 
 function scene:draw()

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -116,6 +116,7 @@ end
 
 class("RoxyStagTilemap").extends(RoxyTilemap)
 
+-- ! Initialize
 function RoxyStagTilemap:init(jsonPath, opts, scene)
   opts = opts or {}
   opts.wrapInSprites = false
@@ -153,16 +154,9 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   end
   self.worldHeight = worldHeightBase + maxOverdrawPx
 
-  -- Refresh camera bounds if requested
+  -- Store camera bounds for attach/apply time; constructors are load-only.
   if opts and opts.cameraBounds then
-    local x2 = max(0, self.worldWidth - DISPLAY_WIDTH)
-    local y2 = max(0, self.worldHeight - DISPLAY_HEIGHT)
-
-    if type(self.setCameraBounds) == "function" then
-      pcall(function() self:setCameraBounds(0, 0, x2, y2) end)
-    elseif Camera and type(setCameraBounds) == "function" then
-      pcall(function() setCameraBounds({ x1 = 0, y1 = 0, x2 = x2, y2 = y2 }) end)
-    end
+    self:updateCameraBounds(false)
   end
 
   self._projection = "staggered-y"
@@ -330,15 +324,7 @@ end
 -- ! Rebuild Ordered Layers
 -- Build a stable, z-sorted draw list (rarely changes)
 function RoxyStagTilemap:_rebuildOrderedLayers()
-  local items = {}
-  for name, layer in pairs(self.layers) do
-    if layer.tilemap and layer.visible ~= false then
-      local renderType = self._staticChunkLayers[name] and "chunked" or "dynamic"
-      tableInsert(items, { layer = layer, name = name, type = renderType, z = layer.zIndex or 0 })
-    end
-  end
-  tableSort(items, function(a, b) return a.z < b.z end)
-  self._orderedLayers = items
+  RoxyTilemap._rebuildOrderedLayers(self)
 end
 
 -- ! Preload Layer Caches
@@ -402,6 +388,7 @@ function RoxyStagTilemap:_renderLayerToImage(layerName, opts)
   local seen = {}
   local order = 0
 
+  -- ! Helper: Enqueue Layer
   local function enqueueLayer(name, layer)
     if not layer or seen[layer] then return end
 
@@ -599,6 +586,7 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
   -- Respect stagger axis/index/direction like the fast path
+  -- ! Helper: Row Shift X
   local function rowShiftX(row0) return _rowShiftX_for_row0(self, row0, halfWidth) end
 
   local maxImageHeight = layerData.maxImageHeight or 0
@@ -840,7 +828,7 @@ function RoxyStagTilemap:setTileAt(layerName, x, y, tileIndex, updateSprite)
     self:markTilesDirty(layerName, x, y, 1, 1)
   end
 
-  self:markLayerImageDirty(layerName)
+  self:_onLayerTilesChanged(layerName, layer)
 
   if updateSprite and layer.imageTable then
     local tileWidth, tileHeight = layer.tileWidth, layer.tileHeight
@@ -1166,7 +1154,6 @@ local scene = RoxyScene()
 
 local map = RoxyStagTilemap("assets/maps/isometric-test-4.json", {
   cameraBounds = true,
-  deferCameraBounds = true,
   layerOptions = {
     ground = {
       preRenderChunked = true,
@@ -1174,10 +1161,11 @@ local map = RoxyStagTilemap("assets/maps/isometric-test-4.json", {
       overlapPx = 32,
     },
   },
-}, scene)
+})
+scene:addTilemap(map)
 
 function scene:start()
-  map:applyCameraBounds()
+  scene:activateCamera({ tilemap = map })
   map:forceRedraw(2)
 end
 

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -100,6 +100,16 @@ local function _rowShiftX_for_row0(self, row0, halfWidth)
   return (direction == "right") and halfWidth or -halfWidth
 end
 
+-- ! Helper: Camera Position
+-- Reuse drawVisible's camera stamp during a frame; otherwise query once.
+local function _cameraPositionFor(self)
+  local cameraX, cameraY = self._cameraX, self._cameraY
+  if cameraX ~= nil and cameraY ~= nil then
+    return cameraX, cameraY
+  end
+  return getCameraPosition()
+end
+
 --------------------------------------------------------------------------------
 -- ! Class Definition / Initialize
 --------------------------------------------------------------------------------
@@ -113,7 +123,7 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   RoxyStagTilemap.super.init(self, jsonPath, opts, scene)
 
   -- Scratch reused across frames to avoid allocations in _drawStaticLayerChunked
-  self._scratchToDraw = {} -- { {img=..., dx=..., dy=...}, ... }
+  self._chunkDrawScratch = { images = {}, xs = {}, ys = {} }
 
   -- Override world size for staggered-y projection
   local mapWidthTiles   = self.mapWidth  or 0
@@ -179,41 +189,7 @@ function RoxyStagTilemap:init(jsonPath, opts, scene)
   for _, layerData in pairs(self.layers) do
     if layerData.tilemap then
       self:_preloadLayerCaches(layerData)
-
-      -- Create native renderer instance for this layer
-      if layerData.imageTable and newTileRenderer_C then
-        -- Sanitize tiles once on load so the native blob never sees out-of-range values
-        sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
-
-        local isIsometric = 0
-        local staggerIndexOdd = (self.staggerIndex == "odd") and 1 or 0
-        local staggerDirectionRight = (self.staggerDirection == "right") and 1 or 0
-
-        --#DEBUG START
-        if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
-           or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
-          Log.error("[RoxyStagTilemap] Invalid tile metrics; width/height/halves must be > 0")
-        end
-        --#DEBUG END
-
-        layerData._nativeRenderer = newTileRenderer_C(
-          isIsometric,
-          staggerIndexOdd,
-          staggerDirectionRight,
-          layerData.mapWidth,       -- Tiles
-          layerData.mapHeight,      -- Tiles
-          layerData.tileWidth,      -- px
-          layerData.tileHeight,     -- px
-          layerData.halfWidth,      -- px
-          layerData.halfHeight,     -- px
-          layerData.maxImageHeight, -- Tall art overdraw
-          layerData.imageTable,     -- LCDBitmapTable
-          layerData.imageCount,     -- Frames in table
-          nil                       -- Optional tiles blob
-        )
-        layerData.ownerTilemap = self
-        syncNativeTiles(layerData)
-      end
+      self:_createNativeRenderer(layerData)
     end
   end
 
@@ -223,6 +199,75 @@ end
 --------------------------------------------------------------------------------
 -- Internal API
 --------------------------------------------------------------------------------
+
+-- ! Auto Chunk Overlap
+local function _autoChunkOverlap(layer)
+  local tileWidth = layer.tileWidth or 0
+  local halfWidth = layer.halfWidth or floor(tileWidth * 0.5)
+  local tileHeight = layer.tileHeight or 0
+  local maxImageHeight = layer.maxImageHeight or tileHeight
+  local tallOverdraw = max(0, ceil(maxImageHeight - tileHeight))
+
+  return max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+end
+
+-- ! Create Native Renderer
+function RoxyStagTilemap:_createNativeRenderer(layerData)
+  if not layerData or not layerData.imageTable or not newTileRenderer_C then return end
+
+  sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
+
+  local staggerIndexOdd = (self.staggerIndex == "odd") and 1 or 0
+  local staggerDirectionRight = (self.staggerDirection == "right") and 1 or 0
+
+  --#DEBUG START
+  if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
+     or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
+    Log.error("[RoxyStagTilemap] Invalid tile metrics; width/height/halves must be > 0")
+  end
+  --#DEBUG END
+
+  layerData._nativeRenderer = newTileRenderer_C(
+    0,                        -- Staggered
+    staggerIndexOdd,
+    staggerDirectionRight,
+    layerData.mapWidth,       -- Tiles
+    layerData.mapHeight,      -- Tiles
+    layerData.tileWidth,      -- px
+    layerData.tileHeight,     -- px
+    layerData.halfWidth,      -- px
+    layerData.halfHeight,     -- px
+    layerData.maxImageHeight, -- Tall art overdraw
+    layerData.imageTable,     -- LCDBitmapTable
+    layerData.imageCount,     -- Frames in table
+    nil                       -- Optional tiles blob
+  )
+  layerData.ownerTilemap = self
+  syncNativeTiles(layerData)
+end
+
+-- ! Refresh Projection Layer Render Resources
+function RoxyStagTilemap:_refreshProjectionLayerRenderResources(layerName, layerData)
+  if not layerData then return end
+
+  if layerData._nativeRenderer then
+    layerData._nativeRenderer:destroy()
+    layerData._nativeRenderer = nil
+  end
+
+  local layerConfig = self._staticChunkLayers and self._staticChunkLayers[layerName]
+  if layerConfig then
+    if not layerConfig._explicitOverlap then
+      layerConfig.overlap = _autoChunkOverlap(layerData)
+    end
+    layerConfig.imageWidth = layerConfig.size + 2 * layerConfig.overlap
+    layerConfig.imageHeight = layerConfig.imageWidth
+    layerConfig._dirty = true
+  end
+
+  self:_preloadLayerCaches(layerData)
+  self:_createNativeRenderer(layerData)
+end
 
 --
 -- Static Layer Configuration
@@ -239,15 +284,7 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
   for layerName, layer in pairs(self.layers) do
     local layerOpts = layerOptions[layerName] or {}
     if layerOpts.preRenderChunked then
-      local tileWidth = layer.tileWidth or 0
-      local halfWidth = layer.halfWidth or floor(tileWidth * 0.5)
-
-      local tallOverdraw = 0
-      if layer.maxImageHeight and layer.tileHeight then
-        tallOverdraw = max(0, ceil((layer.maxImageHeight - layer.tileHeight) * 0.5))
-      end
-
-      local overlap = layerOpts.overlapPx or max(halfWidth, tallOverdraw, DEFAULT_CHUNK_OVERLAP)
+      local overlap = layerOpts.overlapPx or _autoChunkOverlap(layer)
       local size    = max(1, layerOpts.chunkSizePx or DEFAULT_CHUNK_SIZE)
 
       self._staticChunkLayers[layerName] = {
@@ -259,6 +296,7 @@ function RoxyStagTilemap:_initializeStaticLayers(opts)
         _dirty    = true,
         imageWidth  = size + 2 * overlap,
         imageHeight = size + 2 * overlap,
+        _explicitOverlap = layerOpts.overlapPx ~= nil,
       }
     end
   end
@@ -486,7 +524,7 @@ end
 -- ! Build Chunk
 function RoxyStagTilemap:_buildChunk(layerConfig, chunkX, chunkY)
   local size, overlap = layerConfig.size, layerConfig.overlap
-  local width, height = size + 2 * overlap, size + 2 * overlap
+  local width, height = layerConfig.imageWidth, layerConfig.imageHeight
   local img = newImage(width, height)
   if not img then
     -- Low-memory guard
@@ -647,10 +685,10 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
 
   -- First pass - scan for any missing chunks and enqueue builds.
   local anyMissing = false
-  local toDraw = self._scratchToDraw
-  local count = 0
-
   local imageWidth, imageHeight = layerConfig.imageWidth, layerConfig.imageHeight
+  local scratch = self._chunkDrawScratch
+  local images, xs, ys = scratch.images, scratch.xs, scratch.ys
+  local drawCount = 0
 
   for chunkY = minY, maxY do
     local rowDeltaY = chunkY * size - overlap + screenY
@@ -661,13 +699,10 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
         local dx = chunkX * size - overlap + screenX
         local dy = rowDeltaY
         if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
-          count += 1
-          local slot = toDraw[count]
-          if slot then
-            slot.img, slot.dx, slot.dy = img, dx, dy
-          else
-            toDraw[count] = { img = img, dx = dx, dy = dy }
-          end
+          drawCount += 1
+          images[drawCount] = img
+          xs[drawCount] = dx
+          ys[drawCount] = dy
         end
       else
         anyMissing = true
@@ -677,20 +712,19 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
   end
 
   if anyMissing then
+    for index = 1, drawCount do
+      images[index] = nil
+    end
     setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
       self:drawLayerRows(layerName, nil, nil, nil, nil)
     clearClipRect()
-    -- Trim scratch table length for next frame
-    for i = count + 1, #toDraw do toDraw[i] = nil end
     return
   end
 
-  for i = 1, count do
-    local e = toDraw[i]
-    e.img:draw(e.dx, e.dy)
+  for index = 1, drawCount do
+    images[index]:draw(xs[index], ys[index])
+    images[index] = nil
   end
-  -- Trim for next frame
-  for i = count + 1, #toDraw do toDraw[i] = nil end
 end
 
 --
@@ -706,8 +740,7 @@ function RoxyStagTilemap:worldToScreen(worldX, worldY, layerData)
   local originX, originY = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
 
-  local cameraX = self._cameraX ~= nil and self._cameraX or select(1, getCameraPosition())
-  local cameraY = self._cameraY ~= nil and self._cameraY or select(2, getCameraPosition())
+  local cameraX, cameraY = _cameraPositionFor(self)
 
   local row0 = floor(worldY + FLOAT_EPSILON)
   local shiftX = _rowShiftX_for_row0(self, row0, halfWidth)
@@ -733,8 +766,7 @@ function RoxyStagTilemap:screenToWorld(screenX, screenY, layerData)
   local originX, originY = layerData.originX or 0, layerData.originY or 0
   local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
 
-  local cameraX = self._cameraX ~= nil and self._cameraX or select(1, getCameraPosition())
-  local cameraY = self._cameraY ~= nil and self._cameraY or select(2, getCameraPosition())
+  local cameraX, cameraY = _cameraPositionFor(self)
 
   local parallaxOriginX = layerData.parallaxoriginx or 0
   local parallaxOriginY = layerData.parallaxoriginy or 0
@@ -869,14 +901,14 @@ end
 -- ! Draw
 -- Draw a single layer (chunked or dynamic fallback)
 function RoxyStagTilemap:draw(layerName)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap or layerData.visible == false then return end
+
   if self._staticChunkLayers[layerName] then
     self:_drawStaticLayerChunked(layerName); return
   end
 
-  -- Dynamic fallback (rare): draw only visible rows/cols with coarse margin
-  local layerData = self.layers and self.layers[layerName]
-  if not layerData or not layerData.tilemap or layerData.visible == false then return end
-
+  -- Dynamic fallback (rare): draw only visible rows and columns with coarse margin
   local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
 
   local leftWorld, topWorld = self:screenToWorld(0, 0, layerData)
@@ -992,7 +1024,7 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
     local parallaxX, parallaxY  = layerData.parallaxx or 1, layerData.parallaxy or 1
     local parallaxOriginX       = layerData.parallaxoriginx or 0
     local parallaxOriginY       = layerData.parallaxoriginy or 0
-    local cameraX, cameraY      = getCameraPosition()
+    local cameraX, cameraY      = _cameraPositionFor(self)
 
     local tr = layerData._nativeRenderer
     if tr then
@@ -1051,7 +1083,7 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   local parallaxOriginY       = layerData.parallaxoriginy or 0
   local pivotAdjustX          = parallaxOriginX * (1 - parallaxX)
   local pivotAdjustY          = parallaxOriginY * (1 - parallaxY)
-  local cameraX, cameraY      = getCameraPosition()
+  local cameraX, cameraY      = _cameraPositionFor(self)
   local halfWidth, halfHeight = layerData.halfWidth, layerData.halfHeight
 
   layerData._imageCache  = layerData._imageCache  or {}
@@ -1103,6 +1135,8 @@ end
 -- ! Destroy
 -- Clean up static layer resources
 function RoxyStagTilemap:destroy()
+  if self._destroyed or self._destroying then return end
+
   -- Destroy native renderers first
   for _, layerData in pairs(self.layers or {}) do
     if layerData._nativeRenderer then
@@ -1121,3 +1155,45 @@ function RoxyStagTilemap:destroy()
 
   RoxyStagTilemap.super.destroy(self)
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local scene = RoxyScene()
+
+local map = RoxyStagTilemap("assets/maps/isometric-test-4.json", {
+  cameraBounds = true,
+  deferCameraBounds = true,
+  layerOptions = {
+    ground = {
+      preRenderChunked = true,
+      chunkSizePx = 256,
+      overlapPx = 32,
+    },
+  },
+}, scene)
+
+function scene:start()
+  map:applyCameraBounds()
+  map:forceRedraw(2)
+end
+
+function scene:draw()
+  map:drawVisible()
+end
+
+map:setTileAt("ground", 8, 10, 2, true)
+map:markTilesDirty("ground", 8, 10, 2, 2)
+
+local row = map:getRowFromScreen(200, 120, "ground")
+map:drawLayerRows("ground", 1, row, 1, 16)
+
+local previewImage, offsetX, offsetY = map:getLayerImage("ground")
+
+map:drawVisibleInRect(0, 0, 400, 240)
+map:destroy()
+
+]]

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -54,6 +54,8 @@ local sanitizeTileIndex       <const> = TilemapHelpers.sanitizeTileIndex
 local sanitizeTilesInPlace    <const> = TilemapHelpers.sanitizeTilesInPlace
 local syncNativeTiles         <const> = TilemapHelpers.syncNativeTiles
 local dequeueBestWarmJob      <const> = TilemapHelpers.dequeueBestWarmJob
+local clearChunkDrawScratch   <const> = TilemapHelpers.clearChunkDrawScratch
+local recordPerfCount         <const> = TilemapHelpers.recordPerfCount --#DEBUG
 
 -- C-side bindings
 local newTileRenderer_C <const> = RoxyTileRendererC and RoxyTileRendererC.new or nil
@@ -354,8 +356,9 @@ end
 -- Amortize chunk builds across frames
 function RoxyStagTilemap:_warmSomeChunks()
   local built = 0
+  local centerCache = {}
   while built < BUILD_BUDGET and #self._warmQueue > 0 do
-    local job = dequeueBestWarmJob(self)
+    local job = dequeueBestWarmJob(self, centerCache)
     if not job then break end
     if not getIsAssetCached(self._globalChunkBucket, job.key) then
       local img = self:_buildChunk(job.layerConfig, job.chunkX, job.chunkY)
@@ -570,11 +573,13 @@ function RoxyStagTilemap:_renderLayerToBuffer(layerData, targetImage, offsetX, o
 
   -- Fast path: native renderer to a real LCDBitmap
   if nativeRenderer and targetImage ~= nil then
+    recordPerfCount("tilemap.nativeBuffer.stag") --#DEBUG
     nativeRenderer:renderToBuffer(targetImage, offsetX, offsetY, bufferWidth, bufferHeight)
     return
   end
 
   -- Fallback Lua implementation (rare in practice)
+  recordPerfCount("tilemap.luaBuffer.stag") --#DEBUG
   Log.debug("[_renderLayerToBuffer] Falling back on Lua implementation") --#DEBUG
 
   local imageTable = layerData.imageTable
@@ -684,6 +689,7 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
       local key = layerConfig.keyPrefix .. chunkX .. ":" .. chunkY
       local img = getCachedAsset(self._globalChunkBucket, key)
       if img then
+        recordPerfCount("tilemap.chunkHit.stag") --#DEBUG
         local dx = chunkX * size - overlap + screenX
         local dy = rowDeltaY
         if dx < DISPLAY_WIDTH and dy < DISPLAY_HEIGHT and (dx + imageWidth) > 0 and (dy + imageHeight) > 0 then
@@ -693,6 +699,7 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
           ys[drawCount] = dy
         end
       else
+        recordPerfCount("tilemap.chunkMiss.stag") --#DEBUG
         anyMissing = true
         self:_enqueueWarm(layerConfig, chunkX, chunkY)
       end
@@ -700,9 +707,7 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
   end
 
   if anyMissing then
-    for index = 1, drawCount do
-      images[index] = nil
-    end
+    clearChunkDrawScratch(scratch, drawCount)
     setClipRect(0, 0, DISPLAY_WIDTH, DISPLAY_HEIGHT)
       self:drawLayerRows(layerName, nil, nil, nil, nil)
     clearClipRect()
@@ -711,8 +716,8 @@ function RoxyStagTilemap:_drawStaticLayerChunked(layerName)
 
   for index = 1, drawCount do
     images[index]:draw(xs[index], ys[index])
-    images[index] = nil
   end
+  clearChunkDrawScratch(scratch, drawCount)
 end
 
 --
@@ -1016,6 +1021,7 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
 
     local tr = layerData._nativeRenderer
     if tr then
+      recordPerfCount("tilemap.nativeRows.stag") --#DEBUG
       tr:drawRows(
         rowStart, rowEnd,
         minX, maxX,
@@ -1034,6 +1040,7 @@ function RoxyStagTilemap:drawLayerRows(layerName, minRow, maxRow, minColumn, max
   --
 
   Log.debug("[drawLayerRows] Falling back on Lua implementation") --#DEBUG
+  recordPerfCount("tilemap.luaRows.stag") --#DEBUG
 
   local imageTable = layerData.imageTable
   if not imageTable then

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -71,8 +71,7 @@ local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
 
 -- Shared reference counts for all RoxyTilemap instances.
--- Be sure to call _retain/_release in pairs so you don't
--- evict an asset another map still needs.
+-- Call _retain/_release in pairs so assets another map needs are not evicted.
 local referenceCount = {}
 
 --------------------------------------------------------------------------------
@@ -94,6 +93,16 @@ local function _removeSpritesFromScene(scene, sprites)
     for i = 1, #sprites do
       sprites[i]:remove()
     end
+  end
+end
+
+-- ! Helper: Add Sprites To Scene
+-- Adds a batch through scene ownership so pooled re-add paths stay consistent.
+local function _addSpritesToScene(scene, sprites)
+  if not scene or not sprites or #sprites == 0 then return end
+
+  for i = 1, #sprites do
+    scene:addSprite(sprites[i])
   end
 end
 
@@ -198,11 +207,24 @@ end
 -- Configuration & Validation Helpers
 --
 
+local REMOVED_OPTIONS <const> = {
+  layers = "use tileLayers for tile-layer load selection",
+  deferCameraBounds = "constructors always store camera bounds for explicit activation",
+  deferLayerSprites = "layer sprites are created during scene attachment",
+  deferObjectProcessing = "object sprites are created during scene attachment",
+}
+
 -- ! Helper: Validate Options
 -- Ensures all required options have sensible defaults
 local function _validateOptions(opts)
   -- Mutate the original options table instead of creating a new one
   opts = opts or {}
+
+  for optionName, message in pairs(REMOVED_OPTIONS) do
+    if opts[optionName] ~= nil then
+      error("[RoxyTilemap:_validateOptions] Unsupported option '" .. optionName .. "': " .. message, 3)
+    end
+  end
 
   -- Only create layerOptions table if it doesn't exist
   if not opts.layerOptions then
@@ -228,16 +250,14 @@ local function _validateOptions(opts)
     end
   end
 
-  -- Set defaults directly on options
-  if opts.layers == nil then opts.layers = {} end
+  -- Set defaults directly on options. Preserve nil versus empty selection tables:
+  -- Nil means "load all"; an empty table means "load none".
   if opts.wrapInSprites == nil then opts.wrapInSprites = true end
   if opts.zIndices == nil or type(opts.zIndices) ~= "table" then opts.zIndices = {} end
   if opts.cameraBounds == nil then opts.cameraBounds = false end
-  if opts.deferCameraBounds == nil then opts.deferCameraBounds = false end
   if opts.anchor == nil or opts.anchor ~= "topLeft" then opts.anchor = "center" end
   if opts.collisionResponse == nil then opts.collisionResponse = "overlap" end
   if opts.wallCollidesWithGroups == nil then opts.wallCollidesWithGroups = {} end
-  if opts.objectLayers == nil then opts.objectLayers = {} end
 
   -- Return the mutated options instead of a new table
   return opts
@@ -248,6 +268,7 @@ end
 --
 
 -- ! Clone Table
+-- Returns a shallow copy, or nil when the source is nil.
 local function _cloneTable(source)
   if not source then return nil end
   local clone = {}
@@ -258,10 +279,11 @@ local function _cloneTable(source)
 end
 
 -- ! Normalize Composite List
+-- Builds a deduplicated composite layer list for layer image handles.
 local function _normalizeCompositeList(primaryName, opts)
   if not opts then return nil end
 
-  local list = opts.compositeLayers or opts.layers
+  local list = opts.compositeLayers
   if type(list) ~= "table" then return nil end
 
   local deduped = {}
@@ -279,6 +301,7 @@ local function _normalizeCompositeList(primaryName, opts)
 end
 
 -- ! Build Image Handle Key
+-- Builds a stable cache key for a primary layer and optional composites.
 local function _buildImageHandleKey(layerName, compositeLayers, opts)
   if opts and opts.cacheKey then
     return tostring(opts.cacheKey)
@@ -302,12 +325,12 @@ end
 --
 
 -- ! Helper: Create Parallax Update Function
--- Creates an update function for parallax sprites (hoisted to avoid per-sprite function creation)
+-- Creates a parallax updater hoisted away from object creation hot paths
 local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, roundFn, cameraGetter)
   return function(self)
     local cameraX, cameraY = cameraGetter()
 
-    -- Apply parallax origin pivot (consistent with projection classes)
+    -- Apply parallax origin pivot consistent with projection classes
     local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
     local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
 
@@ -327,29 +350,24 @@ end
 
 class("RoxyTilemap").extends(Object)
 
---[[
-  jsonPath: string - Path to Tiled JSON map
-  opts:   table  - Configuration opts (see _validateOptions)
-  scene:  table? - Optional scene object with addSprite method
-]]
+-- ! Initialize
+-- Parameter jsonPath: path to a Tiled JSON map
+-- Parameter opts: configuration options; see _validateOptions
+-- Parameter scene: unsupported; attach maps with scene:addTilemap(map)
 function RoxyTilemap:init(jsonPath, opts, scene)
+  --#DEBUG START
+  if scene ~= nil then
+    error("[RoxyTilemap:init] Expected RoxyTilemap(jsonPath, opts); attach with scene:addTilemap(map)", 2)
+  end
+  --#DEBUG END
+
   opts = _validateOptions(opts)
   self._opts = opts
-  self.scene = scene
+  self.scene = nil
   self._retainedPaths = {}
   self._layerImageHandles = {}
   self._destroying = false
   self._destroyed = false
-
-  local autoAdd = opts.wrapInSprites and (opts.autoAddSprites ~= false)
-  local sceneHasAdd = scene and type(scene) == "table" and type(scene.addSprite) == "function" or false
-
-  --#DEBUG START
-  if scene and not sceneHasAdd then
-    Log.warn("[RoxyTilemap:init] RoxyTilemap: scene provided but has no addSprite method")
-    -- Will fall back to sprite:add()
-  end
-  --#DEBUG END
 
   -- Load the map JSON
   local mapData, err = loadJSON(jsonPath)
@@ -386,8 +404,8 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   end
   tableSort(gidRanges, function(rangeA, rangeB) return rangeA.first < rangeB.first end)
 
-  -- Helper: Find tileset for a given GID
-  -- Use binary search over sorted gidRanges (firstgid ascending)
+  -- ! Helper: Tileset For GID
+  -- Uses binary search over sorted gidRanges
   local function _tilesetForGid(gid)
     local lo, hi = 1, #gidRanges
     local candidate = nil
@@ -415,15 +433,8 @@ function RoxyTilemap:init(jsonPath, opts, scene)
       x2 = max(0, self.worldWidth  - DISPLAY_WIDTH),
       y2 = max(0, self.worldHeight - DISPLAY_HEIGHT),
     }
-
-    if opts.deferCameraBounds == true then
-      -- store for later, do NOT apply now (Loader scene)
-      self._pendingCameraBounds = bounds
-    else
-      -- apply immediately
-      setCameraBounds(bounds)
-      self._pendingCameraBounds = nil
-    end
+    self._cameraBounds = bounds
+    self._pendingCameraBounds = bounds
   end
 
   -- Get map-level parallax origins
@@ -482,11 +493,12 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   -- Build layers
   self.layers = {}
   local newSprites = {}
-  self.layerManager = LayerManager(self._opts, scene, self.layers, newSprites)
-  local processAllLayers = next(opts.layers) == nil -- Process all if none specified
+  self.layerManager = LayerManager(self._opts, nil, self.layers, newSprites)
+  local tileLayerSelection = opts.tileLayers
+  local processAllTileLayers = tileLayerSelection == nil
 
-  for _, layer in ipairs(mapData.layers or {}) do
-    if layer.type == "tilelayer" and (processAllLayers or opts.layers[layer.name]) then
+  for layerIndex, layer in ipairs(mapData.layers or {}) do
+    if layer.type == "tilelayer" and (processAllTileLayers or tileLayerSelection[layer.name]) then
       local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
 
       -- Reject unsupported Tiled features before converting GIDs to tile indices
@@ -531,6 +543,7 @@ function RoxyTilemap:init(jsonPath, opts, scene)
         -- Create layer data structure
         local layerData = {
           name = layer.name,
+          tiledOrder = layerIndex,
           tilemap = tilemap,
           tiledId = layer.id,
           anchor = opts.anchor,
@@ -579,76 +592,215 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 
         self.layerManager:addLayer(layerData)
 
-        -- Add collision sprites if layer is collidable
+        -- Store collision config for lazy attach-time sprite creation
         if layerOptions.collidable == true then
-          local emptyIDs = layerOptions.emptyIDs or {}
-          local wallGroup = layerOptions.wallSpriteGroup or opts.wallSpriteGroup
-          local layerCollidesWithGroups = layerOptions.wallCollidesWithGroups or opts.wallCollidesWithGroups
-
-          local collisionSprites = addWallSprites(tilemap, emptyIDs)
-          for _, sprite in ipairs(collisionSprites) do
-            -- Use const for tag instead of magic number
-            sprite:setTag(WALL_TAG)
-            sprite:setCollideRect(0, 0, sprite:getSize())
-
-            if wallGroup then
-              sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
-            end
-
-            if layerCollidesWithGroups and type(layerCollidesWithGroups) == "table" and #layerCollidesWithGroups > 0 then
-              sprite:setCollidesWithGroups(layerCollidesWithGroups)
-            end
-
-            -- Default collisionResponse from layerOptions or global, not hard-coded
-            sprite.collisionResponse = layerOptions.collisionResponse or opts.collisionResponse
-          end
-          layerData.collisionSprites = collisionSprites
+          layerData.collisionConfig = {
+            emptyIDs = layerOptions.emptyIDs or {},
+            wallGroup = layerOptions.wallSpriteGroup or opts.wallSpriteGroup,
+            collidesWithGroups = layerOptions.wallCollidesWithGroups or opts.wallCollidesWithGroups,
+            collisionResponse = layerOptions.collisionResponse or opts.collisionResponse,
+          }
+          layerData._collisionDirty = true
         end
       end
     end
     ::continueLayer::
   end
-  -- Optionally defer sprite creation for layers
-  -- Default behavior remains "create now" unless explicitly deferred
-  if self._opts.wrapInSprites and (self._opts.deferLayerSprites ~= true) then
-    self.layerManager:ensureSpritesForAll()
-  end
   self.sprites = newSprites
 
-  -- Optional deferral of object-layer processing
-  local shouldDeferObjects = (opts.deferObjectProcessing == true)
-
-  -- Process object layers now unless deferred
-  local objectSprites = {}
-  if not shouldDeferObjects then
-    for _, layer in ipairs(mapData.layers or {}) do
-      if layer.type == "objectgroup" and (processAllLayers or opts.objectLayers[layer.name]) then
-        local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or EMPTY_TABLE
-        local sprites = processObjectLayer(layer, opts, layerOptions, autoAdd, scene, sceneHasAdd, newSprites)
-        objectSprites[layer.name] = sprites
-      end
-    end
-  end
-  self.objectSprites = objectSprites
+  self.objectSprites = {}
 
   -- Keep raw object data for later on-demand processing
   self.objectLayers = {}
-  for _, layer in ipairs(mapData.layers or {}) do
+  for layerIndex, layer in ipairs(mapData.layers or {}) do
     if layer.type == "objectgroup" then
-      -- Store name, objects, and Tiled per-layer parallax so deferred processing can inherit it
+      -- Store name, objects, and Tiled per-layer parallax for deferred processing
       self.objectLayers[layer.name] = {
         name      = layer.name,
+        tiledOrder = layerIndex,
         objects   = layer.objects or {},
         parallaxx = tonumber(layer.parallaxx),
         parallaxy = tonumber(layer.parallaxy),
       }
     end
   end
+end
 
-  -- Attach to a scene immediately if it supports tilemaps
-  if scene and scene.addTilemap then
-    scene:addTilemap(self)
+--------------------------------------------------------------------------------
+-- Scene Attachment
+--------------------------------------------------------------------------------
+
+-- ! Configure Collision Sprites
+-- Applies tag, group, and response options to wall sprites.
+function RoxyTilemap:_configureCollisionSprites(sprites, config)
+  if not sprites or not config then return end
+
+  for _, sprite in ipairs(sprites) do
+    sprite:setTag(WALL_TAG)
+    sprite:setCollideRect(0, 0, sprite:getSize())
+
+    local wallGroup = config.wallGroup
+    if wallGroup then
+      sprite:setGroups(type(wallGroup) == "table" and wallGroup or { wallGroup })
+    end
+
+    local collidesWithGroups = config.collidesWithGroups
+    if collidesWithGroups and type(collidesWithGroups) == "table" and #collidesWithGroups > 0 then
+      sprite:setCollidesWithGroups(collidesWithGroups)
+    end
+
+    sprite.collisionResponse = config.collisionResponse or "overlap"
   end
+end
+
+-- ! Rebuild Layer Collision Sprites
+-- Recreates wall sprites for one layer from its current tile values.
+function RoxyTilemap:_rebuildLayerCollisionSprites(layerData, config)
+  if not layerData or not layerData.tilemap then return nil end
+  config = config or layerData.collisionConfig
+  if not config then return nil end
+
+  if layerData.collisionSprites then
+    _removeSpritesFromScene(self.scene, layerData.collisionSprites)
+    layerData.collisionSprites = nil
+  end
+
+  local collisionSprites = addWallSprites(layerData.tilemap, config.emptyIDs or {})
+  self:_configureCollisionSprites(collisionSprites, config)
+  layerData.collisionSprites = collisionSprites
+  layerData._collisionDirty = false
+  layerData._collisionAttachPending = false
+  return collisionSprites
+end
+
+-- ! Ensure Collision Sprites Attached
+-- Builds or re-adds collision sprites once the scene can own display sprites.
+function RoxyTilemap:_ensureCollisionSpritesAttached(scene)
+  local sceneEntered = scene and scene._didEnter
+
+  for _, layerData in pairs(self.layers or {}) do
+    if layerData.collisionConfig then
+      if not layerData.collisionSprites or layerData._collisionDirty then
+        if not sceneEntered then
+          layerData._collisionAttachPending = true
+          goto continueCollisionLayer
+        end
+        self:_rebuildLayerCollisionSprites(layerData, layerData.collisionConfig)
+      end
+      _addSpritesToScene(scene, layerData.collisionSprites)
+    end
+    ::continueCollisionLayer::
+  end
+end
+
+-- ! Ensure Object Sprites Attached
+-- Processes pending object layers and re-adds preserved object sprites.
+function RoxyTilemap:_ensureObjectSpritesAttached(scene)
+  local opts = self._opts or {}
+  local objectSelection = opts.objectLayers
+  local objectSprites = self.objectSprites or {}
+
+  for layerName, _ in pairs(self.objectLayers or {}) do
+    local shouldProcess = objectSelection == nil or objectSelection[layerName]
+    if shouldProcess and not objectSprites[layerName] then
+      self:processObjectLayers({ [layerName] = true }, false, nil)
+      objectSprites = self.objectSprites or objectSprites
+    end
+  end
+
+  if opts.wrapInSprites == false or opts.autoAddSprites == false then
+    return
+  end
+
+  for _, sprites in pairs(objectSprites) do
+    _addSpritesToScene(scene, sprites)
+  end
+end
+
+-- ! Attach To Scene
+-- Attaches layer, object, and collision sprites to a scene.
+function RoxyTilemap:attachToScene(scene)
+  if self._destroyed then
+    Log.warn("[RoxyTilemap:attachToScene] Cannot attach destroyed tilemap") --#DEBUG
+    return false
+  end
+
+  if not scene or type(scene.addSprite) ~= "function" then
+    Log.warn("[RoxyTilemap:attachToScene] Expected a scene with addSprite") --#DEBUG
+    return false
+  end
+
+  if self.scene == scene then
+    return true
+  end
+
+  if self.scene and self.scene ~= scene then
+    Log.warn("[RoxyTilemap:attachToScene] Tilemap is already attached to another scene") --#DEBUG
+    return false
+  end
+
+  self.scene = scene
+
+  if self.layerManager then
+    self.layerManager:setScene(scene)
+    if self._opts.wrapInSprites then
+      self.layerManager:ensureSpritesForAll()
+    end
+  end
+
+  self:_ensureCollisionSpritesAttached(scene)
+  self:_ensureObjectSpritesAttached(scene)
+
+  return true
+end
+
+-- ! Scene Did Enter
+-- Builds display-bound resources that were deferred during pre-enter attach.
+function RoxyTilemap:sceneDidEnter(scene)
+  if self.scene ~= scene then return false end
+  self:_ensureCollisionSpritesAttached(scene)
+  return true
+end
+
+-- ! Detach From Scene
+-- Removes scene/display ownership while preserving reusable resources.
+function RoxyTilemap:detachFromScene()
+  local scene = self.scene
+
+  if self.layerManager then
+    self.layerManager:detach()
+  end
+
+  local collisionSprites = nil
+  for _, layerData in pairs(self.layers or {}) do
+    if layerData.collisionSprites then
+      for _, sprite in ipairs(layerData.collisionSprites) do
+        collisionSprites = collisionSprites or {}
+        tableInsert(collisionSprites, sprite)
+      end
+    end
+  end
+  _removeSpritesFromScene(scene, collisionSprites)
+
+  local objectSprites = nil
+  for _, sprites in pairs(self.objectSprites or {}) do
+    for _, sprite in ipairs(sprites) do
+      objectSprites = objectSprites or {}
+      tableInsert(objectSprites, sprite)
+    end
+  end
+  _removeSpritesFromScene(scene, objectSprites)
+
+  if scene and scene._unregisterTilemap then
+    scene:_unregisterTilemap(self)
+  else
+    self.scene = nil
+    if self.layerManager then
+      self.layerManager:setScene(nil)
+    end
+  end
+
+  return true
 end
 
 --------------------------------------------------------------------------------
@@ -658,17 +810,30 @@ end
 -- ! Apply Camera Bounds
 -- Apply the precomputed bounds now (e.g., when a scene enters)
 function RoxyTilemap:applyCameraBounds()
-  local pending = self._pendingCameraBounds
-  if pending then
-    setCameraBounds(pending)
+  local bounds = self._cameraBounds or self._pendingCameraBounds
+  if bounds then
+    setCameraBounds(bounds)
     self._pendingCameraBounds = nil
     return true
   end
   return false
 end
 
+-- ! Get Camera Bounds
+-- Returns a copy of stored camera bounds without applying them.
+function RoxyTilemap:getCameraBounds()
+  local bounds = self._cameraBounds or self._pendingCameraBounds
+  if not bounds then return nil end
+  return {
+    x1 = bounds.x1,
+    y1 = bounds.y1,
+    x2 = bounds.x2,
+    y2 = bounds.y2,
+  }
+end
+
 -- ! Update Camera Bounds
--- Recompute (in case the display size or map changed) and optionally apply or defer
+-- Recompute bounds after a display or map-size change and optionally apply them.
 function RoxyTilemap:updateCameraBounds(shouldApply)
   local bounds = {
     x1 = 0,
@@ -676,6 +841,7 @@ function RoxyTilemap:updateCameraBounds(shouldApply)
     x2 = max(0, self.worldWidth  - DISPLAY_WIDTH),
     y2 = max(0, self.worldHeight - DISPLAY_HEIGHT),
   }
+  self._cameraBounds = bounds
   if shouldApply then
     setCameraBounds(bounds)
     self._pendingCameraBounds = nil
@@ -1014,6 +1180,33 @@ function RoxyTilemap:_clearLayerChunkState(layerName, removeConfig)
   self._frameDirty = true
 end
 
+-- ! Rebuild Ordered Layers
+-- Cold-path stable z-order cache used by projection draw loops.
+function RoxyTilemap:_rebuildOrderedLayers()
+  local items = {}
+  local staticLayers = self._staticChunkLayers or EMPTY_TABLE
+
+  for name, layerData in pairs(self.layers or EMPTY_TABLE) do
+    if layerData.tilemap and layerData.visible ~= false then
+      local renderType = staticLayers[name] and "chunked" or "dynamic"
+      tableInsert(items, {
+        layer = layerData,
+        name = name,
+        type = renderType,
+        z = layerData.zIndex or 0,
+        order = layerData.tiledOrder or 0,
+      })
+    end
+  end
+
+  tableSort(items, function(a, b)
+    if a.z == b.z then return a.order < b.order end
+    return a.z < b.z
+  end)
+
+  self._orderedLayers = items
+end
+
 -- ! Layer Structure Changed
 -- Invalidates ordered layers and render state after hide/show/remove.
 function RoxyTilemap:_onLayerStructureChanged(layerName, reason, layerData)
@@ -1050,6 +1243,20 @@ function RoxyTilemap:_onLayerRenderResourcesChanged(layerName)
   end
 end
 
+-- ! Layer Tiles Changed
+-- Marks derived state that depends on tile values.
+function RoxyTilemap:_onLayerTilesChanged(layerName, layerData)
+  layerData = layerData or (self.layers and self.layers[layerName])
+  if not layerData then return end
+
+  if layerData.collisionConfig then
+    layerData._collisionDirty = true
+  end
+
+  self:markLayerImageDirty(layerName)
+  self._frameDirty = true
+end
+
 --------------------------------------------------------------------------------
 -- Layer Visibility & Management
 --------------------------------------------------------------------------------
@@ -1060,7 +1267,9 @@ function RoxyTilemap:hideLayer(name)
   local layerData = self.layers and self.layers[name]
   if self.layerManager and self.layerManager:hide(name) then
     self:_onLayerStructureChanged(name, "hide", layerData)
+    return true
   end
+  return false
 end
 
 -- ! Show Layer
@@ -1069,9 +1278,19 @@ function RoxyTilemap:showLayer(name)
   local layerData = self.layers and self.layers[name]
   if self.layerManager and self.layerManager:show(name) then
     self:_onLayerStructureChanged(name, "show", layerData)
+    return true
   end
+  return false
 end
 
+-- ! Set Layer Visible
+-- Convenience wrapper for showLayer and hideLayer.
+function RoxyTilemap:setLayerVisible(name, visible)
+  if visible ~= false then
+    return self:showLayer(name)
+  end
+  return self:hideLayer(name)
+end
 
 -- ! Remove Layer
 -- Completely removes a tile layer and cleans up all associated resources
@@ -1079,7 +1298,9 @@ function RoxyTilemap:removeLayer(name)
   local layerData = self.layers and self.layers[name]
   if self.layerManager and self.layerManager:remove(name) then
     self:_onLayerStructureChanged(name, "remove", layerData)
+    return true
   end
+  return false
 end
 
 --------------------------------------------------------------------------------
@@ -1087,12 +1308,12 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Set Layer Image Table
--- Swap the image table used by a tile layer at runtime
--- newImageTableOrPath: a Playdate image table object or a string path (Tiled/normalized)
--- remapFn: optional table or function to remap tile indices (oldIndex --> newIndex)
+-- Swap the image table used by a tile layer at runtime.
+-- Parameter newImageTableOrPath: a Playdate image table object or a string path.
+-- Parameter remapFn: optional table or function to remap tile indices (oldIndex --> newIndex).
 --   - If a table, remapFn[oldIndex] = newIndex
 --   - If a function, newIndex = remapFn(oldIndex) (return nil to keep oldIndex)
--- Does not rebuild collision sprites; call rebuildLayerCollisions if passability changes
+-- Does not rebuild collision sprites; call rebuildLayerCollisions if passability changes.
 function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   local updated = self.layerManager and self.layerManager:setImageTable(name, newImageTableOrPath, remapFn)
   if updated then
@@ -1103,8 +1324,8 @@ function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
 end
 
 -- ! Rebuild Layer Collisions
--- Recreates wall sprites for a tile layer using the provided emptyIDs
--- Use when a tileset swap changes which tile indices should be passable vs solid
+-- Recreates wall sprites for a tile layer using the provided emptyIDs.
+-- Use when a tileset swap changes which tile indices should be passable or solid.
 function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesWithGroups, collisionResponse)
   local layerData = self.layers and self.layers[name]
   if not layerData or not layerData.tilemap then return end
@@ -1130,35 +1351,26 @@ function RoxyTilemap:rebuildLayerCollisions(name, emptyIDs, wallGroup, collidesW
     or global.collisionResponse
     or "overlap"
 
-  -- Remove previous collision sprites
-  if layerData.collisionSprites then
-    for _, sprite in ipairs(layerData.collisionSprites) do
-      sprite:remove()
+  layerData.collisionConfig = {
+    emptyIDs = resolvedEmptyIDs,
+    wallGroup = resolvedWallGroup,
+    collidesWithGroups = resolvedCollidesWithGroups,
+    collisionResponse = resolvedResponse,
+  }
+
+  if not (self.scene and self.scene._didEnter) then
+    if layerData.collisionSprites then
+      _removeSpritesFromScene(self.scene, layerData.collisionSprites)
+      layerData.collisionSprites = nil
     end
-    layerData.collisionSprites = nil
+    layerData._collisionDirty = true
+    layerData._collisionAttachPending = true
+    return nil
   end
 
-  -- Build new collision sprites from current tile indices
-  local collisionSprites = addWallSprites(layerData.tilemap, resolvedEmptyIDs)
-
-  -- Configure sprites with collision properties
-  for _, sprite in ipairs(collisionSprites) do
-    -- Use const for tag, apply resolved defaults
-    sprite:setTag(WALL_TAG)
-    sprite:setCollideRect(0, 0, sprite:getSize())
-
-    if resolvedWallGroup then
-      sprite:setGroups(type(resolvedWallGroup) == "table" and resolvedWallGroup or { resolvedWallGroup })
-    end
-
-    if resolvedCollidesWithGroups and type(resolvedCollidesWithGroups) == "table" and #resolvedCollidesWithGroups > 0 then
-      sprite:setCollidesWithGroups(resolvedCollidesWithGroups)
-    end
-
-    sprite.collisionResponse = resolvedResponse
-  end
-
-  layerData.collisionSprites = collisionSprites
+  local collisionSprites = self:_rebuildLayerCollisionSprites(layerData, layerData.collisionConfig)
+  _addSpritesToScene(self.scene, collisionSprites)
+  return collisionSprites
 end
 
 --------------------------------------------------------------------------------
@@ -1166,15 +1378,26 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Set Layer Origin
--- Updates the origin for a single layer and keeps any display sprite in sync
+-- Updates the origin for a single layer and keeps any display sprite in sync.
 function RoxyTilemap:setLayerOrigin(name, x, y)
-  return self.layerManager and self.layerManager:setOrigin(name, x, y)
+  local updated = self.layerManager and self.layerManager:setOrigin(name, x, y)
+  if updated then
+    self:markLayerImageDirty(name)
+    self._frameDirty = true
+  end
+  return updated
 end
 
 -- ! Set Origin For All Layers
--- Convenience method to apply the same origin to every tile layer
+-- Convenience method to apply the same origin to every tile layer.
 function RoxyTilemap:setOriginForAllLayers(x, y)
-  return self.layerManager and self.layerManager:setOriginForAll(x, y)
+  if not self.layerManager then return false end
+  self.layerManager:setOriginForAll(x, y)
+  for name, _ in pairs(self.layers or {}) do
+    self:markLayerImageDirty(name)
+  end
+  self._frameDirty = true
+  return true
 end
 
 --------------------------------------------------------------------------------
@@ -1541,22 +1764,6 @@ end
 -- Cleanup
 --------------------------------------------------------------------------------
 
--- ! Detach Sprites
-function RoxyTilemap:detachSprites()
-  if self.layerManager then self.layerManager:detach() end
-
-  -- Collect object sprites so the scene can unregister them in one batch
-  local objectSprites = nil
-  for _, sprites in pairs(self.objectSprites or {}) do
-    for _, sprite in ipairs(sprites) do
-      objectSprites = objectSprites or {}
-      tableInsert(objectSprites, sprite)
-    end
-  end
-  _removeSpritesFromScene(self.scene, objectSprites)
-  self.objectSprites = {}
-end
-
 -- ! Destroy
 -- Cleans up all resources and removes sprites from display
 function RoxyTilemap:destroy()
@@ -1642,7 +1849,6 @@ local scene = RoxyScene()
 -- RoxyTilemap is usually instantiated through a projection subclass.
 local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
   cameraBounds = true,
-  deferCameraBounds = true,
   wrapInSprites = true,
   layerOptions = {
     Ground = {
@@ -1661,9 +1867,10 @@ local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
       spriteGroup = 2,
     },
   },
-}, scene)
+})
+scene:addTilemap(map)
 
-map:applyCameraBounds()
+scene:activateCamera({ tilemap = map })
 local worldWidth, worldHeight = map:getWorldSize()
 
 map:hideLayer("Decor")
@@ -1680,6 +1887,8 @@ map:rebuildLayerCollisions("Walls", { 0 })
 map:processObjectLayers({ Objects = true })
 local pickups = map:findObjectSpritesByType("Objects", "pickup")
 
+scene:detachTilemap(map)
+scene:addTilemap(map)
 map:removeObjectLayer("Objects")
 map:removeLayer("Decor")
 map:destroy()

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -11,6 +11,7 @@ local Graphics  <const> = pd.graphics
 local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
 local Camera      <const> = r.Camera
+local Cache       <const> = r.Cache
 
 local min   <const> = math.min
 local max   <const> = math.max
@@ -30,9 +31,10 @@ local setDrawOffset   <const> = Graphics.setDrawOffset
 local newTilemap      <const> = Graphics.tilemap.new
 local addWallSprites  <const> = Graphics.sprite.addWallSprites
 
-local retain          <const> = AssetStore.retain
-local release         <const> = AssetStore.release
-local getImagetable   <const> = AssetStore.getImagetable
+local retain        <const> = AssetStore.retain
+local release       <const> = AssetStore.release
+local getImagetable <const> = AssetStore.getImagetable
+local evictAsset    <const> = Cache.evictAsset
 
 local setCameraBounds   <const> = Camera.setBounds
 
@@ -43,10 +45,13 @@ local processObjectLayers   <const> = ObjectLayerProcessor.processObjectLayers
 
 local IMAGE_PATH_PREFIX <const> = "assets/images/"
 
+local TILED_GID_MASK        <const> = 0x0FFFFFFF
+local TILED_TRANSFORM_MASK  <const> = 0xF0000000
+
 local SPRITE_DEFAULT_DIMS <const> = 16
 
-local WALL_TAG   <const> = 1
-local OBJECT_TAG <const> = 2
+local WALL_TAG    <const> = 1
+local OBJECT_TAG  <const> = 2
 
 local RESERVED_IMAGE_OPTS <const> = {
   registerSprite  = true,
@@ -74,6 +79,24 @@ local referenceCount = {}
 -- Helpers
 --------------------------------------------------------------------------------
 
+-- ! Helper: Remove Sprites From Scene
+-- Uses the scene batch unregister path when available; otherwise removes directly.
+local function _removeSpritesFromScene(scene, sprites)
+  if not sprites or #sprites == 0 then return end
+
+  if scene and scene._unregisterSprites then
+    scene:_unregisterSprites(sprites, true)
+  elseif scene and scene.removeSprite then
+    for i = 1, #sprites do
+      scene:removeSprite(sprites[i])
+    end
+  else
+    for i = 1, #sprites do
+      sprites[i]:remove()
+    end
+  end
+end
+
 --
 -- Asset Management Helpers
 --
@@ -95,6 +118,80 @@ local function _normalizeImagePath(tiledImagePath)
   end
 
   return IMAGE_PATH_PREFIX .. base
+end
+
+-- ! Helper: Clean Tiled GID
+-- Strips Tiled transform bits and returns the raw tile GID.
+local function _cleanTiledGid(rawGid)
+  return (rawGid or 0) & TILED_GID_MASK
+end
+
+-- ! Helper: Has Tiled Transform Flags
+-- Returns true when a Tiled GID includes unsupported transform flags.
+local function _hasTiledTransformFlags(rawGid)
+  return rawGid ~= nil and ((rawGid & TILED_TRANSFORM_MASK) ~= 0)
+end
+
+-- ! Helper: Build Layer Tile Indices
+-- Rejects unsupported Tiled data while converting GIDs in a single pass.
+local function _buildLayerTileIndices(layer, tilesetForGid)
+  local data = layer.data or EMPTY_TABLE
+  local indices = createTable(#data, 0)
+  local usedTileset = nil
+  local firstgid = nil
+  local lastgid = nil
+  local isEmpty = true
+
+  for index = 1, #data do
+    local rawGid = data[index] or 0
+    local tileIndex = 0
+
+    if _hasTiledTransformFlags(rawGid) then
+      error("[RoxyTilemap:init] Unsupported Tiled transform flags in layer '" .. tostring(layer.name) .. "' at tile " .. tostring(index), 2)
+    end
+
+    local gid = _cleanTiledGid(rawGid)
+    if gid ~= 0 then
+      isEmpty = false
+
+      if not usedTileset then
+        usedTileset = tilesetForGid(gid)
+        if usedTileset then
+          firstgid = usedTileset.firstgid
+          lastgid = firstgid + (usedTileset.tilecount or 0) - 1
+        end
+      end
+
+      if usedTileset then
+        if gid < firstgid or gid > lastgid then
+          error("[RoxyTilemap:init] Unsupported mixed tilesets in tile layer '" .. tostring(layer.name) .. "'", 2)
+        end
+        tileIndex = gid - firstgid + 1
+      end
+    end
+
+    indices[index] = tileIndex
+  end
+
+  return usedTileset, indices, isEmpty
+end
+
+-- ! Helper: Remove Keys With Prefix
+-- Evicts every cached asset whose key starts with the layer chunk prefix.
+local function _evictCacheKeysWithPrefix(bucket, prefix)
+  if not bucket or not bucket.cache or not prefix then return end
+
+  local keys = {}
+  local prefixLength = #prefix
+  for key, _ in pairs(bucket.cache) do
+    if tostring(key):sub(1, prefixLength) == prefix then
+      keys[#keys + 1] = key
+    end
+  end
+
+  for index = 1, #keys do
+    evictAsset(bucket, keys[index])
+  end
 end
 
 --
@@ -241,6 +338,8 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   self.scene = scene
   self._retainedPaths = {}
   self._layerImageHandles = {}
+  self._destroying = false
+  self._destroyed = false
 
   local autoAdd = opts.wrapInSprites and (opts.autoAddSprites ~= false)
   local sceneHasAdd = scene and type(scene) == "table" and type(scene.addSprite) == "function" or false
@@ -389,34 +488,13 @@ function RoxyTilemap:init(jsonPath, opts, scene)
   for _, layer in ipairs(mapData.layers or {}) do
     if layer.type == "tilelayer" and (processAllLayers or opts.layers[layer.name]) then
       local layerOptions = (opts.layerOptions and opts.layerOptions[layer.name]) or {}
-      local data = layer.data or {}
 
-      -- Find first nonzero GID and cache the tileset
-      -- We break early for the first non-empty tile to avoid O(n) on dense layers
-      -- For very sparse/empty layers the scan is still O(n); consider precomputing a
-      -- layer->tileset mapping at export time in Tiled for true O(1)
-      local usedTileset = nil
-      for index = 1, #data do
-        local rawGid = data[index]
-        local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
-        if gid ~= 0 then
-          usedTileset = _tilesetForGid(gid)
-          break
-        end
-      end
+      -- Reject unsupported Tiled features before converting GIDs to tile indices
+      local usedTileset, indices, isEmpty = _buildLayerTileIndices(layer, _tilesetForGid)
 
       if not usedTileset then
         Log.warn("[RoxyTilemap:init] Layer '"..layer.name.."' has no matching tileset") --#DEBUG
         goto continueLayer -- Skip this layer if no valid tileset
-      end
-
-      -- Check if layer is non-empty
-      local isEmpty = true
-      for index = 1, #data do
-        if data[index] ~= 0 then
-          isEmpty = false
-          break
-        end
       end
 
       --#DEBUG START
@@ -430,21 +508,11 @@ function RoxyTilemap:init(jsonPath, opts, scene)
 
       -- Only process layers with valid tilesets and non-empty data
       if usedTileset and not isEmpty and usedTileset.imageTable then
-        local firstgid = usedTileset.firstgid
         local tilemap = newTilemap()
         tilemap:setSize(layer.width, layer.height)
         tilemap:setImageTable(usedTileset.imageTable)
 
-        -- Convert GIDs to tilemap indices
-        local indices = createTable(#data, 0)
-        for index = 1, #data do
-          local rawGid = data[index]
-          local gid = rawGid & 0x1FFFFFFF -- Remove flip flags
-          -- Use cached usedTileset instead of calling _tilesetForGid for each tile
-          indices[index] = (gid ~= 0) and (gid - firstgid + 1) or 0
-        end
         tilemap:setTiles(indices, layer.width)
-        local tiles, stride = tilemap:getTiles()
 
         -- Use logical map tile size (e.g., 64x32) for iso math/culling
         -- Actual image size (e.g., 64x64) is handled via per-image offsets
@@ -473,8 +541,8 @@ function RoxyTilemap:init(jsonPath, opts, scene)
           tileHeight = tileHeight,
           halfWidth = tileWidth * 0.5,
           halfHeight = tileHeight * 0.5,
-          tilesFlat  = tiles,
-          tilesStride = stride or layer.width,
+          tilesFlat  = indices,
+          tilesStride = layer.width,
           maxImageHeight = maxImageHeight,
           zIndex = (layerOptions.zIndex or opts.zIndices[layer.name] or 0),
           visible = (layerOptions.visible ~= false),
@@ -709,7 +777,8 @@ end
 -- ! Get Objects
 -- Returns the raw Tiled object data for the specified object layer
 function RoxyTilemap:getObjects(name)
-  return self.objectLayers and self.objectLayers[name]
+  local entry = self.objectLayers and self.objectLayers[name]
+  return entry and entry.objects or nil
 end
 
 -- ! Get Object Sprites
@@ -751,17 +820,35 @@ end
 -- ! Find Object Sprites By Type
 -- Returns all sprites from the layer whose Tiled objects have the specified type
 function RoxyTilemap:findObjectSpritesByType(layerName, objectType)
-  return self:findObjectSprites(layerName, function(object)
-    return object.type == objectType
-  end)
+  local sprites = self:getObjectSprites(layerName)
+  local matches = {}
+
+  for index = 1, #sprites do
+    local sprite = sprites[index]
+    local object = sprite.tiledObject
+    if object and object.type == objectType then
+      matches[#matches + 1] = sprite
+    end
+  end
+
+  return matches
 end
 
 -- ! Find Object Sprites By Name
 -- Returns all sprites from the layer whose Tiled objects have the specified name
 function RoxyTilemap:findObjectSpritesByName(layerName, objectName)
-  return self:findObjectSprites(layerName, function(object)
-    return object.name == objectName
-  end)
+  local sprites = self:getObjectSprites(layerName)
+  local matches = {}
+
+  for index = 1, #sprites do
+    local sprite = sprites[index]
+    local object = sprite.tiledObject
+    if object and object.name == objectName then
+      matches[#matches + 1] = sprite
+    end
+  end
+
+  return matches
 end
 
 -- ! Find Object Sprites
@@ -781,17 +868,18 @@ end
 -- Removes all sprites from an object layer and cleans up references
 function RoxyTilemap:removeObjectLayer(layerName)
   local sprites = self:getObjectSprites(layerName)
+
+  -- Release retained images before unregistering sprites
   for _, sprite in ipairs(sprites) do
     if sprite._retainedImagePath then
       release(sprite._retainedImagePath)
       sprite._retainedImagePath = nil
     end
-    if self.scene and self.scene.removeSprite then
-      self.scene:removeSprite(sprite)
-    else
-      sprite:remove()
-    end
   end
+
+  -- Remove from scene/display in one batch
+  _removeSpritesFromScene(self.scene, sprites)
+
   if self.objectSprites then
     self.objectSprites[layerName] = nil
   end
@@ -805,22 +893,160 @@ end
 -- Returns the tile index at the given tile coordinates (x, y) on the specified layer
 -- Note: Coordinates are in tile units, not pixels
 function RoxyTilemap:getTileAt(name, tileX, tileY)
-  local tilemap = self:getTilemap(name)
-  return tilemap and tilemap:getTileAtPosition(tileX, tileY) or nil
+  local layerData = self.layers and self.layers[name]
+  if not layerData then return nil end
+
+  local tiles = layerData.tilesFlat
+  local stride = layerData.tilesStride or layerData.mapWidth
+  local mapWidth = layerData.mapWidth
+  local mapHeight = layerData.mapHeight
+  if tiles and stride and mapWidth and mapHeight then
+    if tileX < 1 or tileY < 1 or tileX > mapWidth or tileY > mapHeight then return nil end
+    local tileIndex = tiles[(tileY - 1) * stride + tileX]
+    return tileIndex ~= 0 and tileIndex or nil
+  end
+
+  local tilemap = layerData.tilemap
+  local tileIndex = tilemap and tilemap:getTileAtPosition(tileX, tileY) or nil
+  return tileIndex ~= 0 and tileIndex or nil
 end
 
 -- ! For Each Tile
 -- Iterates over each tile on the specified layer, calling the provided function
 -- Note: Coordinates passed to the function are in tile units.
 function RoxyTilemap:forEachTile(name, fn)
-  local tilemap = self:getTilemap(name)
-  if not tilemap or type(fn) ~= "function" then return end
+  local layerData = self.layers and self.layers[name]
+  if not layerData or type(fn) ~= "function" then return end
 
+  local tiles = layerData.tilesFlat
+  local stride = layerData.tilesStride or layerData.mapWidth
+  local width = layerData.mapWidth
+  local height = layerData.mapHeight
+  if tiles and stride and width and height then
+    for tileY = 1, height do
+      local rowOffset = (tileY - 1) * stride
+      for tileX = 1, width do
+        fn(tileX, tileY, tiles[rowOffset + tileX])
+      end
+    end
+    return
+  end
+
+  local tilemap = layerData.tilemap
+  if not tilemap then return end
   local width, height = tilemap:getSize()
   for tileY = 1, height do
     for tileX = 1, width do
       fn(tileX, tileY, tilemap:getTileAtPosition(tileX, tileY))
     end
+  end
+end
+
+-- ! Sync Layer Tiles
+-- Sanitizes cached tile indices and writes them back to the Playdate tilemap.
+function RoxyTilemap:_syncLayerTilesFromTilemap(layerData)
+  if not layerData or not layerData.tilemap then return end
+
+  local tiles, stride = nil, nil
+  if layerData.tilemap.getTiles then
+    tiles, stride = layerData.tilemap:getTiles()
+  end
+  if not tiles then
+    tiles = layerData.tilesFlat
+    stride = layerData.tilesStride or layerData.mapWidth
+  end
+  if not tiles then return end
+
+  local imageCount = layerData.imageCount or 0
+  for index = 1, #tiles do
+    local tileIndex = tiles[index]
+    if tileIndex == nil or tileIndex == 0 then
+      tiles[index] = 0
+    else
+      tiles[index] = (tileIndex >= 1 and tileIndex <= imageCount) and tileIndex or 0
+    end
+  end
+
+  layerData.tilemap:setTiles(tiles, stride or layerData.mapWidth)
+  layerData.tilesFlat = tiles
+  layerData.tilesStride = stride or layerData.mapWidth
+end
+
+-- ! Clear Layer Chunk State
+-- Evicts cached chunks and pending warm jobs for a layer.
+function RoxyTilemap:_clearLayerChunkState(layerName, removeConfig)
+  local staticLayers = self._staticChunkLayers
+  local layerConfig = staticLayers and staticLayers[layerName] or nil
+  if not layerConfig then return end
+
+  local prefix = layerConfig.keyPrefix
+  if prefix then
+    _evictCacheKeysWithPrefix(self._globalChunkBucket, prefix)
+
+    if self._warmQueue then
+      local prefixLength = #prefix
+      for index = #self._warmQueue, 1, -1 do
+        local job = self._warmQueue[index]
+        if job and job.key and tostring(job.key):sub(1, prefixLength) == prefix then
+          tableRemove(self._warmQueue, index)
+        end
+      end
+    end
+
+    if self._warmSet then
+      local prefixLength = #prefix
+      for key, _ in pairs(self._warmSet) do
+        if tostring(key):sub(1, prefixLength) == prefix then
+          self._warmSet[key] = nil
+        end
+      end
+    end
+  end
+
+  layerConfig._dirty = true
+  layerConfig._lastRingBounds = nil
+
+  if removeConfig and staticLayers then
+    staticLayers[layerName] = nil
+  end
+
+  self._didPrimeVisible = false
+  self._frameDirty = true
+end
+
+-- ! Layer Structure Changed
+-- Invalidates ordered layers and render state after hide/show/remove.
+function RoxyTilemap:_onLayerStructureChanged(layerName, reason, layerData)
+  self:markLayerImageDirty(layerName)
+  self._frameDirty = true
+  self._didPrimeVisible = false
+
+  if reason == "remove" then
+    self:_clearLayerChunkState(layerName, true)
+  end
+
+  if type(self._rebuildOrderedLayers) == "function" then
+    self:_rebuildOrderedLayers()
+  end
+end
+
+-- ! Layer Render Resources Changed
+-- Refreshes cached/native render state after image table changes.
+function RoxyTilemap:_onLayerRenderResourcesChanged(layerName)
+  local layerData = self.layers and self.layers[layerName]
+  if not layerData or not layerData.tilemap then return end
+
+  self:_syncLayerTilesFromTilemap(layerData)
+
+  layerData._imageCache = {}
+  layerData._offsetCache = {}
+
+  self:_clearLayerChunkState(layerName, false)
+  self:markLayerImageDirty(layerName)
+  self._frameDirty = true
+
+  if type(self._refreshProjectionLayerRenderResources) == "function" then
+    self:_refreshProjectionLayerRenderResources(layerName, layerData)
   end
 end
 
@@ -831,36 +1057,46 @@ end
 -- ! Hide Layer
 -- Hides a tile layer from rendering (affects both sprites and direct drawing)
 function RoxyTilemap:hideLayer(name)
-  if self.layerManager then self.layerManager:hide(name) end
+  local layerData = self.layers and self.layers[name]
+  if self.layerManager and self.layerManager:hide(name) then
+    self:_onLayerStructureChanged(name, "hide", layerData)
+  end
 end
 
 -- ! Show Layer
 -- Shows a previously hidden tile layer
 function RoxyTilemap:showLayer(name)
-  if self.layerManager then self.layerManager:show(name) end
+  local layerData = self.layers and self.layers[name]
+  if self.layerManager and self.layerManager:show(name) then
+    self:_onLayerStructureChanged(name, "show", layerData)
+  end
 end
 
 
 -- ! Remove Layer
 -- Completely removes a tile layer and cleans up all associated resources
 function RoxyTilemap:removeLayer(name)
-  if self.layerManager then self.layerManager:remove(name) end
+  local layerData = self.layers and self.layers[name]
+  if self.layerManager and self.layerManager:remove(name) then
+    self:_onLayerStructureChanged(name, "remove", layerData)
+  end
 end
 
 --------------------------------------------------------------------------------
 -- Dynamic Layer Modification
 --------------------------------------------------------------------------------
 
--- ! Set Layer ImageTable
--- Swap the imagetable used by a tile layer at runtime
--- newImageTableOrPath: a playdate.graphics.imagetable or a string path (Tiled/normalized)
+-- ! Set Layer Image Table
+-- Swap the image table used by a tile layer at runtime
+-- newImageTableOrPath: a Playdate image table object or a string path (Tiled/normalized)
 -- remapFn: optional table or function to remap tile indices (oldIndex --> newIndex)
 --   - If a table, remapFn[oldIndex] = newIndex
 --   - If a function, newIndex = remapFn(oldIndex) (return nil to keep oldIndex)
+-- Does not rebuild collision sprites; call rebuildLayerCollisions if passability changes
 function RoxyTilemap:setLayerImageTable(name, newImageTableOrPath, remapFn)
   local updated = self.layerManager and self.layerManager:setImageTable(name, newImageTableOrPath, remapFn)
   if updated then
-    self:markLayerImageDirty(name)
+    self:_onLayerRenderResourcesChanged(name)
   end
 
   return updated
@@ -1308,17 +1544,27 @@ end
 -- ! Detach Sprites
 function RoxyTilemap:detachSprites()
   if self.layerManager then self.layerManager:detach() end
+
+  -- Collect object sprites so the scene can unregister them in one batch
+  local objectSprites = nil
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
-      if self.scene and self.scene.removeSprite then self.scene:removeSprite(sprite) else sprite:remove() end
+      objectSprites = objectSprites or {}
+      tableInsert(objectSprites, sprite)
     end
   end
+  _removeSpritesFromScene(self.scene, objectSprites)
   self.objectSprites = {}
 end
 
 -- ! Destroy
 -- Cleans up all resources and removes sprites from display
 function RoxyTilemap:destroy()
+  if self._destroyed or self._destroying then return end
+  self._destroying = true
+
+  local scene = self.scene
+
   -- Manager handles layer sprites, collisions, and swap-retained paths
   if self.layerManager then
     self.layerManager:destroy()
@@ -1346,33 +1592,96 @@ function RoxyTilemap:destroy()
     self._layerImageHandles = nil
   end
 
-  -- Remove object sprites (unchanged from your current logic)
+  -- Release retained images, then unregister object sprites in one batch
+  local objectSprites = nil
   for _, sprites in pairs(self.objectSprites or {}) do
     for _, sprite in ipairs(sprites) do
       if sprite._retainedImagePath then
         release(sprite._retainedImagePath)
         sprite._retainedImagePath = nil
       end
-      -- Always remove the sprite directly;
-      -- the scene will remove the tilemap itself
-      sprite:remove()
+      objectSprites = objectSprites or {}
+      tableInsert(objectSprites, sprite)
     end
   end
+  _removeSpritesFromScene(scene, objectSprites)
 
-  -- Clean up tilesets retained at initialization (unchanged)
+  -- Clean up tilesets retained at initialization
   for _, tileset in pairs(self.tilesets or {}) do
     if tileset.imagePath then
       release(tileset.imagePath)
     end
   end
 
-  -- Clear refs + detach from scene (unchanged)
+  -- Clear refs and detach from scene
   self.layers = {}
   self.sprites = {}
   self.objectSprites = {}
   self.tilesets = nil
   self.objectLayers = nil
 
-  -- Just clear the back-pointer; do not call back into the scene
+  if scene and scene._unregisterTilemap then
+    scene:_unregisterTilemap(self)
+  end
+
   self.scene = nil
+  self._destroyed = true
+  self._destroying = false
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+local Graphics <const> = playdate.graphics
+
+local scene = RoxyScene()
+
+-- RoxyTilemap is usually instantiated through a projection subclass.
+local map = RoxyOrthoTilemap("assets/maps/level-01.json", {
+  cameraBounds = true,
+  deferCameraBounds = true,
+  wrapInSprites = true,
+  layerOptions = {
+    Ground = {
+      preRenderChunked = true,
+      chunkSizePx = 320,
+      overlapPx = 32,
+    },
+    Walls = {
+      collidable = true,
+      emptyIDs = { 0 },
+      wallSpriteGroup = 1,
+      wallCollidesWithGroups = { 2 },
+    },
+    Objects = {
+      collidable = true,
+      spriteGroup = 2,
+    },
+  },
+}, scene)
+
+map:applyCameraBounds()
+local worldWidth, worldHeight = map:getWorldSize()
+
+map:hideLayer("Decor")
+map:showLayer("Decor")
+map:setLayerOrigin("Ground", 0, 16)
+
+local winterTiles = Graphics.imagetable.new("images/terrain-winter")
+map:setLayerImageTable("Ground", winterTiles, {
+  [1] = 2,
+  [2] = 1,
+})
+map:rebuildLayerCollisions("Walls", { 0 })
+
+map:processObjectLayers({ Objects = true })
+local pickups = map:findObjectSpritesByType("Objects", "pickup")
+
+map:removeObjectLayer("Objects")
+map:removeLayer("Decor")
+map:destroy()
+
+]]

--- a/core/tilemaps/TilemapHelpers.lua
+++ b/core/tilemaps/TilemapHelpers.lua
@@ -8,15 +8,33 @@ local r <const> = roxy
 
 local floor <const> = math.floor
 local abs   <const> = math.abs
+local min   <const> = math.min
+local max   <const> = math.max
 
 local stringRep   <const> = string.rep
 local stringPack  <const> = string.pack
 
 local tableUnpack <const> = table.unpack
-local tableRemove <const> = table.remove
 
 local DISPLAY_WIDTH  <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT <const> = r.Graphics.displayHeight
+
+local NATIVE_SYNC_CHUNK_CELLS <const> = 512
+local MAX_PACK_FORMAT_CACHE_CELLS <const> = 2048
+local packU16Formats = {}
+
+local function packU16Format(count)
+  if count <= MAX_PACK_FORMAT_CACHE_CELLS then
+    local format = packU16Formats[count]
+    if not format then
+      format = stringRep("<I2", count)
+      packU16Formats[count] = format
+    end
+    return format
+  end
+
+  return stringRep("<I2", count)
+end
 
 -- ! Visible Layer Rectangle
 -- Compute visible layer-space rect
@@ -48,7 +66,7 @@ end
 function TilemapHelpers.packTilesU16(tiles)
   if not tiles or #tiles == 0 then return nil end
   local n = #tiles
-  local format = stringRep("<I2", n)
+  local format = packU16Format(n)
   local temp = {}
   for i = 1, n do
     local v = tiles[i] or 0
@@ -56,6 +74,22 @@ function TilemapHelpers.packTilesU16(tiles)
     temp[i] = v
   end
   return stringPack(format, tableUnpack(temp, 1, n))
+end
+
+-- ! Pack Tiles U16 Range
+-- Pack a 1-based tile range as little-endian uint16 with clamping
+function TilemapHelpers.packTilesU16Range(tiles, startIndex, count)
+  if not tiles or not startIndex or startIndex < 1 or not count or count <= 0 then return nil end
+  local format = packU16Format(count)
+  local temp = {}
+  local sourceIndex = startIndex
+  for outputIndex = 1, count do
+    local v = tiles[sourceIndex] or 0
+    if v < 0 then v = 0 elseif v > 0xFFFF then v = 0xFFFF end
+    temp[outputIndex] = v
+    sourceIndex = sourceIndex + 1
+  end
+  return stringPack(format, tableUnpack(temp, 1, count))
 end
 
 -- ! Sanitize a single tile index
@@ -80,42 +114,132 @@ end
 -- Sync native tiles from current tilesFlat
 function TilemapHelpers.syncNativeTiles(layerData)
   if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then
-return end
-  local blob = TilemapHelpers.packTilesU16(layerData.tilesFlat)
-  if blob then
-    layerData._nativeRenderer:updateTilesBytes(blob)
-    local selfRef = layerData.ownerTilemap
-    if selfRef then selfRef._frameDirty = true end
+    return
   end
+
+  local renderer = layerData._nativeRenderer
+  local tiles = layerData.tilesFlat
+  local tileCount = #tiles
+  local selfRef = layerData.ownerTilemap
+
+  local function syncFull()
+    local blob = TilemapHelpers.packTilesU16(tiles)
+    if blob then
+      renderer:updateTilesBytes(blob)
+      if selfRef then selfRef._frameDirty = true end
+    end
+  end
+
+  if type(renderer.updateTilesBytesRange) ~= "function" then
+    syncFull()
+    return
+  end
+
+  local startIndex = 1
+  while startIndex <= tileCount do
+    local count = min(NATIVE_SYNC_CHUNK_CELLS, tileCount - startIndex + 1)
+    local blob = TilemapHelpers.packTilesU16Range(tiles, startIndex, count)
+    if not blob or renderer:updateTilesBytesRange(blob, startIndex, count) ~= true then
+      Log.warn("[TilemapHelpers.syncNativeTiles] Range sync failed; falling back to full sync") --#DEBUG
+      syncFull()
+      return
+    end
+    startIndex = startIndex + count
+  end
+
+  if selfRef then selfRef._frameDirty = true end
+end
+
+-- ! Native Sync Chunk Cells
+function TilemapHelpers.nativeSyncChunkCells()
+  return NATIVE_SYNC_CHUNK_CELLS
+end
+
+-- ! Record Perf Count
+function TilemapHelpers.recordPerfCount(label, amount)
+  local perf = r.TilemapPerf
+  if perf and type(perf.count) == "function" then
+    perf.count(label, amount)
+  end
+end
+
+-- ! Warm Center
+-- Compute visible chunk center once per layer config batch.
+function TilemapHelpers.warmCenter(self, layerConfig)
+  local size = layerConfig.size
+  local visibleX, visibleY, visibleWidth, visibleHeight = TilemapHelpers.visibleLayerRect(self, layerConfig.layer)
+  local minX, maxX, minY, maxY = TilemapHelpers.chunkIndicesForRect(visibleX, visibleY, visibleWidth, visibleHeight, size)
+  return (minX + maxX) * 0.5, (minY + maxY) * 0.5
+end
+
+-- ! Warm Center From Cache
+function TilemapHelpers.warmCenterFromCache(self, layerConfig, centerCache)
+  if not centerCache then return TilemapHelpers.warmCenter(self, layerConfig) end
+
+  local center = centerCache[layerConfig]
+  if not center then
+    local centerX, centerY = TilemapHelpers.warmCenter(self, layerConfig)
+    center = { x = centerX, y = centerY }
+    centerCache[layerConfig] = center
+  end
+  return center.x, center.y
+end
+
+-- ! Clear Chunk Draw Scratch
+function TilemapHelpers.clearChunkDrawScratch(scratch, drawCount)
+  if not scratch then return end
+  local images = scratch.images or {}
+  local xs = scratch.xs or {}
+  local ys = scratch.ys or {}
+  scratch.images = images
+  scratch.xs = xs
+  scratch.ys = ys
+  local clearCount = max(drawCount or 0, scratch.count or 0)
+  for index = 1, clearCount do
+    images[index] = nil
+    xs[index] = nil
+    ys[index] = nil
+  end
+  scratch.count = 0
 end
 
 -- ! Warm Score
 -- Warm queue prioritization helper (closest chunk to visible center)
-function TilemapHelpers.warmScore(self, job)
-  local layerConfig = job.layerConfig
-  local size = layerConfig.size
-  local visibleX, visibleY, visibleWidth, visibleHeight = TilemapHelpers.visibleLayerRect(self, layerConfig.layer)
-  local minX, maxX, minY, maxY = TilemapHelpers.chunkIndicesForRect(visibleX, visibleY,visibleWidth, visibleHeight, size)
-  local centerX = (minX + maxX) * 0.5
-  local centerY = (minY + maxY) * 0.5
+function TilemapHelpers.warmScore(self, job, centerCache)
+  local centerX, centerY = TilemapHelpers.warmCenterFromCache(self, job.layerConfig, centerCache)
   local dx = abs(job.chunkX - centerX)
   local dy = abs(job.chunkY - centerY)
   return dx + dy -- Manhattan distance is cheap and good enough
 end
 
 -- ! Dequeue Best Warm Job
-function TilemapHelpers.dequeueBestWarmJob(self)
+function TilemapHelpers.dequeueBestWarmJob(self, centerCache)
   local queue = self._warmQueue
   local bestIndex, bestScore
   for i = 1, #queue do
-    local score = TilemapHelpers.warmScore(self, queue[i])
+    local score = TilemapHelpers.warmScore(self, queue[i], centerCache)
     if not bestScore or score < bestScore then
       bestScore, bestIndex = score, i
     end
   end
   if not bestIndex then return nil end
+
   local job = queue[bestIndex]
-  tableRemove(queue, bestIndex)
+  queue[bestIndex] = queue[#queue]
+  queue[#queue] = nil
   self._warmSet[job.key] = nil
   return job
+end
+
+-- ! Sync Native Tiles Full
+function TilemapHelpers.syncNativeTilesFull(layerData)
+  if not layerData or not layerData._nativeRenderer or not layerData.tilesFlat then
+    return
+  end
+  local blob = TilemapHelpers.packTilesU16(layerData.tilesFlat)
+  if blob then
+    layerData._nativeRenderer:updateTilesBytes(blob)
+    local selfRef = layerData.ownerTilemap
+    if selfRef then selfRef._frameDirty = true end
+  end
 end

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -50,6 +50,49 @@ static inline int indexFromRowColumn(const RoxyTileRendererC* tileRenderer, int 
     return rowZeroBased * tileRenderer->mapWidth + columnZeroBased;
 }
 
+static int tileCountForRenderer(const RoxyTileRendererC* tileRenderer, size_t* outCount)
+{
+    if (!roxy_valid(tileRenderer) || !outCount) return 0;
+    if (tileRenderer->mapWidth <= 0 || tileRenderer->mapHeight <= 0) return 0;
+    if (tileRenderer->mapWidth > INT_MAX / tileRenderer->mapHeight) return 0;
+
+    *outCount = (size_t)tileRenderer->mapWidth * (size_t)tileRenderer->mapHeight;
+    return 1;
+}
+
+static inline void recordTilesPayloadBytes(RoxyTileRendererC* tileRenderer, size_t bytesLength)
+{
+    tileRenderer->tilesCountBytes = bytesLength > (size_t)INT_MAX ? INT_MAX : (int)bytesLength;
+}
+
+static inline int sanitizeTileValue(const RoxyTileRendererC* tileRenderer, int value)
+{
+    if (value < 0 || value > tileRenderer->imageCount) return 0;
+    return value;
+}
+
+static int ensureTilesAllocated(RoxyTileRendererC* tileRenderer, int zeroFill)
+{
+    if (!roxy_valid(tileRenderer)) return 0;
+    if (tileRenderer->tiles) return 1;
+
+    size_t tilesCount = 0;
+    if (!tileCountForRenderer(tileRenderer, &tilesCount) || tilesCount > SIZE_MAX / sizeof(int32_t)) {
+        pd->system->logToConsole("RoxyTileRendererC: tiles size overflow");
+        return 0;
+    }
+
+    tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
+    if (!tileRenderer->tiles) return 0;
+    ROXY_LABEL(tileRenderer->tiles, "RoxyTileRendererC.tiles");
+
+    if (zeroFill) {
+        roxy_memset(tileRenderer->tiles, 0, sizeof(int32_t) * tilesCount);
+    }
+
+    return 1;
+}
+
 static inline int16_t safeOffsetX(const RoxyTileRendererC* tileRenderer, int tileIndex)
 {
     // Guard null offset array
@@ -215,45 +258,47 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         tileRenderer->offsetY[i] = offsetY;
     }
 
-    // Tiles blob (optional) with overflow guard
-    const int tilesCount = mw * mh;
-    if ((size_t)tilesCount > SIZE_MAX / sizeof(int32_t)) {
+    // Tiles blob (optional) with overflow guard. Without an initial blob, tile
+    // memory is allocated lazily by the first native sync.
+    const size_t tilesCount = (size_t)mw * (size_t)mh;
+    if (tilesCount > SIZE_MAX / sizeof(int32_t)) {
         pd->system->logToConsole("RoxyTileRendererC.new: tiles size overflow");
         roxy_tileRenderer_free(tileRenderer);
         pd_free(tileRenderer);
         return 0;
     }
-    tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
-    if (!tileRenderer->tiles) {
-        roxy_tileRenderer_free(tileRenderer);
-        pd_free(tileRenderer);
-        return 0;
-    }
-    roxy_memset(tileRenderer->tiles, 0, sizeof(int32_t) * tilesCount);
-    ROXY_LABEL(tileRenderer->tiles, "RoxyTileRendererC.tiles");
+    const size_t tilesCountBytes16 = tilesCount * 2;
+    const size_t tilesCountBytes32 = tilesCount * 4;
 
     if (argumentCount >= 13 && !pd->lua->argIsNil(13)) {
         size_t bytesLength = 0;
         const char* bytes = pd->lua->getArgBytes(13, &bytesLength);
         if (bytes && bytesLength > 0) {
-            if ((int)bytesLength == tilesCount * 2) {
-                for (int i = 0; i < tilesCount; ++i) {
+            if (bytesLength == tilesCountBytes16) {
+                if (!ensureTilesAllocated(tileRenderer, 0)) {
+                    roxy_tileRenderer_free(tileRenderer);
+                    pd_free(tileRenderer);
+                    return 0;
+                }
+                for (size_t i = 0; i < tilesCount; ++i) {
                     uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
                     int v = (int)value;
-                    // Sanitize tile value to avoid out-of-range image table lookups
-                    if (v < 0 || v > tileRenderer->imageCount) v = 0;
-                    tileRenderer->tiles[i] = v;
+                    tileRenderer->tiles[i] = sanitizeTileValue(tileRenderer, v);
                 }
-                tileRenderer->tilesCountBytes = (int)bytesLength;
-            } else if ((int)bytesLength == tilesCount * 4) {
-                for (int i = 0; i < tilesCount; ++i) {
+                recordTilesPayloadBytes(tileRenderer, bytesLength);
+            } else if (bytesLength == tilesCountBytes32) {
+                if (!ensureTilesAllocated(tileRenderer, 0)) {
+                    roxy_tileRenderer_free(tileRenderer);
+                    pd_free(tileRenderer);
+                    return 0;
+                }
+                for (size_t i = 0; i < tilesCount; ++i) {
                     const uint8_t* p = (const uint8_t*)bytes + 4*i;
-                    int v = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
-                    // Sanitize tile value
-                    if (v < 0 || v > tileRenderer->imageCount) v = 0;
-                    tileRenderer->tiles[i] = v;
+                    uint32_t raw = ((uint32_t)p[0]) | (((uint32_t)p[1]) << 8) | (((uint32_t)p[2]) << 16) | (((uint32_t)p[3]) << 24);
+                    int v = (int)raw;
+                    tileRenderer->tiles[i] = sanitizeTileValue(tileRenderer, v);
                 }
-                tileRenderer->tilesCountBytes = (int)bytesLength;
+                recordTilesPayloadBytes(tileRenderer, bytesLength);
             }
         }
     }
@@ -286,43 +331,124 @@ static int roxy_tileRenderer_updateTilesBytes(lua_State* L)
     const char* bytes = pd->lua->getArgBytes(2, &bytesLength);
     if (!bytes || bytesLength == 0) return 0;
 
-    const int tilesCount = tileRenderer->mapWidth * tileRenderer->mapHeight;
-    if ((int)bytesLength != tilesCount * 2 && (int)bytesLength != tilesCount * 4) {
-        pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: bad size %d (expected %d or %d)",
-                                 (int)bytesLength, tilesCount*2, tilesCount*4);
+    size_t tilesCount = 0;
+    if (!tileCountForRenderer(tileRenderer, &tilesCount) || tilesCount > SIZE_MAX / 4) {
+        pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: tiles size overflow");
         return 0;
     }
 
-    if (!tileRenderer->tiles) {
-        if ((size_t)tilesCount > SIZE_MAX / sizeof(int32_t)) {
-            pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: tiles size overflow");
-            return 0;
-        }
-        tileRenderer->tiles = (int32_t*)pd_alloc(sizeof(int32_t) * tilesCount);
-        if (!tileRenderer->tiles) return 0;
-        ROXY_LABEL(tileRenderer->tiles, "RoxyTileRendererC.tiles");
+    const size_t tilesCountBytes16 = tilesCount * 2;
+    const size_t tilesCountBytes32 = tilesCount * 4;
+    if (bytesLength != tilesCountBytes16 && bytesLength != tilesCountBytes32) {
+        pd->system->logToConsole("RoxyTileRendererC.updateTilesBytes: bad size %lu (expected %lu or %lu)",
+                                 (unsigned long)bytesLength,
+                                 (unsigned long)tilesCountBytes16,
+                                 (unsigned long)tilesCountBytes32);
+        return 0;
     }
 
-    if ((int)bytesLength == tilesCount * 2) {
-        for (int i = 0; i < tilesCount; ++i) {
+    if (!ensureTilesAllocated(tileRenderer, 0)) return 0;
+
+    if (bytesLength == tilesCountBytes16) {
+        for (size_t i = 0; i < tilesCount; ++i) {
             uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
             int v = (int)value;
-            // Sanitize tile value
-            if (v < 0 || v > tileRenderer->imageCount) v = 0;
-            tileRenderer->tiles[i] = v;
+            tileRenderer->tiles[i] = sanitizeTileValue(tileRenderer, v);
         }
-        tileRenderer->tilesCountBytes = (int)bytesLength;
+        recordTilesPayloadBytes(tileRenderer, bytesLength);
     } else {
-        for (int i = 0; i < tilesCount; ++i) {
+        for (size_t i = 0; i < tilesCount; ++i) {
             const uint8_t* p = (const uint8_t*)bytes + 4*i;
-            int v = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
-            // Sanitize tile value
-            if (v < 0 || v > tileRenderer->imageCount) v = 0;
-            tileRenderer->tiles[i] = v;
+            uint32_t raw = ((uint32_t)p[0]) | (((uint32_t)p[1]) << 8) | (((uint32_t)p[2]) << 16) | (((uint32_t)p[3]) << 24);
+            int v = (int)raw;
+            tileRenderer->tiles[i] = sanitizeTileValue(tileRenderer, v);
         }
-        tileRenderer->tilesCountBytes = (int)bytesLength;
+        recordTilesPayloadBytes(tileRenderer, bytesLength);
     }
     return 0;
+}
+
+// ! Update Tiles Bytes Range
+// lua: ok = self:updateTilesBytesRange(bytes, startIndex, count)
+// startIndex is 1-based row-major. count == 0 is a no-op.
+static int roxy_tileRenderer_updateTilesBytesRange(lua_State* L)
+{
+    RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
+    if (!roxy_valid(tileRenderer)) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    size_t tilesCount = 0;
+    if (!tileCountForRenderer(tileRenderer, &tilesCount)) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    const int startIndex = pd->lua->getArgInt(3);
+    const int count = pd->lua->getArgInt(4);
+
+    if (count < 0 || startIndex < 1) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    if (count == 0) {
+        pd->lua->pushBool((size_t)startIndex <= tilesCount + 1);
+        return 1;
+    }
+
+    const size_t totalCells = tilesCount;
+    const size_t rangeStart = (size_t)startIndex;
+    const size_t rangeCount = (size_t)count;
+    if (rangeCount > totalCells || rangeStart > totalCells || rangeCount > totalCells - rangeStart + 1) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    size_t bytesLength = 0;
+    const char* bytes = pd->lua->getArgBytes(2, &bytesLength);
+    if (!bytes) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    if (rangeCount > SIZE_MAX / 4) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+    const size_t bytes16 = rangeCount * 2;
+    const size_t bytes32 = rangeCount * 4;
+    const int payloadWidth = (bytesLength == bytes16) ? 2 : ((bytesLength == bytes32) ? 4 : 0);
+    if (payloadWidth == 0) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    if (!ensureTilesAllocated(tileRenderer, 1)) {
+        pd->lua->pushBool(0);
+        return 1;
+    }
+
+    const size_t destinationStart = rangeStart - 1;
+    if (payloadWidth == 2) {
+        for (size_t i = 0; i < rangeCount; ++i) {
+            uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
+            int v = (int)value;
+            tileRenderer->tiles[destinationStart + i] = sanitizeTileValue(tileRenderer, v);
+        }
+    } else {
+        for (size_t i = 0; i < rangeCount; ++i) {
+            const uint8_t* p = (const uint8_t*)bytes + 4*i;
+            uint32_t raw = ((uint32_t)p[0]) | (((uint32_t)p[1]) << 8) | (((uint32_t)p[2]) << 16) | (((uint32_t)p[3]) << 24);
+            int v = (int)raw;
+            tileRenderer->tiles[destinationStart + i] = sanitizeTileValue(tileRenderer, v);
+        }
+    }
+
+    recordTilesPayloadBytes(tileRenderer, bytesLength);
+    pd->lua->pushBool(1);
+    return 1;
 }
 
 // ! Set Tile At
@@ -618,6 +744,7 @@ static const lua_reg roxyTileRendererLib[] = {
     {    "new",                     roxy_tileRenderer_newobject               },
     {    "__gc",                    roxy_tileRenderer_gc                      },
     {    "updateTilesBytes",        roxy_tileRenderer_updateTilesBytes        },
+    {    "updateTilesBytesRange",   roxy_tileRenderer_updateTilesBytesRange   },
     {    "setTileAt",               roxy_tileRenderer_setTileAt               },
     {    "drawRows",                roxy_tileRenderer_drawRows                },
     {    "renderToBuffer",          roxy_tileRenderer_renderToBuffer          },

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -240,7 +240,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
                 for (int i = 0; i < tilesCount; ++i) {
                     uint16_t value = ((const uint8_t*)bytes)[2*i] | (((const uint8_t*)bytes)[2*i + 1] << 8);
                     int v = (int)value;
-                    // Sanitize tile value to avoid out-of-range imagetable lookups
+                    // Sanitize tile value to avoid out-of-range image table lookups
                     if (v < 0 || v > tileRenderer->imageCount) v = 0;
                     tileRenderer->tiles[i] = v;
                 }
@@ -339,29 +339,24 @@ static int roxy_tileRenderer_setTileAt(lua_State* L)
     x = roxy_math_clampi(x, 1, tileRenderer->mapWidth);
     y = roxy_math_clampi(y, 1, tileRenderer->mapHeight);
 
-    // Sanitize tileIndex to prevent OOB imagetable lookups
+    // Sanitize tileIndex to prevent out-of-bounds image table lookups
     if (tileIndex < 0 || tileIndex > tileRenderer->imageCount) tileIndex = 0;
 
     tileRenderer->tiles[indexFromRowColumn(tileRenderer, x-1, y-1)] = tileIndex;
     return 0;
 }
 
-// ! Draw Cell
-// core draw for a single tile (shared)
-static inline void drawCell(const RoxyTileRendererC* tileRenderer, int tileIndex, int sx, int sy)
+// ! Draw Cell Unchecked
+// Core draw for a range-checked tile using cached renderer fields.
+static inline void drawCellUnchecked(LCDBitmapTable* imageTable, const int16_t* offsetX, const int16_t* offsetY, int tileIndex, int sx, int sy)
 {
-    // Guard tileRenderer and validate tileIndex range
-    if (!tileRenderer || tileIndex <= 0 || tileIndex > tileRenderer->imageCount) return;
-    // Extra safety
-    if (!pd || !pd->graphics || !tileRenderer->imageTable) return;
-
     // Convert 1-based tile index to 0-based bitmap table index
     const int bitmapIndex = tileIndex - 1;
-    LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
+    LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
     if (!cell) return;
 
-    const int dx = sx + safeOffsetX(tileRenderer, tileIndex);
-    const int dy = sy + safeOffsetY(tileRenderer, tileIndex);
+    const int dx = sx + offsetX[tileIndex];
+    const int dy = sy + offsetY[tileIndex];
 
     pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
 }
@@ -377,6 +372,18 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
     RoxyTileRendererC* tileRenderer = (RoxyTileRendererC*)pd->lua->getArgObject(1, "RoxyTileRendererC", NULL);
     if (!roxy_valid(tileRenderer) || !tileRenderer->tiles) return 0;
     if (!pd || !pd->graphics) return 0;
+
+    const int mapWidth = tileRenderer->mapWidth;
+    const int mapHeight = tileRenderer->mapHeight;
+    const int tileWidth = tileRenderer->tileWidth;
+    const int halfTileWidth = tileRenderer->halfTileWidth;
+    const int halfTileHeight = tileRenderer->halfTileHeight;
+    const int imageCount = tileRenderer->imageCount;
+    const int32_t* tiles = tileRenderer->tiles;
+    const int16_t* offsetX = tileRenderer->offsetX;
+    const int16_t* offsetY = tileRenderer->offsetY;
+    LCDBitmapTable* imageTable = tileRenderer->imageTable;
+    if (!imageTable || !offsetX || !offsetY) return 0;
 
     int minRow = pd->lua->getArgInt(2);
     int maxRow = pd->lua->getArgInt(3);
@@ -395,10 +402,10 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
     int cameraX = pd->lua->getArgInt(12);
     int cameraY = pd->lua->getArgInt(13);
 
-    minRow = roxy_math_clampi(minRow, 1, tileRenderer->mapHeight);
-    maxRow = roxy_math_clampi(maxRow, 1, tileRenderer->mapHeight);
-    minColumn = roxy_math_clampi(minColumn, 1, tileRenderer->mapWidth);
-    maxColumn = roxy_math_clampi(maxColumn, 1, tileRenderer->mapWidth);
+    minRow = roxy_math_clampi(minRow, 1, mapHeight);
+    maxRow = roxy_math_clampi(maxRow, 1, mapHeight);
+    minColumn = roxy_math_clampi(minColumn, 1, mapWidth);
+    maxColumn = roxy_math_clampi(maxColumn, 1, mapWidth);
     if (minRow > maxRow || minColumn > maxColumn) return 0;
 
     const float pivotAdjustX = parallaxOriginX * (1.f - parallaxX);
@@ -411,32 +418,36 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
             const int rowShift = rowShiftX_for_row0(tileRenderer, rowZeroBased);
 
             const int baseX = roxy_math_roundInt(originX + rowShift + pivotAdjustX - cameraX * parallaxX);
-            const int baseY = roxy_math_roundInt(originY + rowZeroBased * tileRenderer->halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+            const int baseY = roxy_math_roundInt(originY + rowZeroBased * halfTileHeight + pivotAdjustY - cameraY * parallaxY);
 
-            int screenX = baseX + (minColumn - 1) * tileRenderer->tileWidth;
-            const int rowIndexBase = rowZeroBased * tileRenderer->mapWidth + (minColumn - 1);
+            int screenX = baseX + (minColumn - 1) * tileWidth;
+            const int rowIndexBase = rowZeroBased * mapWidth + (minColumn - 1);
 
             for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
-                const int currentTileIndex = tileRenderer->tiles[tileIndex];
-                if (currentTileIndex > 0) drawCell(tileRenderer, currentTileIndex, screenX, baseY);
-                screenX += tileRenderer->tileWidth;
+                const int currentTileIndex = tiles[tileIndex];
+                if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
+                    drawCellUnchecked(imageTable, offsetX, offsetY, currentTileIndex, screenX, baseY);
+                }
+                screenX += tileWidth;
             }
         }
     } else {
         // Isometric
         for (int tileY = minRow; tileY <= maxRow; ++tileY) {
             const int rowZeroBased = tileY - 1;
-            const int rowIndexBase = rowZeroBased * tileRenderer->mapWidth + (minColumn - 1);
+            const int rowIndexBase = rowZeroBased * mapWidth + (minColumn - 1);
             for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
                 const int columnZeroBased = tileX - 1;
                 const float worldX = (float)columnZeroBased;
                 const float worldY = (float)rowZeroBased;
 
-                const int isoX = roxy_math_roundInt(originX + (worldX - worldY) * tileRenderer->halfTileWidth + pivotAdjustX - cameraX * parallaxX);
-                const int isoY = roxy_math_roundInt(originY + (worldX + worldY) * tileRenderer->halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+                const int isoX = roxy_math_roundInt(originX + (worldX - worldY) * halfTileWidth + pivotAdjustX - cameraX * parallaxX);
+                const int isoY = roxy_math_roundInt(originY + (worldX + worldY) * halfTileHeight + pivotAdjustY - cameraY * parallaxY);
 
-                const int currentTileIndex = tileRenderer->tiles[tileIndex];
-                if (currentTileIndex > 0) drawCell(tileRenderer, currentTileIndex, isoX, isoY);
+                const int currentTileIndex = tiles[tileIndex];
+                if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
+                    drawCellUnchecked(imageTable, offsetX, offsetY, currentTileIndex, isoX, isoY);
+                }
             }
         }
     }
@@ -453,6 +464,20 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     if (!roxy_valid(tileRenderer) || !tileRenderer->tiles) return 0;
     if (!pd || !pd->graphics) return 0;
 
+    const int mapWidth = tileRenderer->mapWidth;
+    const int mapHeight = tileRenderer->mapHeight;
+    const int tileWidth = tileRenderer->tileWidth;
+    const int tileHeight = tileRenderer->tileHeight;
+    const int halfTileWidth = tileRenderer->halfTileWidth;
+    const int halfTileHeight = tileRenderer->halfTileHeight;
+    const int maxImageHeight = tileRenderer->maxImageHeight;
+    const int imageCount = tileRenderer->imageCount;
+    const int32_t* tiles = tileRenderer->tiles;
+    const int16_t* offsetXTable = tileRenderer->offsetX;
+    const int16_t* offsetYTable = tileRenderer->offsetY;
+    LCDBitmapTable* imageTable = tileRenderer->imageTable;
+    if (!imageTable || !offsetXTable || !offsetYTable) return 0;
+
     LCDBitmap* targetBitmap = pd->lua->getBitmap(2); // May be NULL
     const int offsetX = pd->lua->getArgInt(3);
     const int offsetY = pd->lua->getArgInt(4);
@@ -461,11 +486,12 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     if (bufferWidth <= 0 || bufferHeight <= 0) return 0;
 
     // Defensive check to prevent division-by-zero
-    if (tileRenderer->tileWidth <= 0 || tileRenderer->halfTileHeight <= 0 ||
-        tileRenderer->halfTileWidth <= 0) {
+    if (tileWidth <= 0 || halfTileHeight <= 0 || halfTileWidth <= 0) {
         pd->system->logToConsole("RoxyTileRendererC.renderToBuffer: invalid tile dimensions, cannot render");
         return 0;
     }
+
+    const int cullHeight = (maxImageHeight > tileHeight) ? maxImageHeight : tileHeight;
 
     int contextPushed = 0;
     if (targetBitmap) {
@@ -476,72 +502,98 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     // Compute conservative row/column bounds
     if (!tileRenderer->isIsometric) {
         // staggered-y
-        const int overdrawRows = (int)ceilf(fmaxf(0.f, (float)(tileRenderer->maxImageHeight - tileRenderer->tileHeight)) /
-                                          fmaxf(1.f, (float)tileRenderer->halfTileHeight)) + 1;
+        const int overdrawRows = (int)ceilf(fmaxf(0.f, (float)(maxImageHeight - tileHeight)) /
+                                          fmaxf(1.f, (float)halfTileHeight)) + 1;
 
-        int minRowZeroBased = (int)floorf((float)(-offsetY - tileRenderer->maxImageHeight) /
-                                        (float)tileRenderer->halfTileHeight) - 1 - overdrawRows;
+        int minRowZeroBased = (int)floorf((float)(-offsetY - maxImageHeight) /
+                                        (float)halfTileHeight) - 1 - overdrawRows;
         int maxRowZeroBased = (int)ceilf ((float)(bufferHeight - offsetY) /
-                                        (float)tileRenderer->halfTileHeight) + 1 + overdrawRows;
-        minRowZeroBased = roxy_math_clampi(minRowZeroBased, 0, tileRenderer->mapHeight - 1);
-        maxRowZeroBased = roxy_math_clampi(maxRowZeroBased, 0, tileRenderer->mapHeight - 1);
+                                        (float)halfTileHeight) + 1 + overdrawRows;
+        minRowZeroBased = roxy_math_clampi(minRowZeroBased, 0, mapHeight - 1);
+        maxRowZeroBased = roxy_math_clampi(maxRowZeroBased, 0, mapHeight - 1);
 
         for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
             const int baseX = rowShiftX_for_row0(tileRenderer, rowZeroBased) + offsetX;
-            const int baseY = rowZeroBased * tileRenderer->halfTileHeight + offsetY;
+            const int baseY = rowZeroBased * halfTileHeight + offsetY;
 
-            int minColumnZeroBased = (int)floorf((float)(-tileRenderer->tileWidth - baseX) / (float)tileRenderer->tileWidth) - 1;
-            int maxColumnZeroBased = (int)floorf((float)(bufferWidth - 1 - baseX) / (float)tileRenderer->tileWidth) + 1;
-            minColumnZeroBased = roxy_math_clampi(minColumnZeroBased, 0, tileRenderer->mapWidth - 1);
-            maxColumnZeroBased = roxy_math_clampi(maxColumnZeroBased, 0, tileRenderer->mapWidth - 1);
+            int minColumnZeroBased = (int)floorf((float)(-tileWidth - baseX) / (float)tileWidth) - 1;
+            int maxColumnZeroBased = (int)floorf((float)(bufferWidth - 1 - baseX) / (float)tileWidth) + 1;
+            minColumnZeroBased = roxy_math_clampi(minColumnZeroBased, 0, mapWidth - 1);
+            maxColumnZeroBased = roxy_math_clampi(maxColumnZeroBased, 0, mapWidth - 1);
             if (minColumnZeroBased > maxColumnZeroBased) continue; // Handle negative-length window
 
-            int drawX = baseX + minColumnZeroBased * tileRenderer->tileWidth;
-            int tileIndex = rowZeroBased * tileRenderer->mapWidth + minColumnZeroBased;
+            int drawX = baseX + minColumnZeroBased * tileWidth;
+            int tileIndex = rowZeroBased * mapWidth + minColumnZeroBased;
             for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased, ++tileIndex) {
-                const int currentTileIndex = tileRenderer->tiles[tileIndex];
+                const int currentTileIndex = tiles[tileIndex];
                 if (currentTileIndex > 0) {
-                    // Ensure index is within imagetable range before touching graphics
-                    if (currentTileIndex <= tileRenderer->imageCount) {
-                        const int dx = drawX + safeOffsetX(tileRenderer, currentTileIndex);
-                        const int dy = baseY + safeOffsetY(tileRenderer, currentTileIndex);
-                        if (dx < bufferWidth && dy < bufferHeight && dx > -tileRenderer->tileWidth && dy > -tileRenderer->tileHeight) {
+                    // Ensure index is within image table range before touching graphics
+                    if (currentTileIndex <= imageCount) {
+                        const int dx = drawX + offsetXTable[currentTileIndex];
+                        const int dy = baseY + offsetYTable[currentTileIndex];
+                        if (dx < bufferWidth && dy < bufferHeight && dx > -tileWidth && dy > -cullHeight) {
                             // Convert 1-based tile index to 0-based bitmap table index
                             const int bitmapIndex = currentTileIndex - 1;
-                            LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
+                            LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
                             if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
                         }
                     }
                 }
-                drawX += tileRenderer->tileWidth;
+                drawX += tileWidth;
             }
         }
     } else {
         // Isometric
-        // Conservative world bounds - these are broad but safe for a stub
-        const int overdrawRows = (int)ceilf(fmaxf(0.f, (float)(tileRenderer->maxImageHeight - tileRenderer->tileHeight)) / fmaxf(1.f, (float)tileRenderer->halfTileHeight)) + 1;
+        const float halfWidth = (float)halfTileWidth;
+        const float halfHeight = (float)halfTileHeight;
+        const float horizontalPadding = (float)tileWidth;
+        const float verticalPadding = fmaxf(0.f, (float)(maxImageHeight - tileHeight));
 
-        const int minColumnZeroBased = roxy_math_clampi(-(bufferWidth / tileRenderer->halfTileWidth) - overdrawRows, 0, tileRenderer->mapWidth  - 1);
-        const int maxColumnZeroBased = roxy_math_clampi((bufferWidth / tileRenderer->halfTileWidth) + overdrawRows, 0, tileRenderer->mapWidth  - 1);
-        const int minRowZeroBased    = roxy_math_clampi(-(bufferHeight / tileRenderer->halfTileHeight) - overdrawRows, 0, tileRenderer->mapHeight - 1);
-        const int maxRowZeroBased    = roxy_math_clampi((bufferHeight / tileRenderer->halfTileHeight) + overdrawRows, 0, tileRenderer->mapHeight - 1);
+        const float left = (float)(-offsetX) - horizontalPadding;
+        const float right = (float)(bufferWidth - offsetX) + horizontalPadding;
+        const float top = (float)(-offsetY) - verticalPadding;
+        const float bottom = (float)(bufferHeight - offsetY) + verticalPadding;
+
+        float minColumn = INFINITY;
+        float maxColumn = -INFINITY;
+        float minRow = INFINITY;
+        float maxRow = -INFINITY;
+
+        const float xs[4] = { left, right, left, right };
+        const float ys[4] = { top, top, bottom, bottom };
+        for (int i = 0; i < 4; ++i) {
+            const float screenX = xs[i];
+            const float screenY = ys[i];
+            const float column = ((screenY / halfHeight) + (screenX / halfWidth)) * 0.5f;
+            const float row = ((screenY / halfHeight) - (screenX / halfWidth)) * 0.5f;
+
+            if (column < minColumn) minColumn = column;
+            if (column > maxColumn) maxColumn = column;
+            if (row < minRow) minRow = row;
+            if (row > maxRow) maxRow = row;
+        }
+
+        const int minColumnZeroBased = roxy_math_clampi((int)floorf(minColumn) - 1, 0, mapWidth  - 1);
+        const int maxColumnZeroBased = roxy_math_clampi((int)ceilf(maxColumn)  + 1, 0, mapWidth  - 1);
+        const int minRowZeroBased    = roxy_math_clampi((int)floorf(minRow)    - 1, 0, mapHeight - 1);
+        const int maxRowZeroBased    = roxy_math_clampi((int)ceilf(maxRow)     + 1, 0, mapHeight - 1);
 
         for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
-            for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased) {
-                const int tileIndex = indexFromRowColumn(tileRenderer, columnZeroBased, rowZeroBased);
-                const int currentTileIndex = tileRenderer->tiles[tileIndex];
-                if (currentTileIndex > 0 && currentTileIndex <= tileRenderer->imageCount) {
+            int tileIndex = rowZeroBased * mapWidth + minColumnZeroBased;
+            for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased, ++tileIndex) {
+                const int currentTileIndex = tiles[tileIndex];
+                if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
                     const float worldX = (float)columnZeroBased;
                     const float worldY = (float)rowZeroBased;
-                    const int screenX = roxy_math_roundInt((worldX - worldY) * tileRenderer->halfTileWidth  + offsetX);
-                    const int screenY = roxy_math_roundInt((worldX + worldY) * tileRenderer->halfTileHeight + offsetY);
+                    const int screenX = roxy_math_roundInt((worldX - worldY) * halfTileWidth  + offsetX);
+                    const int screenY = roxy_math_roundInt((worldX + worldY) * halfTileHeight + offsetY);
 
-                    const int drawX = screenX + safeOffsetX(tileRenderer, currentTileIndex);
-                    const int drawY = screenY + safeOffsetY(tileRenderer, currentTileIndex);
-                    if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileRenderer->tileWidth && drawY > -tileRenderer->tileHeight) {
+                    const int drawX = screenX + offsetXTable[currentTileIndex];
+                    const int drawY = screenY + offsetYTable[currentTileIndex];
+                    if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileWidth && drawY > -cullHeight) {
                         // Convert 1-based tile index to 0-based bitmap table index
                         const int bitmapIndex = currentTileIndex - 1;
-                        LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
+                        LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
                         if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
                     }
                 }

--- a/core/tilemaps/roxy_tileRenderer.h
+++ b/core/tilemaps/roxy_tileRenderer.h
@@ -27,7 +27,7 @@ typedef struct {
 
     // Tiles: copied into C memory for speed (row-major, 0-based)
     int32_t* tiles;           // Length = mapWidth*mapHeight
-    int      tilesCountBytes; // Original byte size, for sanity/debug
+    int      tilesCountBytes; // Last accepted tile payload byte size
 
     // Lifetime guard
     uint32_t magic; // Magic cookie used to validate the instance


### PR DESCRIPTION
### Overview
Roxy Engine v0.16.0 reworks tilemap lifecycle so maps can be loaded separately from scene attachment, hardens cleanup/cache/native rendering behavior, and reduces cold-path native tile sync allocation cost for large maps. It includes a breaking constructor change: create tilemaps without scene arguments and attach them with `scene:addTilemap(map)`.

### Key Changes
- Added load-only tilemap construction with scene ownership moving through `scene:addTilemap(map)`.
- Preserved object, collision, and parallax sprite state across pooled tilemap detach/reattach flows.
- Hardened scene-owned tilemap teardown, layer mutation invalidation, runtime image-table swaps, and unsupported Tiled feature rejection.
- Fixed native isometric chunk bounds so off-origin chunks render coherently without stale caches or clipped tall art.
- Added internal range-based native tile syncing to reduce full-map Lua packing spikes on large tilemaps while preserving full-sync fallback behavior.
- Reused warm queue centers and chunk draw scratch arrays to lower allocation pressure without adding release draw-loop counter overhead.

### Breaking Changes
- Tilemap constructors no longer accept scene arguments. Attach constructed maps with `scene:addTilemap(map)`.

### Challenges/Notes
- Review any game code that relied on constructor-time scene attachment.
- The new native range sync path is internal; the existing full-sync compatibility path remains available.