### PR TITLE
[0.17.0] - Optimize Tilemaps and Scene Pause

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -30,15 +30,20 @@ local drawImage     <const> = Graphics.imagetable.drawImage
 --------------------------------------------------------------------------------
 
 -- Roxy core
-local r         <const> = roxy
-local Math      <const> = r.Math
-local Assets    <const> = r.Assets
-local Registry  <const> = r.AssetPoolRegistry
-local Animation <const> = r.Animation
+local r           <const> = roxy
+local Math        <const> = r.Math
+local Cache       <const> = r.Cache
+local AssetStore  <const> = r.AssetStore
+local Assets      <const> = r.Assets
+local Registry    <const> = r.AssetPoolRegistry
+local Animation   <const> = r.Animation
 
 -- Roxy framework function aliases
 local clamp           <const> = Math.clamp
 local truncateDecimal <const> = Math.truncateDecimal
+local getCachedAsset  <const> = Cache.getCachedAsset
+local retainAsset     <const> = AssetStore.retain
+local releaseAsset    <const> = AssetStore.release
 local getAsset        <const> = Assets.getAsset
 local recycleAsset    <const> = Assets.recycleAsset
 local isFromPool      <const> = Registry.isFromPool
@@ -55,19 +60,11 @@ local UNFLIPPED <const> = Graphics.kImageUnflipped
 -- Animation Constants
 --------------------------------------------------------------------------------
 
-local FRAME_DURATION_DEFAULT  <const> = 0.033 -- About 30 FPS
-local MIN_FRAME_DURATION      <const> = 0.016 -- Guard against >60 FPS
-local MAX_FRAME_DURATION      <const> = 10    -- Sensible upper limit (sec)
-local MAX_ANIMATION_SPEED     <const> = 100   -- UI clamp for setSpeed
-
---------------------------------------------------------------------------------
--- Local State Variables
---------------------------------------------------------------------------------
-
--- Track shared animations by imagetable identity (weak keys)
-local _animationCache = setmetatable({}, { __mode = "k" })
--- Cache animations by path to avoid duplicate imagetables
-local _pathCache = setmetatable({}, { __mode = "k" })
+local FRAME_DURATION_DEFAULT        <const> = 0.033 -- About 30 FPS
+local MIN_FRAME_DURATION            <const> = 0.016 -- Guard against >60 FPS
+local MAX_FRAME_DURATION            <const> = 10    -- Sensible upper limit (sec)
+local MAX_ANIMATION_SPEED           <const> = 100   -- UI clamp for setSpeed
+local PATH_IMAGETABLE_CACHE_PREFIX  <const> = "RoxyAnimation.imagetable:"
 
 --------------------------------------------------------------------------------
 -- Class Definition
@@ -79,41 +76,87 @@ class("RoxyAnimation").extends(Object)
 -- Static Factory Methods
 --------------------------------------------------------------------------------
 
+-- ! Helper: Is Image Table
+-- Returns true for Playdate imagetable-like values
+local function _isImageTable(value)
+  local valueType = type(value)
+  if valueType ~= "table" and valueType ~= "userdata" then return false end
+
+  local ok, drawImage = pcall(function() return value.drawImage end)
+  return ok and type(drawImage) == "function"
+end
+
+-- ! Helper: Get Image Table Length
+-- Reads frame count from table length, then Playdate-style getLength()
+local function _getImageTableLength(imagetable)
+  local ok, length = pcall(function() return #imagetable end)
+  if ok and type(length) == "number" and length > 0 then
+    return length
+  end
+
+  if imagetable and type(imagetable.getLength) == "function" then
+    return imagetable:getLength() or 0
+  end
+
+  return 0
+end
+
+-- ! Helper: Get Path Cache Key
+-- Namespaces path-backed imagetable assets inside AssetStore
+local function _getPathCacheKey(path)
+  return PATH_IMAGETABLE_CACHE_PREFIX .. path
+end
+
+RoxyAnimation.PATH_IMAGETABLE_CACHE_PREFIX = PATH_IMAGETABLE_CACHE_PREFIX
+
+-- ! Get Path Cache Key
+-- Returns the AssetStore key used for a path-backed animation imagetable
+function RoxyAnimation.getPathCacheKey(path)
+  return _getPathCacheKey(path)
+end
+
+-- ! From Path
+-- Creates fresh playback state backed by a retained cached imagetable
+function RoxyAnimation.fromPath(path)
+  return RoxyAnimation(path)
+end
+
 -- ! From Image Table
--- Create animation from existing imagetable with reference counting
+-- Creates fresh playback state over an existing imagetable
 function RoxyAnimation.fromImagetable(imagetable)
-  if not (imagetable and imagetable.drawImage) then
-    error("[RoxyAnimation.fromImagetable] Expected imagetable userdata") --#DEBUG
+  if not _isImageTable(imagetable) then
+    error("[RoxyAnimation.fromImagetable] Expected imagetable") --#DEBUG
     return nil
   end
 
-  -- Return existing cached instance with incremented reference count
-  local cached = _animationCache[imagetable]
-  if cached then
-    return cached:retain()
-  end
-
-  -- Create new instance and add to cache
-  local self = RoxyAnimation(imagetable)
-  self._refcount = 1
-  _animationCache[imagetable] = self
-  return self
+  return RoxyAnimation(imagetable)
 end
 
 -- ! From Pool
--- Create animation from Assets pool
+-- Creates fresh playback state over an imagetable checked out of an Assets pool
 function RoxyAnimation.fromPool(poolKey)
   local imagetable = getAsset(poolKey)
   if not imagetable then
-    error("[RoxyAnimation.fromPool] No asset for key: ", tostring(poolKey))
+    error("[RoxyAnimation.fromPool] No asset for key: " .. tostring(poolKey))
     return nil
   end
-  local animation = RoxyAnimation.fromImagetable(imagetable)
-  if animation then
-    animation._pooledKey = poolKey
-    animation._pooledAsset = imagetable
-    animation._pooledAssetKind = "imagetable"
+
+  local ok, animation = pcall(function()
+    return RoxyAnimation.fromImagetable(imagetable)
+  end)
+
+  if not ok then
+    -- Return checked-out image data before rethrowing construction errors
+    if isFromPool(imagetable) then
+      recycleAsset(poolKey, imagetable)
+    end
+    error(animation, 2)
   end
+
+  animation._pooledKey = poolKey
+  animation._pooledAsset = imagetable
+  animation._pooledAssetKind = "imagetable"
+  animation._pooledAssetRecycled = false
   return animation
 end
 
@@ -129,37 +172,48 @@ function RoxyAnimation:init(view)
   local viewType = type(view)
   if viewType == "string" then
     return self:_initFromPath(view)
-  elseif viewType == "userdata" and view and view.drawImage then
+  elseif _isImageTable(view) then
     return self:_initFromImagetable(view)
   else
-    error("[RoxyAnimation:init] Expected string path or imagetable userdata (got " .. viewType .. ")")
+    error("[RoxyAnimation:init] Expected string path or imagetable (got " .. viewType .. ")")
   end
 end
 
 -- ! Initialize From Path
--- Initialize from file path with caching
+-- Initialize fresh animation state from a retained cached imagetable
 function RoxyAnimation:_initFromPath(path)
-  -- Check path cache to avoid duplicate imagetables
-  local cached = _pathCache[path]
-  if cached then
-    return cached:retain()
+  if type(path) ~= "string" or path == "" then
+    error("[RoxyAnimation:_initFromPath] Expected non-empty path")
   end
 
-  local imagetable = newImagetable(path)
+  local cacheKey = _getPathCacheKey(path)
+  -- Cache only image data; each animation keeps private playback state
+  local retained = retainAsset(cacheKey, function()
+    return newImagetable(path)
+  end)
+  if not retained then
+    error("[RoxyAnimation:_initFromPath] Failed to retain imagetable from: " .. path)
+    return
+  end
+
+  local imagetable = getCachedAsset(cacheKey)
   if not imagetable then
-    error("[RoxyAnimation:_initFromPath] Failed to create imagetable from: " .. path)
+    releaseAsset(cacheKey)
+    error("[RoxyAnimation:_initFromPath] Failed to get retained imagetable from: " .. path)
+    return
+  end
+  if not _isImageTable(imagetable) then
+    releaseAsset(cacheKey)
+    error("[RoxyAnimation:_initFromPath] Retained asset is not an imagetable: " .. path)
     return
   end
 
   self:_initCommon()
   self.imagetable = imagetable
-  self._length = #imagetable
-  self._refcount = 1
-  self._path = path -- Store for cache cleanup
-
-  -- Add to both caches
-  _pathCache[path] = self
-  _animationCache[imagetable] = self
+  self._length = _getImageTableLength(imagetable)
+  self._path = path
+  self._retainedPath = cacheKey
+  self._retainedPathReleased = false
 end
 
 -- ! Initialize From Image Table
@@ -167,8 +221,7 @@ end
 function RoxyAnimation:_initFromImagetable(imagetable)
   self:_initCommon()
   self.imagetable = imagetable
-  self._length = #imagetable
-  self._refcount = 1
+  self._length = _getImageTableLength(imagetable)
 end
 
 -- ! Initialize Common
@@ -182,9 +235,15 @@ function RoxyAnimation:_initCommon()
   self.isFirstCycle     = true
   self.isReversed       = false
   self.accumulator      = 0
+  self._refcount        = 1
+  self._destroyed       = false
+  self._path            = nil
+  self._retainedPath    = nil
+  self._retainedPathReleased = true
   self._pooledKey       = nil
   self._pooledAsset     = nil
   self._pooledAssetKind = nil
+  self._pooledAssetRecycled = true
 end
 
 --------------------------------------------------------------------------------
@@ -194,6 +253,7 @@ end
 -- ! Retain
 -- Increment reference count and return self for chaining
 function RoxyAnimation:retain()
+  if self._destroyed then return self end
   self._refcount = (self._refcount or 0) + 1
   return self
 end
@@ -201,31 +261,38 @@ end
 -- ! Release
 -- Decrement reference count, cleanup when reaches zero
 function RoxyAnimation:release()
-  if not self._refcount then return end
+  if self._destroyed or not self._refcount then return end
 
   self._refcount -= 1
   if self._refcount <= 0 then
-    self:_cleanupCaches()
-    self:_recyclePooledAsset()
     self:destroy()
   end
 end
 
--- ! Cleanup Caches
--- Remove from both caches when reference count reaches zero
-function RoxyAnimation:_cleanupCaches()
-  _animationCache[self.imagetable] = nil
-  if self._path then
-    _pathCache[self._path] = nil
+-- ! Is Destroyed
+-- Returns true after this animation has been destroyed
+function RoxyAnimation:isDestroyed()
+  return self._destroyed == true
+end
+
+-- ! Release Retained Path
+-- Releases a retained path imagetable exactly once
+function RoxyAnimation:_releaseRetainedPath()
+  if self._retainedPath and not self._retainedPathReleased then
+    releaseAsset(self._retainedPath)
+    self._retainedPathReleased = true
   end
+  self._retainedPath = nil
 end
 
 -- ! Recycle Pooled Asset
+-- Returns a checked-out pooled imagetable exactly once
 function RoxyAnimation:_recyclePooledAsset()
   local pooledAsset = self._pooledAsset
-  if pooledAsset and self._pooledKey and isFromPool(pooledAsset) then
+  if pooledAsset and self._pooledKey and not self._pooledAssetRecycled and isFromPool(pooledAsset) then
     recycleAsset(self._pooledKey, pooledAsset)
   end
+  self._pooledAssetRecycled = true
   self._pooledAsset = nil
   self._pooledKey = nil
   self._pooledAssetKind = nil
@@ -488,6 +555,12 @@ function RoxyAnimation:jumpToFrame(frame)
   return self
 end
 
+-- ! Jump To Specific Frame
+-- Legacy alias for jumpToFrame
+function RoxyAnimation:jumpToSpecificFrame(frame)
+  return self:jumpToFrame(frame)
+end
+
 -- ! Step Frame
 -- Step forward or backward by one frame with wrapping
 function RoxyAnimation:stepFrame(direction)
@@ -731,9 +804,13 @@ end
 -- ! Destroy
 -- Clean up resources and break references
 function RoxyAnimation:destroy()
-  -- Clear callback to prevent retention cycles
+  if self._destroyed then return end
+
+  self._destroyed = true
+  self:_releaseRetainedPath()
   self:_recyclePooledAsset()
 
+  -- Clear callback to prevent retention cycles
   if self.currentAnimation and self.currentAnimation.onCompleteCallback then
     self.currentAnimation.onCompleteCallback = nil
   end
@@ -752,6 +829,7 @@ function RoxyAnimation:destroy()
   self._refcount = nil
   self._length = nil
   self._path = nil
+  self._retainedPath = nil
 end
 
 --------------------------------------------------------------------------------
@@ -809,12 +887,13 @@ if myAnimation:isPlaying() then
   Log.debug("Current frame:", myAnimation:getCurrentFrame())          --#DEBUG
 end
 
--- Factory Methods for Asset Management
+-- Factory Methods share image data while returning fresh playback state
+local pathAnimation = RoxyAnimation.fromPath("images/shared-sheet")
 local poolAnimation = RoxyAnimation.fromPool("character_animations")
 local existingImagetable = playdate.graphics.imagetable.new("images/shared-sheet")
-local sharedAnimation = RoxyAnimation.fromImagetable(existingImagetable)
+local tableAnimation = RoxyAnimation.fromImagetable(existingImagetable)
 
--- Reference Counting (for shared resources)
+-- Explicit sharing is opt-in by retaining a known animation instance
 local myAnimation2 = myAnimation:retain() -- Increment reference count
 myAnimation:release()                     -- Decrement reference count
 myAnimation2:release()                    -- Final release cleans up resources

--- a/core/modules/Camera.lua
+++ b/core/modules/Camera.lua
@@ -4,65 +4,37 @@ roxy = roxy or {}
 roxy.Camera = roxy.Camera or {}
 local Camera <const> = roxy.Camera
 
---------------------------------------------------------------------------------
--- Standard Lua Function Aliases
---------------------------------------------------------------------------------
+local abs <const> = math.abs
+local min <const> = math.min
+local max <const> = math.max
+local sin <const> = math.sin
+local cos <const> = math.cos
+local pi  <const> = math.pi
 
--- Math functions
-local abs   <const> = math.abs
-local min   <const> = math.min
-local max   <const> = math.max
-local sin   <const> = math.sin
-local cos   <const> = math.cos
-local floor <const> = math.floor
-local ceil  <const> = math.ceil
-local pi    <const> = math.pi
-
--- Table functions
 local tableRemove <const> = table.remove
 local tableInsert <const> = table.insert
 
---------------------------------------------------------------------------------
--- Playdate SDK Aliases
---------------------------------------------------------------------------------
-
--- Core Playdate
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 local Timer     <const> = pd.timer
 
--- Timer functions
 local performAfterDelay <const> = Timer.performAfterDelay
 
--- Graphics functions
 local setDrawOffset <const> = Graphics.setDrawOffset
 
--- Sprite functions
 local redrawBackground <const> = Sprite.redrawBackground
 
---------------------------------------------------------------------------------
--- Roxy Utilities Function Aliases
---------------------------------------------------------------------------------
+local r <const> = roxy
 
--- Math functions
-local clamp <const> = roxy.Math.clamp
-local lerp  <const> = roxy.Math.lerp
-local round <const> = roxy.Math.roundInt
+local clamp <const> = r.Math.clamp
+local lerp  <const> = r.Math.lerp
+local round <const> = r.Math.roundInt
 
---------------------------------------------------------------------------------
--- Graphics Constants
---------------------------------------------------------------------------------
-
--- Display dimensions
-local DISPLAY_WIDTH   <const> = roxy.Graphics.displayWidth
-local DISPLAY_HEIGHT  <const> = roxy.Graphics.displayHeight
-local CENTER_X        <const> = roxy.Graphics.displayWidthCenter
-local CENTER_Y        <const> = roxy.Graphics.displayHeightCenter
-
---------------------------------------------------------------------------------
--- Default Values
---------------------------------------------------------------------------------
+local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
+local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
+local CENTER_X        <const> = r.Graphics.displayWidthCenter
+local CENTER_Y        <const> = r.Graphics.displayHeightCenter
 
 local CAMERA_SPEED_DEFAULT  <const> = 120   -- Default pan velocity (pixels per second)
 local FRICTION_DEFAULT      <const> = 0.85  -- Default friction factor (0 to 1, higher = slower stop)
@@ -111,7 +83,7 @@ Camera._maxX              = 0     -- Maximum x bound (effective)
 Camera._maxY              = 0     -- Maximum y bound (effective)
 Camera._shakeAmplitude    = 0     -- Shake intensity (pixels)
 Camera._shakeFrequency    = 0     -- Shake oscillations per second
-Camera._shakeAngularFreq  = 0     -- Cached angular frequency (frequency * 2π)
+Camera._shakeAngularFreq  = 0     -- Cached angular frequency (frequency * 2 * pi)
 Camera._shakeTimer        = 0     -- Tracks elapsed shake time
 Camera._deadZoneWidth     = 0     -- Dead zone width (pixels, 0 = disabled)
 Camera._deadZoneHeight    = 0     -- Dead zone height (pixels, 0 = disabled)
@@ -164,7 +136,7 @@ local function _commitOffset(dt)
     Camera._screenRight = totalOffsetX + DISPLAY_WIDTH
     Camera._screenBottom = totalOffsetY + DISPLAY_HEIGHT
     Camera._isActive = true
-    for i=1,#Camera._onOffsetChanged do
+    for i = 1, #Camera._onOffsetChanged do
       Camera._onOffsetChanged[i](totalOffsetX, totalOffsetY)
     end
   else
@@ -201,6 +173,37 @@ local function _recalculateEffectiveBounds()
   Camera._minY = min(Camera._bounds.y1, Camera._bounds.y2)
   Camera._maxY = max(Camera._bounds.y1, Camera._bounds.y2)
   Camera._hasBounds = true
+end
+
+-- ! Copy Bounds
+-- Copies a camera bounds table without keeping caller-owned table identity
+local function _copyBounds(bounds)
+  if not bounds then return nil end
+  return {
+    x1 = bounds.x1,
+    y1 = bounds.y1,
+    x2 = bounds.x2,
+    y2 = bounds.y2,
+  }
+end
+
+-- ! Copy List
+-- Copies an array-style listener list while preserving listener references
+local function _copyList(list)
+  local copy = {}
+  if type(list) ~= "table" then return copy end
+  for i = 1, #list do
+    copy[i] = list[i]
+  end
+  return copy
+end
+
+-- ! Validate Target
+-- Keeps restored snapshots from following an object that lost getPosition
+local function _validateTarget(target)
+  if target == nil then return nil end
+  if type(target.getPosition) == "function" then return target end
+  return nil
 end
 
 --------------------------------------------------------------------------------
@@ -410,6 +413,93 @@ function Camera.reset()
   Camera._isActive = true
 end
 
+-- ! Snapshot State
+-- Captures the active camera state so a paused scene can restore ownership after
+-- another scene resets the global camera during stack pop cleanup.
+function Camera._snapshotState()
+  return {
+    x                 = Camera.x,
+    y                 = Camera.y,
+    _velocityX        = Camera._velocityX,
+    _velocityY        = Camera._velocityY,
+    _targetX          = Camera._targetX,
+    _targetY          = Camera._targetY,
+    target            = Camera.target,
+    _logicalBounds    = _copyBounds(Camera._logicalBounds),
+    smoothing         = Camera.smoothing,
+    _shakeAmplitude   = Camera._shakeAmplitude,
+    shakeDuration     = Camera.shakeDuration,
+    _shakeFrequency   = Camera._shakeFrequency,
+    _shakeAngularFreq = Camera._shakeAngularFreq,
+    _shakeTimer       = Camera._shakeTimer,
+    _deadZoneWidth    = Camera._deadZoneWidth,
+    _deadZoneHeight   = Camera._deadZoneHeight,
+    _deadZoneHalfW    = Camera._deadZoneHalfW,
+    _deadZoneHalfH    = Camera._deadZoneHalfH,
+    friction          = Camera.friction,
+    _updateFunc       = Camera._updateFunc,
+    targetBiasX       = Camera.targetBiasX,
+    targetBiasY       = Camera.targetBiasY,
+    biasReturnRate    = Camera.biasReturnRate,
+    mode              = Camera.mode,
+    springFreq        = Camera.springFreq,
+    springDamp        = Camera.springDamp,
+    _onOffsetChanged  = _copyList(Camera._onOffsetChanged),
+  }
+end
+
+-- ! Restore State
+-- Restores a snapshot created by Camera._snapshotState().
+function Camera._restoreState(snapshot)
+  if type(snapshot) ~= "table" then return false end
+
+  local target = _validateTarget(snapshot.target)
+
+  Camera.x                  = snapshot.x or 0
+  Camera.y                  = snapshot.y or 0
+  Camera._velocityX         = snapshot._velocityX or 0
+  Camera._velocityY         = snapshot._velocityY or 0
+  Camera._targetX           = snapshot._targetX or Camera.x
+  Camera._targetY           = snapshot._targetY or Camera.y
+  Camera.target             = target
+  Camera.smoothing          = snapshot.smoothing or 0
+  Camera._shakeAmplitude    = snapshot._shakeAmplitude or 0
+  Camera.shakeDuration      = snapshot.shakeDuration or 0
+  Camera._shakeFrequency    = snapshot._shakeFrequency or 0
+  Camera._shakeAngularFreq  = snapshot._shakeAngularFreq or 0
+  Camera._shakeTimer        = snapshot._shakeTimer or 0
+  Camera._deadZoneWidth     = snapshot._deadZoneWidth or 0
+  Camera._deadZoneHeight    = snapshot._deadZoneHeight or 0
+  Camera._deadZoneHalfW     = snapshot._deadZoneHalfW or 0
+  Camera._deadZoneHalfH     = snapshot._deadZoneHalfH or 0
+  Camera.friction           = snapshot.friction ~= nil and snapshot.friction or FRICTION_DEFAULT
+  Camera.targetBiasX        = snapshot.targetBiasX or 0
+  Camera.targetBiasY        = snapshot.targetBiasY or 0
+  Camera.biasReturnRate     = snapshot.biasReturnRate or 6
+  Camera.mode               = snapshot.mode or "lerp"
+  Camera.springFreq         = snapshot.springFreq or 4.0
+  Camera.springDamp         = snapshot.springDamp or 0.9
+  Camera._onOffsetChanged   = _copyList(snapshot._onOffsetChanged)
+  Camera._logicalBounds     = _copyBounds(snapshot._logicalBounds)
+
+  _recalculateEffectiveBounds()
+
+  local updateFunc = snapshot._updateFunc
+  if updateFunc == Camera.updateFollow and Camera.target == nil then
+    updateFunc = Camera.updateStatic
+  end
+  Camera._updateFunc = updateFunc
+    or (Camera.target and Camera.updateFollow or Camera.updateStatic)
+
+  -- Force the draw offset and parallax listeners to observe the restored camera.
+  Camera._lastX = round(Camera.x) + 1
+  Camera._lastY = round(Camera.y) + 1
+  Camera._isActive = true
+  _commitOffset(0)
+
+  return true
+end
+
 -- ! Set Bias
 function Camera.setBias(x, y)
   Camera.targetBiasX, Camera.targetBiasY = x or 0, y or 0
@@ -508,11 +598,10 @@ function Camera.updateFollow(dt)
 
   -- Interpolate or set position
   if Camera.mode == "spring" then
-    -- critically damped spring (Tustin-ish simple integrator)
-    -- convert freq,damp to params
+    -- Critically damped spring
     local omega = 2 * pi * Camera.springFreq
     local zeta  = Camera.springDamp
-    -- velocity form
+    -- Velocity form
     local ax = omega * omega * (desiredX - Camera.x) - 2 * zeta * omega * Camera._velocityX
     local ay = omega * omega * (desiredY - Camera.y) - 2 * zeta * omega * Camera._velocityY
     Camera._velocityX = Camera._velocityX + ax * dt
@@ -700,3 +789,41 @@ end
 
 -- Default to static mode
 Camera._updateFunc = Camera.updateStatic
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Camera controls the global draw offset for world-space scenes.
+
+-- Follow a Player
+Camera.reset()
+Camera.setBounds({ x1 = 0, y1 = 0, x2 = 1600, y2 = 960 })
+Camera.setTarget(player, 10)
+Camera.setDeadZone(48, 32)
+
+function GameScene:update(dt)
+  Camera.update(dt)
+end
+
+-- Manual Panning
+Camera.reset()
+Camera.setBounds({ x1 = 0, y1 = 0, x2 = 1200, y2 = 800 })
+Camera.setPosition(200, 120)
+Camera.setPanVelocity(80, 0)
+
+function MapScene:update(dt)
+  Camera.update(dt)
+end
+
+-- Screen and World Coordinates
+local screenX, screenY = Camera.worldToScreen(player.x, player.y)
+local worldX, worldY = Camera.screenToWorld(200, 120)
+
+-- Shake and Stop Following
+Camera.shake(6, 0.35, 18)
+Camera.setTarget(nil)
+
+--]]

--- a/core/modules/Scene.lua
+++ b/core/modules/Scene.lua
@@ -13,16 +13,27 @@ local getDisplayImage <const> = Graphics.getDisplayImage
 local setBackgroundDrawing  <const> = Sprite.setBackgroundDrawingCallback
 local redrawBackground      <const> = Sprite.redrawBackground
 
--- Cache a reference to your base scene class draw, if available
+-- Cache base scene class draw if available
 local BaseSceneDraw <const> = (rawget(_G, "RoxyScene") and RoxyScene.draw) or nil
 
 local MAX_SCENE_DEPTH <const> = 32
+
+local SCENE_PAUSE_NONE        <const> = 0
+local SCENE_PAUSE_PLAYBACK    <const> = 1
+local SCENE_PAUSE_UPDATES     <const> = 2
+local SCENE_PAUSE_COLLISIONS  <const> = 4
+local SCENE_PAUSE_ALL         <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
 
 -- Shared no-op function to avoid per-activation allocations
 local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
 -- Global
-Scene.currentScene = nil
+Scene.currentScene            = nil
+Scene._SCENE_PAUSE_NONE       = SCENE_PAUSE_NONE
+Scene._SCENE_PAUSE_PLAYBACK   = SCENE_PAUSE_PLAYBACK
+Scene._SCENE_PAUSE_UPDATES    = SCENE_PAUSE_UPDATES
+Scene._SCENE_PAUSE_COLLISIONS = SCENE_PAUSE_COLLISIONS
+Scene._SCENE_PAUSE_ALL        = SCENE_PAUSE_ALL
 
 -- Local
 local scenes
@@ -31,9 +42,72 @@ local updateList
 local bgList
 local drawList
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Utilities
--- ----------------------------------------
+--------------------------------------------------------------------------------
+
+-- ! Utility: Get Sprite Pause Mask
+-- Internal helper; mask values are an implementation detail, not public API.
+function Scene._getSpritePauseMask(sprite)
+  if not sprite then return SCENE_PAUSE_NONE end
+
+  local mask = sprite._roxyScenePauseMask
+  if mask == nil then return SCENE_PAUSE_ALL end
+  return mask
+end
+
+-- ! Utility: Set Sprite Pause Classification
+function Scene.setSpritePauseClassification(sprite, opts)
+  if not sprite then return nil end
+
+  local oldMask = Scene._getSpritePauseMask(sprite)
+  local newMask = nil
+
+  if opts == nil then
+    sprite._roxyScenePauseMask = nil
+    newMask = SCENE_PAUSE_ALL
+  else
+    if type(opts) ~= "table" then
+      Log.error("[Scene.setSpritePauseClassification] Expected table or nil", 2)
+    end
+
+    local playback = opts.playback
+    local updates = opts.updates
+    local collisions = opts.collisions
+
+    -- Validate in all builds; silent coercion makes pause state difficult to trace.
+    if playback ~= nil and type(playback) ~= "boolean" then
+      Log.error("[Scene.setSpritePauseClassification] playback must be a boolean when supplied", 2)
+    end
+    if updates ~= nil and type(updates) ~= "boolean" then
+      Log.error("[Scene.setSpritePauseClassification] updates must be a boolean when supplied", 2)
+    end
+    if collisions ~= nil and type(collisions) ~= "boolean" then
+      Log.error("[Scene.setSpritePauseClassification] collisions must be a boolean when supplied", 2)
+    end
+
+    newMask = SCENE_PAUSE_NONE
+    if playback == true then newMask = newMask + SCENE_PAUSE_PLAYBACK end
+    if updates == true then newMask = newMask + SCENE_PAUSE_UPDATES end
+    if collisions == true then newMask = newMask + SCENE_PAUSE_COLLISIONS end
+    sprite._roxyScenePauseMask = newMask
+  end
+
+  if oldMask ~= newMask then
+    local scene = sprite.scene
+    if scene and type(scene._spritePauseClassificationDidChange) == "function" then
+      scene:_spritePauseClassificationDidChange(sprite, oldMask, newMask)
+    end
+  end
+
+  return sprite
+end
+
+if type(Sprite.setPauseClassification) ~= "function" then
+  function Sprite:setPauseClassification(opts)
+    return Scene.setSpritePauseClassification(self, opts)
+  end
+end
 
 -- ! Utility: Rebuild Lists
 -- Rebuilds the update lists based on the current stack.
@@ -138,9 +212,9 @@ local function activateScene(scene)
   end
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- ! Initialize Scene module
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 function Scene.init()
   -- Clear registered scenes, stack and lists
@@ -155,9 +229,9 @@ function Scene.init()
   rebuildLists()
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Scene Registration
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Register Scenes
 function Scene.registerScenes(...)
@@ -208,9 +282,9 @@ function Scene.registerScenes(...)
   Log.error("[Scene.registerScenes] Invalid parameters to roxy.Scene.registerScenes.", 2) --#DEBUG
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Scene Stack Management
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Replace Scene Raw
 function Scene.replaceRaw(newScene)
@@ -330,9 +404,9 @@ function Scene.invalidateLists()
   rebuildLists()
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Scene State / Getters
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Get Current Scene
 function Scene.getCurrentScene()
@@ -359,8 +433,61 @@ function Scene.getBackgroundList()
   return bgList
 end
 
--- ! Get Draw List (Added)
+-- ! Get Draw List
 -- Returns the cached draw list honoring blocksLowerDraw and isVisible flags.
 function Scene.getDrawList()
   return drawList
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Scene manages registration, stack flow, background updates, and sprite pause classification.
+
+-- Register and Start Scenes
+Scene.init()
+Scene.registerScenes({
+  Title    = TitleScene,
+  Gameplay = GameplayScene,
+  Pause    = PauseScene,
+})
+
+Scene.replaceScene(TitleScene)
+
+-- Stack a Pause Scene
+Scene.pushScene(PauseScene)
+local currentScene = Scene.getCurrentScene()
+local depth = Scene.getStackDepth()
+Scene.popScene()
+
+-- Keep a Background Scene Updating
+GameplayScene.alwaysUpdate = true
+GameplayScene.updateBackground = true
+Scene.invalidateLists()
+
+-- Classify Sprites for Scene Pause
+local player = RoxySprite({ name = "player" })
+player:setPauseClassification(nil) -- Default dynamic behavior
+
+local decoration = playdate.graphics.sprite.new()
+decoration:setPauseClassification({}) -- Static; skip pause/resume work
+
+local parallaxLayer = playdate.graphics.sprite.new()
+parallaxLayer:setPauseClassification({ updates = true })
+
+local wall = playdate.graphics.sprite.new()
+Scene.setSpritePauseClassification(wall, { collisions = true })
+
+-- Manual Loop Integration
+for _, scene in ipairs(Scene.getUpdateList()) do
+  scene:update(dt)
+end
+
+for _, scene in ipairs(Scene.getDrawList()) do
+  scene:draw(dt)
+end
+
+--]]

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -55,7 +55,7 @@ local _imageCallbacks = setmetatable({}, { __mode = "k" }) -- Cache: image --> f
 --------------------------------------------------------------------------------
 
 -- ! Helper: Remove Item From Array
--- Removes every matching item and returns whether the array changed.
+-- Removes every matching item and returns whether the array changed
 local function _removeItem(array, item)
   if not array or not item then return false end
 
@@ -70,7 +70,7 @@ local function _removeItem(array, item)
 end
 
 -- ! Helper: Has Item In Array
--- Returns true when the array contains the given item.
+-- Returns true when the array contains the given item
 local function _hasItem(array, item)
   if not array or not item then return false end
 
@@ -81,7 +81,7 @@ local function _hasItem(array, item)
 end
 
 -- ! Helper: Is Bounds Table
--- Returns true for camera bounds tables accepted by Camera.setBounds.
+-- Returns true for camera bounds tables accepted by Camera.setBounds
 local function _isBoundsTable(bounds)
   return type(bounds) == "table"
      and type(bounds.x1) == "number"
@@ -91,14 +91,14 @@ local function _isBoundsTable(bounds)
 end
 
 -- ! Helper: Read XY Pair
--- Reads either { x, y } or array-style { x, y } option pairs.
+-- Reads either { x, y } or array-style { x, y } option pairs
 local function _readXYPair(value)
   if type(value) ~= "table" then return nil, nil end
   return value.x or value[1], value.y or value[2]
 end
 
 -- ! Helper: Get Color Callback
--- Builds (and returns) a drawing callback for a solid color.
+-- Builds (and returns) a drawing callback for a solid color
 local function _getColorCallback(color)
   local fn = _colorCallbacks[color]
   if fn == nil then
@@ -118,7 +118,7 @@ local function _getImageCallback(img)
   local fn = _imageCallbacks[img]
   if fn == nil then
     fn = function(x, y, width, height)
-      -- Set a clip to the dirty rect, then draw the full image once.
+      -- Set a clip to the dirty rect, then draw the full image once
       setClipRect(x, y, width, height)  -- Only redraw the dirty rect
       img:draw(0, 0, UNFLIPPED)         -- Avoid per-call src rect; let clip do the work
       clearClipRect()                   -- Restore clip
@@ -181,7 +181,7 @@ function RoxyScene:enter()
   end
   self._spriteAutoAddQueue = {}
 
-  -- Activate tilemap resources that cannot be created detached from display.
+  -- Activate tilemap resources that cannot be created detached from display
   for i = 1, #self.tilemaps do
     local tilemap = self.tilemaps[i]
     if tilemap and tilemap.sceneDidEnter then
@@ -208,6 +208,7 @@ end
 
 -- ! Activate Camera
 -- Opt-in scene camera setup. Scenes that do not use Camera pay no enter cost.
+-- Supports tilemap bounds, raw bounds, or explicitly clearing bounds.
 function RoxyScene:activateCamera(opts)
   opts = opts or {}
 
@@ -451,7 +452,7 @@ function RoxyScene:removeSprite(sprite)
 end
 
 -- ! Unregister Sprite
--- Private cleanup path used by tilemaps and direct scene sprite removal.
+-- Private cleanup path used by tilemaps and direct scene sprite removal
 function RoxyScene:_unregisterSprite(sprite, removeFromDisplay)
   if not sprite then return end
 
@@ -529,7 +530,12 @@ function RoxyScene:removeAllSprites()
     if sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
     end
-    sprite:remove()
+    -- Prefer view-aware cleanup so pooled sprite assets are released
+    if sprite.removeAndClearView then
+      sprite:removeAndClearView()
+    else
+      sprite:remove()
+    end
   end
   self.sprites = {}
   self._spriteAutoAddQueue = {}
@@ -545,7 +551,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Add Tilemap
--- Attaches a load-only tilemap to this scene.
+-- Attaches a load-only tilemap to this scene
 function RoxyScene:addTilemap(tilemap)
   if not tilemap then return false end
 
@@ -567,7 +573,7 @@ function RoxyScene:addTilemap(tilemap)
 end
 
 -- ! Remove Tilemap
--- Destroys a tilemap and unregisters it from this scene.
+-- Destroys a tilemap and unregisters it from this scene
 function RoxyScene:removeTilemap(tilemap)
   if not tilemap then return false end
   if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
@@ -582,7 +588,7 @@ function RoxyScene:removeTilemap(tilemap)
 end
 
 -- ! Detach Tilemap
--- Detaches scene/display state while preserving pooled tilemap resources.
+-- Detaches scene/display state while preserving pooled tilemap resources
 function RoxyScene:detachTilemap(tilemap)
   if not tilemap then return false end
   if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
@@ -596,7 +602,7 @@ function RoxyScene:detachTilemap(tilemap)
 end
 
 -- ! Unregister Tilemap
--- Removes a tilemap from scene ownership without destroying it.
+-- Removes a tilemap from scene ownership without destroying it
 function RoxyScene:_unregisterTilemap(tilemap)
   if not tilemap then return end
 
@@ -626,7 +632,7 @@ function RoxyScene:removeAllTilemaps()
 end
 
 -- ! Spawn Tilemap
--- Convenience helper that creates and attaches an orthogonal tilemap.
+-- Convenience helper that creates and attaches an orthogonal tilemap
 function RoxyScene:spawnTilemap(path, tilemapOpts)
   local tilemap = RoxyOrthoTilemap(path, tilemapOpts)
   self:addTilemap(tilemap)
@@ -755,7 +761,7 @@ function GameplayScene:start()
 end
 
 function GameplayScene:update(dt)
-  -- Game logic here.
+  -- Game logic here
 end
 
 function GameplayScene:cleanup()

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -38,12 +38,27 @@ local setCameraDeadZone     <const> = Camera.setDeadZone
 local setCameraFriction     <const> = Camera.setFriction
 local setCameraBias         <const> = Camera.setBias
 local setCameraMode         <const> = Camera.setMode
+local snapshotCameraState   <const> = Camera._snapshotState
+local restoreCameraState    <const> = Camera._restoreState
 
 local COLOR_WHITE <const> = Graphics.kColorWhite
 local COLOR_BLACK <const> = Graphics.kColorBlack
 local CLEAR_COLOR <const> = COLOR_WHITE
 
 local UNFLIPPED <const> = Graphics.kImageUnflipped
+
+local SCENE_PAUSE_NONE        <const> = 0
+local SCENE_PAUSE_PLAYBACK    <const> = 1
+local SCENE_PAUSE_UPDATES     <const> = 2
+local SCENE_PAUSE_COLLISIONS  <const> = 4
+local SCENE_PAUSE_PLAYBACK_UPDATES <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_UPDATES
+local SCENE_PAUSE_PLAYBACK_COLLISIONS <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_COLLISIONS
+local SCENE_PAUSE_UPDATES_COLLISIONS <const> = SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
+local SCENE_PAUSE_ALL <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
+
+local RESTORE_UPDATES     <const> = 1
+local RESTORE_COLLISIONS  <const> = 2
+local SHOULD_PLAY         <const> = 4
 
 local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
@@ -149,6 +164,472 @@ local function _readXYPair(value)
   return value.x or value[1], value.y or value[2]
 end
 
+-- ! Helper: Get Scene Pause Mask
+-- Nil classification fields keep custom sprites on the legacy full-dynamic path;
+-- False opts a subsystem out. The scene caches this at registration time.
+local function _getScenePauseMask(sprite)
+  if not sprite then return SCENE_PAUSE_NONE end
+
+  local mask = SCENE_PAUSE_NONE
+  if sprite._roxyScenePausePlayback ~= false then
+    mask = mask + SCENE_PAUSE_PLAYBACK
+  end
+  if sprite._roxyScenePauseUpdates ~= false then
+    mask = mask + SCENE_PAUSE_UPDATES
+  end
+  if sprite._roxyScenePauseCollisions ~= false then
+    mask = mask + SCENE_PAUSE_COLLISIONS
+  end
+  return mask
+end
+
+-- ! Helper: Clear Scene Pause Registration
+-- Clears registration-only pause fields when the scene stops tracking a sprite
+local function _clearScenePauseRegistration(sprite)
+  if not sprite then return end
+
+  sprite._roxyScenePauseMask = nil
+
+  -- Remove fields from older cache-based builds when dirty scenes are recycled.
+  sprite._roxyScenePausePause = nil
+  sprite._roxyScenePausePlay = nil
+  sprite._roxyScenePauseGetIsPaused = nil
+  sprite._roxyScenePauseReadIsPaused = nil
+  sprite._roxyScenePauseSetUpdatesEnabled = nil
+  sprite._roxyScenePauseUpdatesEnabled = nil
+  sprite._roxyScenePauseSetCollisionsActive = nil
+  sprite._roxyScenePauseSetCollisionsEnabled = nil
+  sprite._roxyScenePauseCollisionsEnabled = nil
+end
+
+-- ! Helper: Remove Sprite From Scene Pause Buckets
+local function _removeFromScenePauseBuckets(scene, sprite)
+  _removeIndexed(scene._pauseSprites, scene._pauseSpriteIndex, sprite)
+  _removeIndexed(scene._pauseUpdateSprites, scene._pauseUpdateSpriteIndex, sprite)
+  _removeIndexed(scene._pauseCollisionSprites, scene._pauseCollisionSpriteIndex, sprite)
+end
+
+-- ! Helper: Add Sprite To Scene Pause Bucket
+local function _addToScenePauseBucket(scene, sprite, pauseMask)
+  if pauseMask == SCENE_PAUSE_NONE then return end
+
+  if pauseMask == SCENE_PAUSE_COLLISIONS then
+    _appendIndexed(scene._pauseCollisionSprites, scene._pauseCollisionSpriteIndex, sprite)
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    _appendIndexed(scene._pauseUpdateSprites, scene._pauseUpdateSpriteIndex, sprite)
+  else
+    _appendIndexed(scene._pauseSprites, scene._pauseSpriteIndex, sprite)
+  end
+end
+
+-- ! Helper: Scene Pause Mask Has Playback
+local function _pauseMaskHasPlayback(mask)
+  return mask == SCENE_PAUSE_PLAYBACK
+      or mask == SCENE_PAUSE_PLAYBACK_UPDATES
+      or mask == SCENE_PAUSE_PLAYBACK_COLLISIONS
+      or mask == SCENE_PAUSE_ALL
+end
+
+-- ! Helper: Scene Pause Mask Has Updates
+local function _pauseMaskHasUpdates(mask)
+  return mask == SCENE_PAUSE_UPDATES
+      or mask == SCENE_PAUSE_PLAYBACK_UPDATES
+      or mask == SCENE_PAUSE_UPDATES_COLLISIONS
+      or mask == SCENE_PAUSE_ALL
+end
+
+-- ! Helper: Scene Pause Mask Has Collisions
+local function _pauseMaskHasCollisions(mask)
+  return mask == SCENE_PAUSE_COLLISIONS
+      or mask == SCENE_PAUSE_PLAYBACK_COLLISIONS
+      or mask == SCENE_PAUSE_UPDATES_COLLISIONS
+      or mask == SCENE_PAUSE_ALL
+end
+
+-- ! Helper: Read Sprite Paused State
+-- Returns (isPaused, didRead). Custom sprites without state keep legacy resume.
+local function _readSpritePaused(sprite)
+  local getIsPaused = sprite and sprite.getIsPaused
+  if type(getIsPaused) == "function" then
+    local value = getIsPaused(sprite)
+    if type(value) == "boolean" then
+      return value, true
+    end
+  end
+
+  local value = sprite and sprite.isPaused
+  if type(value) == "boolean" then
+    return value, true
+  end
+
+  return nil, false
+end
+
+-- ! Helper: Read Sprite Updates Enabled
+local function _readSpriteUpdatesEnabled(sprite)
+  local updatesEnabled = sprite and sprite.updatesEnabled
+  if type(updatesEnabled) ~= "function" then
+    return true
+  end
+
+  local value = updatesEnabled(sprite)
+  return value ~= false and value ~= 0
+end
+
+-- ! Helper: Read Sprite Collisions Enabled
+local function _readSpriteCollisionsEnabled(sprite)
+  local collisionsEnabled = sprite and sprite.collisionsEnabled
+  if type(collisionsEnabled) ~= "function" then
+    return true
+  end
+
+  local value = collisionsEnabled(sprite)
+  return value ~= false and value ~= 0
+end
+
+-- ! Helper: Run Sprite Pause
+local function _runSpritePause(sprite)
+  local pause = sprite and sprite.pause
+  if type(pause) ~= "function" then return end
+
+  pause(sprite)
+end
+
+-- ! Helper: Run Sprite Play
+local function _runSpritePlay(sprite)
+  local play = sprite and sprite.play
+  if type(play) ~= "function" then return end
+
+  play(sprite)
+end
+
+-- ! Helper: Set Sprite Updates Active
+local function _setSpriteUpdatesActive(sprite, flag)
+  local setter = sprite and sprite.setUpdatesEnabled
+  if type(setter) ~= "function" then return end
+
+  setter(sprite, flag)
+end
+
+-- ! Helper: Set Sprite Collisions Active
+-- RoxySprite exposes a scene-pause-only path that preserves desired collisions.
+local function _setSpriteCollisionsActive(sprite, flag)
+  local sceneSetter = sprite and sprite._setScenePauseCollisionsActive
+  if type(sceneSetter) == "function" then
+    sceneSetter(sprite, flag)
+    return
+  end
+
+  local setter = sprite and sprite.setCollisionsEnabled
+  if type(setter) ~= "function" then return end
+
+  setter(sprite, flag)
+end
+
+-- ! Helper: Clear Scene Pause Snapshot
+local function _clearScenePauseSnapshot(scene, sprite)
+  if not sprite then return end
+  if scene ~= nil and sprite._roxyScenePauseOwner ~= scene then return end
+
+  sprite._roxyScenePauseOwner = nil
+  sprite._roxyScenePauseState = nil
+
+  -- Remove fields from older snapshot builds when dirty scenes are recycled.
+  sprite._roxyScenePauseHadUpdates = nil
+  sprite._roxyScenePauseHadCollisions = nil
+  sprite._roxyScenePauseShouldPlay = nil
+end
+
+-- ! Helper: Reapply Existing Scene Pause
+-- Used when add() re-enables sprite systems while the owning scene is paused.
+local function _reapplyScenePauseSprite(sprite, pauseMask)
+  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+
+  if _pauseMaskHasPlayback(pauseMask) then
+    local isPaused, didReadPaused = _readSpritePaused(sprite)
+    if (not didReadPaused) or isPaused == false then
+      _runSpritePause(sprite)
+    end
+  end
+  if _pauseMaskHasUpdates(pauseMask) then
+    _setSpriteUpdatesActive(sprite, false)
+  end
+  if _pauseMaskHasCollisions(pauseMask) then
+    _setSpriteCollisionsActive(sprite, false)
+  end
+end
+
+-- ! Helper: Build Scene Pause State
+-- Stores only the restore bits needed for the subsystems this mask pauses
+local function _buildScenePauseState(sprite, pauseMask)
+  local state = 0
+
+  if _pauseMaskHasPlayback(pauseMask) then
+    local wasPaused, didReadPaused = _readSpritePaused(sprite)
+    if (not didReadPaused) or wasPaused == false then
+      state = state + SHOULD_PLAY
+    end
+  end
+
+  if _pauseMaskHasUpdates(pauseMask) and _readSpriteUpdatesEnabled(sprite) then
+    state = state + RESTORE_UPDATES
+  end
+
+  if _pauseMaskHasCollisions(pauseMask) and _readSpriteCollisionsEnabled(sprite) then
+    state = state + RESTORE_COLLISIONS
+  end
+
+  return state
+end
+
+-- ! Helper: Pause Scene Collision Sprite
+local function _pauseSceneCollisionSprite(scene, sprite)
+  if not sprite then return end
+
+  if sprite._roxyScenePauseOwner == scene then
+    _setSpriteCollisionsActive(sprite, false)
+    return
+  elseif sprite._roxyScenePauseOwner ~= nil then
+    _clearScenePauseSnapshot(nil, sprite)
+  end
+
+  local state = _readSpriteCollisionsEnabled(sprite) and RESTORE_COLLISIONS or 0
+  sprite._roxyScenePauseOwner = scene
+  sprite._roxyScenePauseState = state
+
+  if (state & RESTORE_COLLISIONS) ~= 0 then
+    _setSpriteCollisionsActive(sprite, false)
+  end
+end
+
+-- ! Helper: Resume Scene Collision Sprite
+local function _resumeSceneCollisionSprite(scene, sprite)
+  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+
+  local state = sprite._roxyScenePauseState or 0
+  _setSpriteCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+  _clearScenePauseSnapshot(scene, sprite)
+end
+
+-- ! Helper: Pause Scene Update Sprite
+local function _pauseSceneUpdateSprite(scene, sprite)
+  if not sprite then return end
+
+  if sprite._roxyScenePauseOwner == scene then
+    _setSpriteUpdatesActive(sprite, false)
+    return
+  elseif sprite._roxyScenePauseOwner ~= nil then
+    _clearScenePauseSnapshot(nil, sprite)
+  end
+
+  local state = _readSpriteUpdatesEnabled(sprite) and RESTORE_UPDATES or 0
+  sprite._roxyScenePauseOwner = scene
+  sprite._roxyScenePauseState = state
+
+  if (state & RESTORE_UPDATES) ~= 0 then
+    _setSpriteUpdatesActive(sprite, false)
+  end
+end
+
+-- ! Helper: Resume Scene Update Sprite
+local function _resumeSceneUpdateSprite(scene, sprite)
+  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+
+  local state = sprite._roxyScenePauseState or 0
+  _setSpriteUpdatesActive(sprite, (state & RESTORE_UPDATES) ~= 0)
+  _clearScenePauseSnapshot(scene, sprite)
+end
+
+-- ! Helper: Pause Scene Sprite
+-- Snapshots update, collision, and playback state before any mutation.
+local function _pauseSceneSprite(scene, sprite, pauseMask)
+  if not sprite then return end
+
+  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  if pauseMask == SCENE_PAUSE_NONE then return end
+  if sprite._roxyScenePauseMask == nil then
+    sprite._roxyScenePauseMask = pauseMask
+  end
+
+  if sprite._roxyScenePauseOwner == scene then
+    _reapplyScenePauseSprite(sprite, pauseMask)
+    return
+  elseif sprite._roxyScenePauseOwner ~= nil then
+    _clearScenePauseSnapshot(nil, sprite)
+  end
+
+  if pauseMask == SCENE_PAUSE_ALL then
+    local state = 0
+    local getIsPaused = sprite.getIsPaused
+    if type(getIsPaused) == "function" then
+      local wasPaused = getIsPaused(sprite)
+      if type(wasPaused) ~= "boolean" or wasPaused == false then
+        state = state + SHOULD_PLAY
+      end
+    else
+      local wasPaused = sprite.isPaused
+      if type(wasPaused) ~= "boolean" or wasPaused == false then
+        state = state + SHOULD_PLAY
+      end
+    end
+
+    local updatesEnabled = sprite.updatesEnabled
+    local updatesValue = type(updatesEnabled) == "function" and updatesEnabled(sprite) or nil
+    if updatesValue == nil or (updatesValue ~= false and updatesValue ~= 0) then
+      state = state + RESTORE_UPDATES
+    end
+
+    local collisionsEnabled = sprite.collisionsEnabled
+    local collisionsValue = type(collisionsEnabled) == "function" and collisionsEnabled(sprite) or nil
+    if collisionsValue == nil or (collisionsValue ~= false and collisionsValue ~= 0) then
+      state = state + RESTORE_COLLISIONS
+    end
+
+    sprite._roxyScenePauseOwner = scene
+    sprite._roxyScenePauseState = state
+
+    local pause = sprite.pause
+    if type(pause) == "function" then pause(sprite) end
+
+    if (state & RESTORE_UPDATES) ~= 0 then
+      local setUpdatesEnabled = sprite.setUpdatesEnabled
+      if type(setUpdatesEnabled) == "function" then setUpdatesEnabled(sprite, false) end
+    end
+
+    if (state & RESTORE_COLLISIONS) ~= 0 then
+      local setCollisionsActive = sprite._setScenePauseCollisionsActive
+      if type(setCollisionsActive) == "function" then
+        setCollisionsActive(sprite, false)
+      else
+        local setCollisionsEnabled = sprite.setCollisionsEnabled
+        if type(setCollisionsEnabled) == "function" then setCollisionsEnabled(sprite, false) end
+      end
+    end
+    return
+  end
+
+  if pauseMask == SCENE_PAUSE_COLLISIONS then
+    _pauseSceneCollisionSprite(scene, sprite)
+    return
+  end
+
+  if pauseMask == SCENE_PAUSE_UPDATES then
+    _pauseSceneUpdateSprite(scene, sprite)
+    return
+  end
+
+  local pausePlayback = _pauseMaskHasPlayback(pauseMask)
+  local pauseUpdates = _pauseMaskHasUpdates(pauseMask)
+  local pauseCollisions = _pauseMaskHasCollisions(pauseMask)
+  local state = _buildScenePauseState(sprite, pauseMask)
+
+  sprite._roxyScenePauseOwner = scene
+  sprite._roxyScenePauseState = state
+
+  if pausePlayback then _runSpritePause(sprite) end
+  if pauseUpdates and (state & RESTORE_UPDATES) ~= 0 then
+    _setSpriteUpdatesActive(sprite, false)
+  end
+  if pauseCollisions and (state & RESTORE_COLLISIONS) ~= 0 then
+    _setSpriteCollisionsActive(sprite, false)
+  end
+end
+
+-- ! Helper: Resume Scene Sprite
+local function _resumeSceneSprite(scene, sprite)
+  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+
+  local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  if pauseMask == SCENE_PAUSE_NONE then
+    _clearScenePauseSnapshot(scene, sprite)
+    return
+  end
+
+  if pauseMask == SCENE_PAUSE_ALL then
+    local state = sprite._roxyScenePauseState or 0
+
+    if (state & SHOULD_PLAY) ~= 0 then
+      local play = sprite.play
+      if type(play) == "function" then play(sprite) end
+    end
+
+    local setUpdatesEnabled = sprite.setUpdatesEnabled
+    if type(setUpdatesEnabled) == "function" then
+      setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
+    end
+
+    local setCollisionsActive = sprite._setScenePauseCollisionsActive
+    if type(setCollisionsActive) == "function" then
+      setCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+    else
+      local setCollisionsEnabled = sprite.setCollisionsEnabled
+      if type(setCollisionsEnabled) == "function" then
+        setCollisionsEnabled(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+      end
+    end
+
+    _clearScenePauseSnapshot(scene, sprite)
+    return
+  end
+
+  if pauseMask == SCENE_PAUSE_COLLISIONS then
+    _resumeSceneCollisionSprite(scene, sprite)
+    return
+  end
+
+  if pauseMask == SCENE_PAUSE_UPDATES then
+    _resumeSceneUpdateSprite(scene, sprite)
+    return
+  end
+
+  local state = sprite._roxyScenePauseState or 0
+  local pausePlayback = _pauseMaskHasPlayback(pauseMask)
+  local pauseUpdates = _pauseMaskHasUpdates(pauseMask)
+  local pauseCollisions = _pauseMaskHasCollisions(pauseMask)
+
+  if pausePlayback and (state & SHOULD_PLAY) ~= 0 then _runSpritePlay(sprite) end
+  if pauseUpdates then
+    _setSpriteUpdatesActive(sprite, (state & RESTORE_UPDATES) ~= 0)
+  end
+  if pauseCollisions then
+    _setSpriteCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+  end
+
+  _clearScenePauseSnapshot(scene, sprite)
+end
+
+-- ! Helper: Pause Registered Scene Sprite
+local function _pauseRegisteredSceneSprite(scene, sprite, pauseMask)
+  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  if pauseMask == SCENE_PAUSE_COLLISIONS then
+    _pauseSceneCollisionSprite(scene, sprite)
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    _pauseSceneUpdateSprite(scene, sprite)
+  elseif pauseMask ~= SCENE_PAUSE_NONE then
+    _pauseSceneSprite(scene, sprite, pauseMask)
+  end
+end
+
+-- ! Helper: Resume Registered Scene Sprite
+local function _resumeRegisteredSceneSprite(scene, sprite, pauseMask)
+  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  if pauseMask == SCENE_PAUSE_COLLISIONS then
+    _resumeSceneCollisionSprite(scene, sprite)
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    _resumeSceneUpdateSprite(scene, sprite)
+  elseif pauseMask ~= SCENE_PAUSE_NONE then
+    _resumeSceneSprite(scene, sprite)
+  end
+end
+
+-- ! Helper: Restore Scene Pause Before Unregister
+-- Normal removal detaches restored sprites; transfers preserve captured state.
+local function _restoreScenePauseBeforeUnregister(scene, sprite)
+  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+
+  _resumeRegisteredSceneSprite(scene, sprite, sprite._roxyScenePauseMask)
+end
+
 -- ! Helper: Get Color Callback
 -- Builds (and returns) a drawing callback for a solid color
 local function _getColorCallback(color)
@@ -180,6 +661,55 @@ local function _getImageCallback(img)
   return fn
 end
 
+-- ! Helper: Read Sequence Playing
+-- Returns readable running state when the sequence exposes one
+local function _readSequencePlaying(sequence)
+  if not sequence then return nil end
+  if type(sequence.isPlaying) == "function" then
+    return sequence:isPlaying() == true
+  end
+  if type(sequence.isRunning) == "boolean" then
+    return sequence.isRunning
+  end
+  return nil
+end
+
+-- ! Helper: Clear Scene Pause Sequence Snapshot
+-- Clears sequence pause fields owned by the pausing scene
+local function _clearScenePauseSequenceSnapshot(scene, sequence)
+  if not sequence or sequence._roxyScenePauseOwner ~= scene then return end
+  sequence._roxyScenePauseOwner = nil
+  sequence._roxyScenePauseWasRunning = nil
+end
+
+-- ! Helper: Pause Scene Sequence
+-- Pauses a scene-managed sequence while remembering whether it should resume
+local function _pauseSceneSequence(scene, sequence)
+  if not sequence then return end
+  local wasRunning = _readSequencePlaying(sequence)
+  local shouldPause = wasRunning ~= false
+
+  sequence._roxyScenePauseOwner = scene
+  sequence._roxyScenePauseWasRunning = shouldPause
+
+  if shouldPause and type(sequence.pause) == "function" then
+    sequence:pause()
+  end
+end
+
+-- ! Helper: Resume Scene Sequence
+-- Restores a sequence paused by the same scene
+local function _resumeSceneSequence(scene, sequence)
+  if not sequence or sequence._roxyScenePauseOwner ~= scene then return end
+
+  local shouldResume = sequence._roxyScenePauseWasRunning ~= false
+  if shouldResume and type(sequence.play) == "function" then
+    sequence:play()
+  end
+
+  _clearScenePauseSequenceSnapshot(scene, sequence)
+end
+
 --------------------------------------------------------------------------------
 -- ! Class Definition and Initialize
 --------------------------------------------------------------------------------
@@ -206,7 +736,15 @@ function RoxyScene:init(background)
   self._spriteIndex = {}
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
+  self._pauseSprites = {}
+  self._pauseSpriteIndex = {}
+  self._pauseUpdateSprites = {}
+  self._pauseUpdateSpriteIndex = {}
+  self._pauseCollisionSprites = {}
+  self._pauseCollisionSpriteIndex = {}
   self._sequenceAutoStartQueue = {}
+  self._roxyCameraActivated = false
+  self._roxyScenePauseCameraSnapshot = nil
 
   -- Sensible defaults used by Scene draw filtering
   self.isVisible = true
@@ -232,7 +770,11 @@ function RoxyScene:enter()
   -- Flush any queued sprite auto-adds
   local spriteQueue = self._spriteAutoAddQueue
   for i = 1, #spriteQueue do
-    spriteQueue[i]:add()
+    local sprite = spriteQueue[i]
+    sprite:add()
+    if self.isPaused then
+      _pauseRegisteredSceneSprite(self, sprite)
+    end
   end
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
@@ -267,6 +809,7 @@ end
 -- Supports tilemap bounds, raw bounds, or explicitly clearing bounds.
 function RoxyScene:activateCamera(opts)
   opts = opts or {}
+  self._roxyCameraActivated = true
 
   --#DEBUG START
   if opts.cameraBounds ~= nil then
@@ -331,12 +874,12 @@ end
 
 -- ! Update
 function RoxyScene:update(dt)
-  -- noop by default
+  -- No-op by default
 end
 
 -- ! Draw
 function RoxyScene:draw(dt)
-  -- noop by default
+  -- No-op by default
 end
 
 -- ! Pause
@@ -345,20 +888,158 @@ function RoxyScene:pause()
   Log.debug("[RoxyScene:pause] Pausing Scene: " .. self.name) --#DEBUG
   self.isPaused = true
 
+  if self._roxyCameraActivated and snapshotCameraState then
+    self._roxyScenePauseCameraSnapshot = snapshotCameraState()
+  end
+
   -- Disable sprites from updating or colliding
-  local sprites = self.sprites
+  local collisionSprites = self._pauseCollisionSprites
+  for i = #collisionSprites, 1, -1 do
+    local sprite = collisionSprites[i]
+    if sprite._roxyScenePauseOwner == self then
+      local setCollisionsActive = sprite._setScenePauseCollisionsActive
+      if setCollisionsActive then
+        setCollisionsActive(sprite, false)
+      else
+        local setCollisionsEnabled = sprite.setCollisionsEnabled
+        if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
+      end
+    else
+      if sprite._roxyScenePauseOwner ~= nil then
+        _clearScenePauseSnapshot(nil, sprite)
+      end
+
+      local collisionsEnabled = sprite.collisionsEnabled
+      local state = 0
+      if not collisionsEnabled then
+        state = RESTORE_COLLISIONS
+      else
+        local value = collisionsEnabled(sprite)
+        if value ~= false and value ~= 0 then
+          state = RESTORE_COLLISIONS
+        end
+      end
+
+      sprite._roxyScenePauseOwner = self
+      sprite._roxyScenePauseState = state
+
+      if (state & RESTORE_COLLISIONS) ~= 0 then
+        local setCollisionsActive = sprite._setScenePauseCollisionsActive
+        if setCollisionsActive then
+          setCollisionsActive(sprite, false)
+        else
+          local setCollisionsEnabled = sprite.setCollisionsEnabled
+          if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
+        end
+      end
+    end
+  end
+
+  local updateSprites = self._pauseUpdateSprites
+  for i = #updateSprites, 1, -1 do
+    local sprite = updateSprites[i]
+    if sprite._roxyScenePauseOwner == self then
+      local setUpdatesEnabled = sprite.setUpdatesEnabled
+      if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
+    else
+      if sprite._roxyScenePauseOwner ~= nil then
+        _clearScenePauseSnapshot(nil, sprite)
+      end
+
+      local updatesEnabled = sprite.updatesEnabled
+      local state = 0
+      if not updatesEnabled then
+        state = RESTORE_UPDATES
+      else
+        local value = updatesEnabled(sprite)
+        if value ~= false and value ~= 0 then
+          state = RESTORE_UPDATES
+        end
+      end
+
+      sprite._roxyScenePauseOwner = self
+      sprite._roxyScenePauseState = state
+
+      if (state & RESTORE_UPDATES) ~= 0 then
+        local setUpdatesEnabled = sprite.setUpdatesEnabled
+        if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
+      end
+    end
+  end
+
+  local sprites = self._pauseSprites
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
-    sprite:pause()
-    sprite:setUpdatesEnabled(false)
-    sprite:setCollisionsEnabled(false)
+    local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+
+    if pauseMask == SCENE_PAUSE_ALL and sprite._roxyScenePauseOwner ~= self then
+      if sprite._roxyScenePauseOwner ~= nil then
+        _clearScenePauseSnapshot(nil, sprite)
+      end
+
+      local state = 0
+      local getIsPaused = sprite.getIsPaused
+      if type(getIsPaused) == "function" then
+        local wasPaused = getIsPaused(sprite)
+        if type(wasPaused) ~= "boolean" or wasPaused == false then
+          state = state + SHOULD_PLAY
+        end
+      else
+        local wasPaused = sprite.isPaused
+        if type(wasPaused) ~= "boolean" or wasPaused == false then
+          state = state + SHOULD_PLAY
+        end
+      end
+
+      local updatesEnabled = sprite.updatesEnabled
+      if not updatesEnabled then
+        state = state + RESTORE_UPDATES
+      else
+        local value = updatesEnabled(sprite)
+        if value ~= false and value ~= 0 then
+          state = state + RESTORE_UPDATES
+        end
+      end
+
+      local collisionsEnabled = sprite.collisionsEnabled
+      if not collisionsEnabled then
+        state = state + RESTORE_COLLISIONS
+      else
+        local value = collisionsEnabled(sprite)
+        if value ~= false and value ~= 0 then
+          state = state + RESTORE_COLLISIONS
+        end
+      end
+
+      sprite._roxyScenePauseOwner = self
+      sprite._roxyScenePauseState = state
+
+      local pause = sprite.pause
+      if pause then pause(sprite) end
+
+      if (state & RESTORE_UPDATES) ~= 0 then
+        local setUpdatesEnabled = sprite.setUpdatesEnabled
+        if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
+      end
+
+      if (state & RESTORE_COLLISIONS) ~= 0 then
+        local setCollisionsActive = sprite._setScenePauseCollisionsActive
+        if setCollisionsActive then
+          setCollisionsActive(sprite, false)
+        else
+          local setCollisionsEnabled = sprite.setCollisionsEnabled
+          if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
+        end
+      end
+    else
+      _pauseSceneSprite(self, sprite, pauseMask)
+    end
   end
 
   -- Disable sequences from updating
   local sequences = self.sequences
   for i = #sequences, 1, -1 do
-    local sequence = sequences[i]
-    sequence:pause()
+    _pauseSceneSequence(self, sequences[i])
   end
 
   removeHandler(self)
@@ -371,19 +1052,81 @@ function RoxyScene:resume()
   self.isPaused = false
 
   -- Enable sprites for updating and colliding
-  local sprites = self.sprites
+  local collisionSprites = self._pauseCollisionSprites
+  for i = #collisionSprites, 1, -1 do
+    local sprite = collisionSprites[i]
+    if sprite._roxyScenePauseOwner == self then
+      local state = sprite._roxyScenePauseState or 0
+      local restoreCollisions = (state & RESTORE_COLLISIONS) ~= 0
+      local setCollisionsActive = sprite._setScenePauseCollisionsActive
+      if setCollisionsActive then
+        setCollisionsActive(sprite, restoreCollisions)
+      else
+        local setCollisionsEnabled = sprite.setCollisionsEnabled
+        if setCollisionsEnabled then setCollisionsEnabled(sprite, restoreCollisions) end
+      end
+      sprite._roxyScenePauseOwner = nil
+      sprite._roxyScenePauseState = nil
+    end
+  end
+
+  local updateSprites = self._pauseUpdateSprites
+  for i = #updateSprites, 1, -1 do
+    local sprite = updateSprites[i]
+    if sprite._roxyScenePauseOwner == self then
+      local state = sprite._roxyScenePauseState or 0
+      local setUpdatesEnabled = sprite.setUpdatesEnabled
+      if setUpdatesEnabled then
+        setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
+      end
+      sprite._roxyScenePauseOwner = nil
+      sprite._roxyScenePauseState = nil
+    end
+  end
+
+  local sprites = self._pauseSprites
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
-    sprite:setUpdatesEnabled(true)
-    sprite:setCollisionsEnabled(true)
-    sprite:play()
+    local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+    if pauseMask == SCENE_PAUSE_ALL and sprite._roxyScenePauseOwner == self then
+      local state = sprite._roxyScenePauseState or 0
+
+      if (state & SHOULD_PLAY) ~= 0 then
+        local play = sprite.play
+        if play then play(sprite) end
+      end
+
+      local setUpdatesEnabled = sprite.setUpdatesEnabled
+      if setUpdatesEnabled then
+        setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
+      end
+
+      local setCollisionsActive = sprite._setScenePauseCollisionsActive
+      if setCollisionsActive then
+        setCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+      else
+        local setCollisionsEnabled = sprite.setCollisionsEnabled
+        if setCollisionsEnabled then
+          setCollisionsEnabled(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+        end
+      end
+
+      sprite._roxyScenePauseOwner = nil
+      sprite._roxyScenePauseState = nil
+    else
+      _resumeSceneSprite(self, sprite)
+    end
   end
 
   -- Enable sequences for updating
   local sequences = self.sequences
   for i = #sequences, 1, -1 do
-    local sequence = sequences[i]
-    sequence:play()
+    _resumeSceneSequence(self, sequences[i])
+  end
+
+  if self._roxyScenePauseCameraSnapshot and restoreCameraState then
+    restoreCameraState(self._roxyScenePauseCameraSnapshot)
+    self._roxyScenePauseCameraSnapshot = nil
   end
 
   self:addHandler()
@@ -413,6 +1156,8 @@ function RoxyScene:cleanup()
   self:resetDrawOffset()
 
   resetCamera()
+  self._roxyCameraActivated = false
+  self._roxyScenePauseCameraSnapshot = nil
 
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
@@ -483,20 +1228,54 @@ end
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
 
+  local pauseMask = _getScenePauseMask(sprite)
+
   if self._spriteSet[sprite] == true then
     local isTracked = _hasIndexed(self.sprites, self._spriteIndex, sprite)
     local isQueued = self._didEnter or _hasIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
-    if sprite.scene == self and isTracked and isQueued then return end
+    local cachedPauseMask = sprite._roxyScenePauseMask or SCENE_PAUSE_NONE
+    if sprite.scene == self and isTracked and isQueued then
+      if cachedPauseMask == pauseMask then return end
+
+      if sprite._roxyScenePauseOwner == self then
+        _resumeRegisteredSceneSprite(self, sprite, cachedPauseMask)
+      end
+
+      _removeFromScenePauseBuckets(self, sprite)
+      _clearScenePauseRegistration(sprite)
+      _clearScenePauseSnapshot(self, sprite)
+
+      if pauseMask ~= SCENE_PAUSE_NONE then
+        sprite._roxyScenePauseMask = pauseMask
+        _addToScenePauseBucket(self, sprite, pauseMask)
+      end
+
+      if self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
+        _pauseRegisteredSceneSprite(self, sprite, pauseMask)
+      end
+
+      return
+    end
 
     _removeIndexed(self.sprites, self._spriteIndex, sprite)
     _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+    _removeFromScenePauseBuckets(self, sprite)
     self._spriteSet[sprite] = nil
+    _clearScenePauseRegistration(sprite)
+    _clearScenePauseSnapshot(self, sprite)
   end
 
   local currentScene = sprite.scene
+  local transferPauseMask = nil
+  local transferPauseState = nil
   if currentScene ~= nil and currentScene ~= self and type(currentScene) == "table" then
+    if sprite._roxyScenePauseOwner == currentScene then
+      transferPauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+      transferPauseState = sprite._roxyScenePauseState
+    end
+
     if type(currentScene._unregisterSprite) == "function" then
-      currentScene:_unregisterSprite(sprite, true)
+      currentScene:_unregisterSprite(sprite, true, true)
     elseif type(currentScene.removeSprite) == "function" then
       currentScene:removeSprite(sprite)
     end
@@ -508,12 +1287,39 @@ function RoxyScene:addSprite(sprite)
   _appendIndexed(self.sprites, self._spriteIndex, sprite)
   self._spriteSet[sprite] = true
 
+  if pauseMask ~= SCENE_PAUSE_NONE then
+    sprite._roxyScenePauseMask = pauseMask
+    _addToScenePauseBucket(self, sprite, pauseMask)
+  else
+    _clearScenePauseRegistration(sprite)
+  end
+
+  if transferPauseMask ~= nil and self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
+    sprite._roxyScenePauseOwner = self
+    sprite._roxyScenePauseState = transferPauseState
+  end
+
   if self._didEnter then
     -- Scene is active -- attach immediately
     sprite:add()
   else
     -- Scene isn't active yet -- queue for enter()
     _appendIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+  end
+
+  if self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
+    _pauseRegisteredSceneSprite(self, sprite, pauseMask)
+  elseif transferPauseMask ~= nil then
+    local restoreMask = sprite._roxyScenePauseMask
+    sprite._roxyScenePauseMask = transferPauseMask
+    sprite._roxyScenePauseOwner = self
+    sprite._roxyScenePauseState = transferPauseState
+    _resumeRegisteredSceneSprite(self, sprite, transferPauseMask)
+    if pauseMask ~= SCENE_PAUSE_NONE then
+      sprite._roxyScenePauseMask = restoreMask or pauseMask
+    else
+      _clearScenePauseRegistration(sprite)
+    end
   end
 end
 
@@ -524,16 +1330,26 @@ end
 
 -- ! Unregister Sprite
 -- Private cleanup path used by tilemaps and direct scene sprite removal
-function RoxyScene:_unregisterSprite(sprite, removeFromDisplay)
+function RoxyScene:_unregisterSprite(sprite, removeFromDisplay, preserveScenePauseState)
   if not sprite then return end
 
   local wasSelfOwnedAtEntry = sprite.scene == self
+  local wasSelfTrackedAtEntry = self._spriteSet[sprite] == true
 
-  -- Remove only this scene's ownership state. Direct external writes to
-  -- scene.sprites are unsupported, but removeAllSprites remains tolerant.
+  if preserveScenePauseState ~= true then
+    _restoreScenePauseBeforeUnregister(self, sprite)
+  end
+
+  -- Remove only this scene's ownership state
+  -- Direct external writes to scene.sprites are unsupported, but removeAllSprites remains tolerant.
   _removeIndexed(self.sprites, self._spriteIndex, sprite)
   _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+  _removeFromScenePauseBuckets(self, sprite)
   self._spriteSet[sprite] = nil
+  if wasSelfTrackedAtEntry then
+    _clearScenePauseRegistration(sprite)
+  end
+  _clearScenePauseSnapshot(self, sprite)
 
   if wasSelfOwnedAtEntry and sprite.scene == self then
     sprite.scene = nil -- Clear back-pointer
@@ -568,10 +1384,18 @@ function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
   for i = 1, #targetList do
     local sprite = targetList[i]
     local wasSelfOwnedAtEntry = sprite.scene == self
+    local wasSelfTrackedAtEntry = self._spriteSet[sprite] == true
+
+    _restoreScenePauseBeforeUnregister(self, sprite)
 
     _removeIndexed(self.sprites, self._spriteIndex, sprite)
     _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+    _removeFromScenePauseBuckets(self, sprite)
     self._spriteSet[sprite] = nil
+    if wasSelfTrackedAtEntry then
+      _clearScenePauseRegistration(sprite)
+    end
+    _clearScenePauseSnapshot(self, sprite)
 
     if wasSelfOwnedAtEntry and sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
@@ -592,9 +1416,18 @@ function RoxyScene:removeAllSprites()
   self._spriteIndex = {}
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
+  self._pauseSprites = {}
+  self._pauseSpriteIndex = {}
+  self._pauseUpdateSprites = {}
+  self._pauseUpdateSpriteIndex = {}
+  self._pauseCollisionSprites = {}
+  self._pauseCollisionSpriteIndex = {}
 
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
+    _restoreScenePauseBeforeUnregister(self, sprite)
+    _clearScenePauseRegistration(sprite)
+    _clearScenePauseSnapshot(self, sprite)
     if sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
     end
@@ -741,6 +1574,7 @@ function RoxyScene:removeSequence(sequence)
   if not sequence then return end
   for i = #self.sequences, 1, -1 do
     if self.sequences[i] == sequence then
+      _clearScenePauseSequenceSnapshot(self, sequence)
       sequence.scene = nil -- Clear back-pointer
       sequence:clear(true)
       tableRemove(self.sequences, i)
@@ -754,6 +1588,7 @@ function RoxyScene:removeAllSequences()
   local sequences = self.sequences
   for i = #sequences, 1, -1 do
     local sequence = sequences[i]
+    _clearScenePauseSequenceSnapshot(self, sequence)
     sequence.scene = nil -- Clear back-pointer
     sequence:clear(true)
   end
@@ -793,12 +1628,13 @@ end
 
 --[[
 
+RoxyScene owns scene lifecycle, input, sprites, tilemaps, sequences, and camera setup.
+
+-- Gameplay Scene
 local Graphics <const> = playdate.graphics
 
 local COLOR_WHITE <const> = Graphics.kColorWhite
-local COLOR_BLACK <const> = Graphics.kColorBlack
 
--- Basic Scene Subclass
 class("GameplayScene").extends(RoxyScene)
 
 function GameplayScene:init()
@@ -806,7 +1642,7 @@ function GameplayScene:init()
 
   self.inputHandler = {
     BButtonDown = function()
-      roxy.Scene.popScene()
+      roxy.Scene.pushScene(PauseScene)
     end,
   }
 end
@@ -814,7 +1650,9 @@ end
 function GameplayScene:start()
   GameplayScene.super.start(self)
 
-  self.player = RoxySprite({ name = "player" }, self)
+  self.player = RoxySprite({ name = "player" })
+  self:addSprite(self.player)
+
   self.map = self:spawnTilemap("assets/maps/level-01.json", {
     cameraBounds = true,
     layerOptions = {
@@ -824,14 +1662,15 @@ function GameplayScene:start()
   self:activateCamera({
     tilemap = self.map,
     target = self.player,
-    smoothing = 0.2,
+    smoothing = 4,
+    deadZone = { 48, 32 },
   })
 
-  self.fadeIn = RoxySequence(self):from(0):to(1, 0.25):play()
+  self.fadeIn = self:spawnSequence():from(0):to(1, 0.25):play()
 end
 
 function GameplayScene:update(dt)
-  -- Game logic here
+  roxy.Camera.update(dt)
 end
 
 function GameplayScene:cleanup()
@@ -841,29 +1680,23 @@ function GameplayScene:cleanup()
   self.fadeIn = nil
 end
 
--- Backgrounds and Draw Stack Behavior
-local pauseScene = RoxyScene(COLOR_BLACK)
+-- Overlay Scene
+local pauseScene = RoxyScene(Graphics.kColorBlack)
 pauseScene.isVisible = true
 pauseScene.blocksLowerDraw = false
 pauseScene.updateBackground = true
 
--- Manual Ownership and Reuse
+-- Manual Ownership
 local scene = RoxyScene()
 local player = RoxySprite({ name = "player" })
-local map = scene:spawnTilemap("assets/maps/level-01.json")
+local tilemap = RoxyOrthoTilemap("assets/maps/level-01.json")
 
 scene:addSprite(player)
-scene:addSprite(player) -- Ignored; scene ownership stays unique
+scene:addTilemap(tilemap)
+scene:activateCamera({ tilemap = tilemap, target = player })
+
+scene:detachTilemap(tilemap)
 scene:removeSprite(player)
-scene:addSprite(player)
-
-local inventoryScene = RoxyScene()
-inventoryScene:addSprite(player) -- Transfers ownership from the old scene
-inventoryScene:removeSprite(player)
-
-scene:detachTilemap(map)
-scene:addTilemap(map)
-scene:removeTilemap(map)
 scene:cleanup()
 
-]]
+--]]

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -80,6 +80,58 @@ local function _hasItem(array, item)
   return false
 end
 
+-- ! Helper: Append Indexed Item
+-- Appends an item and records its array position
+local function _appendIndexed(array, index, item)
+  if not array or not index or not item then return false end
+
+  local existingIndex = index[item]
+  if existingIndex ~= nil then
+    if array[existingIndex] == item then return false end
+    index[item] = nil
+  end
+
+  local nextIndex = #array + 1
+  array[nextIndex] = item
+  index[item] = nextIndex
+  return true
+end
+
+-- ! Helper: Remove Indexed Item
+-- Swap-removes an item from an indexed array
+local function _removeIndexed(array, index, item)
+  if not array or not index or not item then return false end
+
+  local itemIndex = index[item]
+  if itemIndex == nil then return false end
+  if array[itemIndex] ~= item then
+    index[item] = nil
+    return false
+  end
+
+  local lastIndex = #array
+  local lastItem = array[lastIndex]
+
+  array[itemIndex] = lastItem
+  array[lastIndex] = nil
+  index[item] = nil
+
+  if itemIndex ~= lastIndex and lastItem ~= nil then
+    index[lastItem] = itemIndex
+  end
+
+  return true
+end
+
+-- ! Helper: Has Indexed Item
+-- Returns true when the indexed array points back to the item
+local function _hasIndexed(array, index, item)
+  if not array or not index or not item then return false end
+
+  local itemIndex = index[item]
+  return itemIndex ~= nil and array[itemIndex] == item
+end
+
 -- ! Helper: Is Bounds Table
 -- Returns true for camera bounds tables accepted by Camera.setBounds
 local function _isBoundsTable(bounds)
@@ -150,7 +202,10 @@ function RoxyScene:init(background)
   self.tilemaps = {}
   self.sequences = {}
 
+  self._spriteSet = {}
+  self._spriteIndex = {}
   self._spriteAutoAddQueue = {}
+  self._spriteAutoAddIndex = {}
   self._sequenceAutoStartQueue = {}
 
   -- Sensible defaults used by Scene draw filtering
@@ -180,6 +235,7 @@ function RoxyScene:enter()
     spriteQueue[i]:add()
   end
   self._spriteAutoAddQueue = {}
+  self._spriteAutoAddIndex = {}
 
   -- Activate tilemap resources that cannot be created detached from display
   for i = 1, #self.tilemaps do
@@ -359,6 +415,7 @@ function RoxyScene:cleanup()
   resetCamera()
 
   self._spriteAutoAddQueue = {}
+  self._spriteAutoAddIndex = {}
   self._sequenceAutoStartQueue = {}
 
   self.backgroundColor = nil
@@ -425,24 +482,38 @@ end
 -- ! Add Sprite
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
-  if sprite.scene == self then return end
 
-  -- Avoid duplicates
-  for i = 1, #self.sprites do
-    if self.sprites[i] == sprite then return end
+  if self._spriteSet[sprite] == true then
+    local isTracked = _hasIndexed(self.sprites, self._spriteIndex, sprite)
+    local isQueued = self._didEnter or _hasIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+    if sprite.scene == self and isTracked and isQueued then return end
+
+    _removeIndexed(self.sprites, self._spriteIndex, sprite)
+    _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+    self._spriteSet[sprite] = nil
+  end
+
+  local currentScene = sprite.scene
+  if currentScene ~= nil and currentScene ~= self and type(currentScene) == "table" then
+    if type(currentScene._unregisterSprite) == "function" then
+      currentScene:_unregisterSprite(sprite, true)
+    elseif type(currentScene.removeSprite) == "function" then
+      currentScene:removeSprite(sprite)
+    end
   end
 
   -- Give the sprite a back-pointer so it can self-remove later
   sprite.scene = self
 
-  tableInsert(self.sprites, sprite)
+  _appendIndexed(self.sprites, self._spriteIndex, sprite)
+  self._spriteSet[sprite] = true
 
   if self._didEnter then
     -- Scene is active -- attach immediately
     sprite:add()
   else
     -- Scene isn't active yet -- queue for enter()
-    tableInsert(self._spriteAutoAddQueue, sprite)
+    _appendIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
   end
 end
 
@@ -456,16 +527,19 @@ end
 function RoxyScene:_unregisterSprite(sprite, removeFromDisplay)
   if not sprite then return end
 
-  -- Remove from active scene list and pre-enter auto-add queue
-  local wasManaged = _removeItem(self.sprites, sprite)
-  wasManaged = _removeItem(self._spriteAutoAddQueue, sprite) or wasManaged
-  wasManaged = (sprite.scene == self) or wasManaged
+  local wasSelfOwnedAtEntry = sprite.scene == self
 
-  if sprite.scene == self then
+  -- Remove only this scene's ownership state. Direct external writes to
+  -- scene.sprites are unsupported, but removeAllSprites remains tolerant.
+  _removeIndexed(self.sprites, self._spriteIndex, sprite)
+  _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+  self._spriteSet[sprite] = nil
+
+  if wasSelfOwnedAtEntry and sprite.scene == self then
     sprite.scene = nil -- Clear back-pointer
   end
 
-  if removeFromDisplay ~= false and wasManaged then
+  if removeFromDisplay ~= false and wasSelfOwnedAtEntry then
     sprite:remove()
   end
 end
@@ -476,47 +550,34 @@ end
 function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
   if not sprites then return end
 
-  -- Build a lookup set so scene lists only need one pass each
+  -- Build a unique target list so duplicate inputs stay idempotent
   local targets = nil
+  local targetList = nil
   for i = 1, #sprites do
     local sprite = sprites[i]
-    if sprite then
+    if sprite and (not targets or not targets[sprite]) then
       targets = targets or {}
+      targetList = targetList or {}
       targets[sprite] = true
+      targetList[#targetList + 1] = sprite
     end
   end
   if not targets then return end
 
-  local managed = {}
-
-  -- Remove from active scene list
-  local sceneSprites = self.sprites
-  for i = #sceneSprites, 1, -1 do
-    local sprite = sceneSprites[i]
-    if targets[sprite] then
-      tableRemove(sceneSprites, i)
-      managed[sprite] = true
-    end
-  end
-
-  -- Remove from pre-enter auto-add queue
-  local spriteQueue = self._spriteAutoAddQueue
-  for i = #spriteQueue, 1, -1 do
-    local sprite = spriteQueue[i]
-    if targets[sprite] then
-      tableRemove(spriteQueue, i)
-      managed[sprite] = true
-    end
-  end
-
   local shouldRemove = removeFromDisplay ~= false
-  for sprite, _ in pairs(targets) do
-    if sprite.scene == self then
+  for i = 1, #targetList do
+    local sprite = targetList[i]
+    local wasSelfOwnedAtEntry = sprite.scene == self
+
+    _removeIndexed(self.sprites, self._spriteIndex, sprite)
+    _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
+    self._spriteSet[sprite] = nil
+
+    if wasSelfOwnedAtEntry and sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
-      managed[sprite] = true
     end
 
-    if shouldRemove and managed[sprite] then
+    if shouldRemove and wasSelfOwnedAtEntry then
       sprite:remove()
     end
   end
@@ -525,11 +586,22 @@ end
 -- ! Remove All Sprites
 function RoxyScene:removeAllSprites()
   local sprites = self.sprites
+
+  self.sprites = {}
+  self._spriteSet = {}
+  self._spriteIndex = {}
+  self._spriteAutoAddQueue = {}
+  self._spriteAutoAddIndex = {}
+
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
     if sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
     end
+  end
+
+  for i = #sprites, 1, -1 do
+    local sprite = sprites[i]
     -- Prefer view-aware cleanup so pooled sprite assets are released
     if sprite.removeAndClearView then
       sprite:removeAndClearView()
@@ -537,8 +609,6 @@ function RoxyScene:removeAllSprites()
       sprite:remove()
     end
   end
-  self.sprites = {}
-  self._spriteAutoAddQueue = {}
 end
 
 -- ! Spawn Sprite
@@ -777,12 +847,20 @@ pauseScene.isVisible = true
 pauseScene.blocksLowerDraw = false
 pauseScene.updateBackground = true
 
--- Manual Ownership Cleanup
+-- Manual Ownership and Reuse
 local scene = RoxyScene()
-local player = RoxySprite({ name = "player" }, scene)
+local player = RoxySprite({ name = "player" })
 local map = scene:spawnTilemap("assets/maps/level-01.json")
 
+scene:addSprite(player)
+scene:addSprite(player) -- Ignored; scene ownership stays unique
 scene:removeSprite(player)
+scene:addSprite(player)
+
+local inventoryScene = RoxyScene()
+inventoryScene:addSprite(player) -- Transfers ownership from the old scene
+inventoryScene:removeSprite(player)
+
 scene:detachTilemap(map)
 scene:addTilemap(map)
 scene:removeTilemap(map)

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -8,9 +8,11 @@ local Sprite    <const> = Graphics.sprite
 local r       <const> = roxy
 local Input   <const> = r.Input
 local Camera  <const> = r.Camera
+local Scene   <const> = r.Scene
 
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
+local setMetatable <const> = setmetatable
 
 local clearScreen         <const> = Graphics.clear
 local setColor            <const> = Graphics.setColor
@@ -47,23 +49,32 @@ local CLEAR_COLOR <const> = COLOR_WHITE
 
 local UNFLIPPED <const> = Graphics.kImageUnflipped
 
-local SCENE_PAUSE_NONE        <const> = 0
-local SCENE_PAUSE_PLAYBACK    <const> = 1
-local SCENE_PAUSE_UPDATES     <const> = 2
-local SCENE_PAUSE_COLLISIONS  <const> = 4
+local SCENE_PAUSE_NONE        <const> = Scene._SCENE_PAUSE_NONE
+local SCENE_PAUSE_PLAYBACK    <const> = Scene._SCENE_PAUSE_PLAYBACK
+local SCENE_PAUSE_UPDATES     <const> = Scene._SCENE_PAUSE_UPDATES
+local SCENE_PAUSE_COLLISIONS  <const> = Scene._SCENE_PAUSE_COLLISIONS
 local SCENE_PAUSE_PLAYBACK_UPDATES <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_UPDATES
 local SCENE_PAUSE_PLAYBACK_COLLISIONS <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_COLLISIONS
 local SCENE_PAUSE_UPDATES_COLLISIONS <const> = SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
-local SCENE_PAUSE_ALL <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
+local SCENE_PAUSE_ALL <const> = Scene._SCENE_PAUSE_ALL
 
 local RESTORE_UPDATES     <const> = 1
 local RESTORE_COLLISIONS  <const> = 2
 local SHOULD_PLAY         <const> = 4
+local SNAPSHOT_STATE_MASK <const> = 7
+local SNAPSHOT_STATE_BITS <const> = 3
+local SNAPSHOT_UPDATES_OFF <const> = SCENE_PAUSE_UPDATES << SNAPSHOT_STATE_BITS
+local SNAPSHOT_UPDATES_ON <const> = SNAPSHOT_UPDATES_OFF + RESTORE_UPDATES
+local SNAPSHOT_COLLISIONS_OFF <const> = SCENE_PAUSE_COLLISIONS << SNAPSHOT_STATE_BITS
+local SNAPSHOT_COLLISIONS_ON <const> = SNAPSHOT_COLLISIONS_OFF + RESTORE_COLLISIONS
+local SNAPSHOT_ALL_BASE <const> = SCENE_PAUSE_ALL << SNAPSHOT_STATE_BITS
 
 local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
+local getSpritePauseMask <const> = Scene._getSpritePauseMask
+local luaType <const> = type
 
 local _colorCallbacks = {} -- Cache: color --> fn
-local _imageCallbacks = setmetatable({}, { __mode = "k" }) -- Cache: image --> fn, weak keys
+local _imageCallbacks = setMetatable({}, { __mode = "k" }) -- Cache: image --> fn, weak keys
 
 --------------------------------------------------------------------------------
 -- Helpers
@@ -150,76 +161,18 @@ end
 -- ! Helper: Is Bounds Table
 -- Returns true for camera bounds tables accepted by Camera.setBounds
 local function _isBoundsTable(bounds)
-  return type(bounds) == "table"
-     and type(bounds.x1) == "number"
-     and type(bounds.y1) == "number"
-     and type(bounds.x2) == "number"
-     and type(bounds.y2) == "number"
+  return luaType(bounds) == "table"
+     and luaType(bounds.x1) == "number"
+     and luaType(bounds.y1) == "number"
+     and luaType(bounds.x2) == "number"
+     and luaType(bounds.y2) == "number"
 end
 
 -- ! Helper: Read XY Pair
 -- Reads either { x, y } or array-style { x, y } option pairs
 local function _readXYPair(value)
-  if type(value) ~= "table" then return nil, nil end
+  if luaType(value) ~= "table" then return nil, nil end
   return value.x or value[1], value.y or value[2]
-end
-
--- ! Helper: Get Scene Pause Mask
--- Nil classification fields keep custom sprites on the legacy full-dynamic path;
--- False opts a subsystem out. The scene caches this at registration time.
-local function _getScenePauseMask(sprite)
-  if not sprite then return SCENE_PAUSE_NONE end
-
-  local mask = SCENE_PAUSE_NONE
-  if sprite._roxyScenePausePlayback ~= false then
-    mask = mask + SCENE_PAUSE_PLAYBACK
-  end
-  if sprite._roxyScenePauseUpdates ~= false then
-    mask = mask + SCENE_PAUSE_UPDATES
-  end
-  if sprite._roxyScenePauseCollisions ~= false then
-    mask = mask + SCENE_PAUSE_COLLISIONS
-  end
-  return mask
-end
-
--- ! Helper: Clear Scene Pause Registration
--- Clears registration-only pause fields when the scene stops tracking a sprite
-local function _clearScenePauseRegistration(sprite)
-  if not sprite then return end
-
-  sprite._roxyScenePauseMask = nil
-
-  -- Remove fields from older cache-based builds when dirty scenes are recycled.
-  sprite._roxyScenePausePause = nil
-  sprite._roxyScenePausePlay = nil
-  sprite._roxyScenePauseGetIsPaused = nil
-  sprite._roxyScenePauseReadIsPaused = nil
-  sprite._roxyScenePauseSetUpdatesEnabled = nil
-  sprite._roxyScenePauseUpdatesEnabled = nil
-  sprite._roxyScenePauseSetCollisionsActive = nil
-  sprite._roxyScenePauseSetCollisionsEnabled = nil
-  sprite._roxyScenePauseCollisionsEnabled = nil
-end
-
--- ! Helper: Remove Sprite From Scene Pause Buckets
-local function _removeFromScenePauseBuckets(scene, sprite)
-  _removeIndexed(scene._pauseSprites, scene._pauseSpriteIndex, sprite)
-  _removeIndexed(scene._pauseUpdateSprites, scene._pauseUpdateSpriteIndex, sprite)
-  _removeIndexed(scene._pauseCollisionSprites, scene._pauseCollisionSpriteIndex, sprite)
-end
-
--- ! Helper: Add Sprite To Scene Pause Bucket
-local function _addToScenePauseBucket(scene, sprite, pauseMask)
-  if pauseMask == SCENE_PAUSE_NONE then return end
-
-  if pauseMask == SCENE_PAUSE_COLLISIONS then
-    _appendIndexed(scene._pauseCollisionSprites, scene._pauseCollisionSpriteIndex, sprite)
-  elseif pauseMask == SCENE_PAUSE_UPDATES then
-    _appendIndexed(scene._pauseUpdateSprites, scene._pauseUpdateSpriteIndex, sprite)
-  else
-    _appendIndexed(scene._pauseSprites, scene._pauseSpriteIndex, sprite)
-  end
 end
 
 -- ! Helper: Scene Pause Mask Has Playback
@@ -246,19 +199,39 @@ local function _pauseMaskHasCollisions(mask)
       or mask == SCENE_PAUSE_ALL
 end
 
+-- ! Scene Pause Hot Path Contract
+-- The pause loop treats nil hook slots as absent and every non-nil hook as
+-- callable. That avoids type checks in large sprite loops; Roxy-owned sprites
+-- and custom sprites must leave optional hooks nil or provide a function.
+
+-- ! Helper: Pack Scene Pause Snapshot
+local function _packScenePauseSnapshot(pauseMask, state)
+  return (pauseMask << SNAPSHOT_STATE_BITS) + state
+end
+
+-- ! Helper: Unpack Scene Pause Snapshot Mask
+local function _scenePauseSnapshotMask(snapshot)
+  return snapshot >> SNAPSHOT_STATE_BITS
+end
+
+-- ! Helper: Unpack Scene Pause Snapshot State
+local function _scenePauseSnapshotState(snapshot)
+  return snapshot & SNAPSHOT_STATE_MASK
+end
+
 -- ! Helper: Read Sprite Paused State
 -- Returns (isPaused, didRead). Custom sprites without state keep legacy resume.
 local function _readSpritePaused(sprite)
   local getIsPaused = sprite and sprite.getIsPaused
-  if type(getIsPaused) == "function" then
+  if getIsPaused ~= nil then
     local value = getIsPaused(sprite)
-    if type(value) == "boolean" then
+    if luaType(value) == "boolean" then
       return value, true
     end
   end
 
   local value = sprite and sprite.isPaused
-  if type(value) == "boolean" then
+  if luaType(value) == "boolean" then
     return value, true
   end
 
@@ -268,7 +241,7 @@ end
 -- ! Helper: Read Sprite Updates Enabled
 local function _readSpriteUpdatesEnabled(sprite)
   local updatesEnabled = sprite and sprite.updatesEnabled
-  if type(updatesEnabled) ~= "function" then
+  if updatesEnabled == nil then
     return true
   end
 
@@ -279,7 +252,7 @@ end
 -- ! Helper: Read Sprite Collisions Enabled
 local function _readSpriteCollisionsEnabled(sprite)
   local collisionsEnabled = sprite and sprite.collisionsEnabled
-  if type(collisionsEnabled) ~= "function" then
+  if collisionsEnabled == nil then
     return true
   end
 
@@ -290,7 +263,7 @@ end
 -- ! Helper: Run Sprite Pause
 local function _runSpritePause(sprite)
   local pause = sprite and sprite.pause
-  if type(pause) ~= "function" then return end
+  if pause == nil then return end
 
   pause(sprite)
 end
@@ -298,7 +271,7 @@ end
 -- ! Helper: Run Sprite Play
 local function _runSpritePlay(sprite)
   local play = sprite and sprite.play
-  if type(play) ~= "function" then return end
+  if play == nil then return end
 
   play(sprite)
 end
@@ -306,7 +279,7 @@ end
 -- ! Helper: Set Sprite Updates Active
 local function _setSpriteUpdatesActive(sprite, flag)
   local setter = sprite and sprite.setUpdatesEnabled
-  if type(setter) ~= "function" then return end
+  if setter == nil then return end
 
   setter(sprite, flag)
 end
@@ -315,48 +288,15 @@ end
 -- RoxySprite exposes a scene-pause-only path that preserves desired collisions.
 local function _setSpriteCollisionsActive(sprite, flag)
   local sceneSetter = sprite and sprite._setScenePauseCollisionsActive
-  if type(sceneSetter) == "function" then
+  if sceneSetter ~= nil then
     sceneSetter(sprite, flag)
     return
   end
 
   local setter = sprite and sprite.setCollisionsEnabled
-  if type(setter) ~= "function" then return end
+  if setter == nil then return end
 
   setter(sprite, flag)
-end
-
--- ! Helper: Clear Scene Pause Snapshot
-local function _clearScenePauseSnapshot(scene, sprite)
-  if not sprite then return end
-  if scene ~= nil and sprite._roxyScenePauseOwner ~= scene then return end
-
-  sprite._roxyScenePauseOwner = nil
-  sprite._roxyScenePauseState = nil
-
-  -- Remove fields from older snapshot builds when dirty scenes are recycled.
-  sprite._roxyScenePauseHadUpdates = nil
-  sprite._roxyScenePauseHadCollisions = nil
-  sprite._roxyScenePauseShouldPlay = nil
-end
-
--- ! Helper: Reapply Existing Scene Pause
--- Used when add() re-enables sprite systems while the owning scene is paused.
-local function _reapplyScenePauseSprite(sprite, pauseMask)
-  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-
-  if _pauseMaskHasPlayback(pauseMask) then
-    local isPaused, didReadPaused = _readSpritePaused(sprite)
-    if (not didReadPaused) or isPaused == false then
-      _runSpritePause(sprite)
-    end
-  end
-  if _pauseMaskHasUpdates(pauseMask) then
-    _setSpriteUpdatesActive(sprite, false)
-  end
-  if _pauseMaskHasCollisions(pauseMask) then
-    _setSpriteCollisionsActive(sprite, false)
-  end
 end
 
 -- ! Helper: Build Scene Pause State
@@ -364,80 +304,132 @@ end
 local function _buildScenePauseState(sprite, pauseMask)
   local state = 0
 
-  if _pauseMaskHasPlayback(pauseMask) then
+  if pauseMask == SCENE_PAUSE_ALL then
     local wasPaused, didReadPaused = _readSpritePaused(sprite)
     if (not didReadPaused) or wasPaused == false then
       state = state + SHOULD_PLAY
     end
-  end
+    if _readSpriteUpdatesEnabled(sprite) then state = state + RESTORE_UPDATES end
+    if _readSpriteCollisionsEnabled(sprite) then state = state + RESTORE_COLLISIONS end
+    return state
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    if _readSpriteUpdatesEnabled(sprite) then state = RESTORE_UPDATES end
+    return state
+  elseif pauseMask == SCENE_PAUSE_COLLISIONS then
+    if _readSpriteCollisionsEnabled(sprite) then state = RESTORE_COLLISIONS end
+    return state
+  elseif pauseMask == SCENE_PAUSE_PLAYBACK then
+    local wasPaused, didReadPaused = _readSpritePaused(sprite)
+    if (not didReadPaused) or wasPaused == false then state = SHOULD_PLAY end
+    return state
+  else
+    if _pauseMaskHasPlayback(pauseMask) then
+      local wasPaused, didReadPaused = _readSpritePaused(sprite)
+      if (not didReadPaused) or wasPaused == false then
+        state = state + SHOULD_PLAY
+      end
+    end
 
-  if _pauseMaskHasUpdates(pauseMask) and _readSpriteUpdatesEnabled(sprite) then
-    state = state + RESTORE_UPDATES
-  end
+    if _pauseMaskHasUpdates(pauseMask) and _readSpriteUpdatesEnabled(sprite) then
+      state = state + RESTORE_UPDATES
+    end
 
-  if _pauseMaskHasCollisions(pauseMask) and _readSpriteCollisionsEnabled(sprite) then
-    state = state + RESTORE_COLLISIONS
+    if _pauseMaskHasCollisions(pauseMask) and _readSpriteCollisionsEnabled(sprite) then
+      state = state + RESTORE_COLLISIONS
+    end
   end
 
   return state
 end
 
--- ! Helper: Pause Scene Collision Sprite
-local function _pauseSceneCollisionSprite(scene, sprite)
-  if not sprite then return end
-
-  if sprite._roxyScenePauseOwner == scene then
-    _setSpriteCollisionsActive(sprite, false)
-    return
-  elseif sprite._roxyScenePauseOwner ~= nil then
-    _clearScenePauseSnapshot(nil, sprite)
+-- ! Helper: Apply Scene Pause Mutations
+local function _applyScenePauseSprite(sprite, pauseMask, state)
+  if state ~= nil then
+    if pauseMask == SCENE_PAUSE_ALL then
+      _runSpritePause(sprite)
+      if (state & RESTORE_UPDATES) ~= 0 then _setSpriteUpdatesActive(sprite, false) end
+      if (state & RESTORE_COLLISIONS) ~= 0 then _setSpriteCollisionsActive(sprite, false) end
+      return
+    elseif pauseMask == SCENE_PAUSE_UPDATES then
+      if (state & RESTORE_UPDATES) ~= 0 then _setSpriteUpdatesActive(sprite, false) end
+      return
+    elseif pauseMask == SCENE_PAUSE_COLLISIONS then
+      if (state & RESTORE_COLLISIONS) ~= 0 then _setSpriteCollisionsActive(sprite, false) end
+      return
+    elseif pauseMask == SCENE_PAUSE_PLAYBACK then
+      _runSpritePause(sprite)
+      return
+    end
   end
 
-  local state = _readSpriteCollisionsEnabled(sprite) and RESTORE_COLLISIONS or 0
-  sprite._roxyScenePauseOwner = scene
-  sprite._roxyScenePauseState = state
-
-  if (state & RESTORE_COLLISIONS) ~= 0 then
-    _setSpriteCollisionsActive(sprite, false)
-  end
-end
-
--- ! Helper: Resume Scene Collision Sprite
-local function _resumeSceneCollisionSprite(scene, sprite)
-  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
-
-  local state = sprite._roxyScenePauseState or 0
-  _setSpriteCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
-  _clearScenePauseSnapshot(scene, sprite)
-end
-
--- ! Helper: Pause Scene Update Sprite
-local function _pauseSceneUpdateSprite(scene, sprite)
-  if not sprite then return end
-
-  if sprite._roxyScenePauseOwner == scene then
-    _setSpriteUpdatesActive(sprite, false)
-    return
-  elseif sprite._roxyScenePauseOwner ~= nil then
-    _clearScenePauseSnapshot(nil, sprite)
+  if _pauseMaskHasPlayback(pauseMask) then
+    if state == nil then
+      local isPaused, didReadPaused = _readSpritePaused(sprite)
+      if (not didReadPaused) or isPaused == false then
+        _runSpritePause(sprite)
+      end
+    else
+      _runSpritePause(sprite)
+    end
   end
 
-  local state = _readSpriteUpdatesEnabled(sprite) and RESTORE_UPDATES or 0
-  sprite._roxyScenePauseOwner = scene
-  sprite._roxyScenePauseState = state
-
-  if (state & RESTORE_UPDATES) ~= 0 then
+  if _pauseMaskHasUpdates(pauseMask) and (state == nil or (state & RESTORE_UPDATES) ~= 0) then
     _setSpriteUpdatesActive(sprite, false)
   end
+
+  if _pauseMaskHasCollisions(pauseMask) and (state == nil or (state & RESTORE_COLLISIONS) ~= 0) then
+    _setSpriteCollisionsActive(sprite, false)
+  end
 end
 
--- ! Helper: Resume Scene Update Sprite
-local function _resumeSceneUpdateSprite(scene, sprite)
-  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+-- ! Helper: Store Scene Pause Snapshot
+local function _storeScenePauseSnapshot(scene, sprite, pauseMask, state)
+  local snapshots = scene._pauseSpriteSnapshots
+  if not snapshots then
+    snapshots = {}
+    scene._pauseSpriteSnapshots = snapshots
+  end
+  local snapshot = _packScenePauseSnapshot(pauseMask, state)
+  if not snapshots[sprite] then
+    local list = scene._pauseSpriteSnapshotList
+    if not list then
+      list = {}
+      scene._pauseSpriteSnapshotList = list
+    end
+    list[#list + 1] = sprite
+  end
+  snapshots[sprite] = snapshot
+  return snapshot
+end
 
-  local state = sprite._roxyScenePauseState or 0
-  _setSpriteUpdatesActive(sprite, (state & RESTORE_UPDATES) ~= 0)
-  _clearScenePauseSnapshot(scene, sprite)
+-- ! Helper: Forget Scene Pause Snapshot
+local function _forgetScenePauseSnapshot(scene, sprite, pruneList)
+  local snapshots = scene._pauseSpriteSnapshots
+  if snapshots then snapshots[sprite] = nil end
+
+  if pruneList == false then return end
+
+  local snapshotList = scene._pauseSpriteSnapshotList
+  if not snapshotList then return end
+
+  for i = #snapshotList, 1, -1 do
+    if snapshotList[i] == sprite then
+      snapshotList[i] = false
+      return
+    end
+  end
+end
+
+-- ! Helper: Prune Scene Pause Snapshot List
+local function _pruneScenePauseSnapshotList(scene, sprites)
+  local snapshotList = scene._pauseSpriteSnapshotList
+  if not snapshotList or not sprites then return end
+
+  for i = #snapshotList, 1, -1 do
+    if sprites[snapshotList[i]] == true then
+      snapshotList[i] = false
+    end
+  end
 end
 
 -- ! Helper: Pause Scene Sprite
@@ -445,189 +437,188 @@ end
 local function _pauseSceneSprite(scene, sprite, pauseMask)
   if not sprite then return end
 
-  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  pauseMask = pauseMask or getSpritePauseMask(sprite)
   if pauseMask == SCENE_PAUSE_NONE then return end
-  if sprite._roxyScenePauseMask == nil then
-    sprite._roxyScenePauseMask = pauseMask
-  end
 
-  if sprite._roxyScenePauseOwner == scene then
-    _reapplyScenePauseSprite(sprite, pauseMask)
+  local snapshots = scene._pauseSpriteSnapshots
+  if not snapshots then
+    snapshots = {}
+    scene._pauseSpriteSnapshots = snapshots
+  end
+  local snapshot = snapshots[sprite]
+  if snapshot then
+    _applyScenePauseSprite(sprite, _scenePauseSnapshotMask(snapshot))
     return
-  elseif sprite._roxyScenePauseOwner ~= nil then
-    _clearScenePauseSnapshot(nil, sprite)
   end
 
   if pauseMask == SCENE_PAUSE_ALL then
     local state = 0
+
     local getIsPaused = sprite.getIsPaused
-    if type(getIsPaused) == "function" then
-      local wasPaused = getIsPaused(sprite)
-      if type(wasPaused) ~= "boolean" or wasPaused == false then
-        state = state + SHOULD_PLAY
-      end
+    if getIsPaused ~= nil then
+      local value = getIsPaused(sprite)
+      if luaType(value) ~= "boolean" or value == false then state = state + SHOULD_PLAY end
+    elseif luaType(sprite.isPaused) == "boolean" then
+      if sprite.isPaused == false then state = state + SHOULD_PLAY end
     else
-      local wasPaused = sprite.isPaused
-      if type(wasPaused) ~= "boolean" or wasPaused == false then
-        state = state + SHOULD_PLAY
-      end
+      state = state + SHOULD_PLAY
     end
 
     local updatesEnabled = sprite.updatesEnabled
-    local updatesValue = type(updatesEnabled) == "function" and updatesEnabled(sprite) or nil
-    if updatesValue == nil or (updatesValue ~= false and updatesValue ~= 0) then
+    if updatesEnabled ~= nil then
+      local value = updatesEnabled(sprite)
+      if value ~= false and value ~= 0 then state = state + RESTORE_UPDATES end
+    else
       state = state + RESTORE_UPDATES
     end
 
     local collisionsEnabled = sprite.collisionsEnabled
-    local collisionsValue = type(collisionsEnabled) == "function" and collisionsEnabled(sprite) or nil
-    if collisionsValue == nil or (collisionsValue ~= false and collisionsValue ~= 0) then
+    if collisionsEnabled ~= nil then
+      local value = collisionsEnabled(sprite)
+      if value ~= false and value ~= 0 then state = state + RESTORE_COLLISIONS end
+    else
       state = state + RESTORE_COLLISIONS
     end
 
-    sprite._roxyScenePauseOwner = scene
-    sprite._roxyScenePauseState = state
+    _storeScenePauseSnapshot(scene, sprite, pauseMask, state)
 
     local pause = sprite.pause
-    if type(pause) == "function" then pause(sprite) end
-
+    if pause ~= nil then pause(sprite) end
     if (state & RESTORE_UPDATES) ~= 0 then
-      local setUpdatesEnabled = sprite.setUpdatesEnabled
-      if type(setUpdatesEnabled) == "function" then setUpdatesEnabled(sprite, false) end
+      local setter = sprite.setUpdatesEnabled
+      if setter ~= nil then setter(sprite, false) end
+    end
+    if (state & RESTORE_COLLISIONS) ~= 0 then
+      local sceneSetter = sprite._setScenePauseCollisionsActive
+      if sceneSetter ~= nil then
+        sceneSetter(sprite, false)
+      else
+        local setter = sprite.setCollisionsEnabled
+        if setter ~= nil then setter(sprite, false) end
+      end
+    end
+    return
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    local state = 0
+    local updatesEnabled = sprite.updatesEnabled
+    if updatesEnabled ~= nil then
+      local value = updatesEnabled(sprite)
+      if value ~= false and value ~= 0 then state = RESTORE_UPDATES end
+    else
+      state = RESTORE_UPDATES
     end
 
+    _storeScenePauseSnapshot(scene, sprite, pauseMask, state)
+    if (state & RESTORE_UPDATES) ~= 0 then
+      local setter = sprite.setUpdatesEnabled
+      if setter ~= nil then setter(sprite, false) end
+    end
+    return
+  elseif pauseMask == SCENE_PAUSE_COLLISIONS then
+    local state = 0
+    local collisionsEnabled = sprite.collisionsEnabled
+    if collisionsEnabled ~= nil then
+      local value = collisionsEnabled(sprite)
+      if value ~= false and value ~= 0 then state = RESTORE_COLLISIONS end
+    else
+      state = RESTORE_COLLISIONS
+    end
+
+    _storeScenePauseSnapshot(scene, sprite, pauseMask, state)
     if (state & RESTORE_COLLISIONS) ~= 0 then
-      local setCollisionsActive = sprite._setScenePauseCollisionsActive
-      if type(setCollisionsActive) == "function" then
-        setCollisionsActive(sprite, false)
+      local sceneSetter = sprite._setScenePauseCollisionsActive
+      if sceneSetter ~= nil then
+        sceneSetter(sprite, false)
       else
-        local setCollisionsEnabled = sprite.setCollisionsEnabled
-        if type(setCollisionsEnabled) == "function" then setCollisionsEnabled(sprite, false) end
+        local setter = sprite.setCollisionsEnabled
+        if setter ~= nil then setter(sprite, false) end
       end
     end
     return
   end
 
-  if pauseMask == SCENE_PAUSE_COLLISIONS then
-    _pauseSceneCollisionSprite(scene, sprite)
-    return
-  end
-
-  if pauseMask == SCENE_PAUSE_UPDATES then
-    _pauseSceneUpdateSprite(scene, sprite)
-    return
-  end
-
-  local pausePlayback = _pauseMaskHasPlayback(pauseMask)
-  local pauseUpdates = _pauseMaskHasUpdates(pauseMask)
-  local pauseCollisions = _pauseMaskHasCollisions(pauseMask)
   local state = _buildScenePauseState(sprite, pauseMask)
+  _storeScenePauseSnapshot(scene, sprite, pauseMask, state)
 
-  sprite._roxyScenePauseOwner = scene
-  sprite._roxyScenePauseState = state
-
-  if pausePlayback then _runSpritePause(sprite) end
-  if pauseUpdates and (state & RESTORE_UPDATES) ~= 0 then
-    _setSpriteUpdatesActive(sprite, false)
-  end
-  if pauseCollisions and (state & RESTORE_COLLISIONS) ~= 0 then
-    _setSpriteCollisionsActive(sprite, false)
-  end
+  _applyScenePauseSprite(sprite, pauseMask, state)
 end
 
 -- ! Helper: Resume Scene Sprite
-local function _resumeSceneSprite(scene, sprite)
-  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
+local function _resumeSceneSprite(scene, sprite, snapshot, pruneList)
+  if not sprite then return end
+  local snapshots = scene._pauseSpriteSnapshots
+  snapshot = snapshot or (snapshots and snapshots[sprite])
+  if not snapshot then return end
 
-  local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
+  local pauseMask = _scenePauseSnapshotMask(snapshot)
   if pauseMask == SCENE_PAUSE_NONE then
-    _clearScenePauseSnapshot(scene, sprite)
+    _forgetScenePauseSnapshot(scene, sprite, pruneList)
     return
   end
 
+  local state = _scenePauseSnapshotState(snapshot)
   if pauseMask == SCENE_PAUSE_ALL then
-    local state = sprite._roxyScenePauseState or 0
-
     if (state & SHOULD_PLAY) ~= 0 then
       local play = sprite.play
-      if type(play) == "function" then play(sprite) end
+      if play ~= nil then play(sprite) end
     end
-
-    local setUpdatesEnabled = sprite.setUpdatesEnabled
-    if type(setUpdatesEnabled) == "function" then
-      setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
+    local updateSetter = sprite.setUpdatesEnabled
+    if updateSetter ~= nil then
+      updateSetter(sprite, (state & RESTORE_UPDATES) ~= 0)
     end
-
-    local setCollisionsActive = sprite._setScenePauseCollisionsActive
-    if type(setCollisionsActive) == "function" then
-      setCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+    local sceneSetter = sprite._setScenePauseCollisionsActive
+    if sceneSetter ~= nil then
+      sceneSetter(sprite, (state & RESTORE_COLLISIONS) ~= 0)
     else
-      local setCollisionsEnabled = sprite.setCollisionsEnabled
-      if type(setCollisionsEnabled) == "function" then
-        setCollisionsEnabled(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+      local collisionSetter = sprite.setCollisionsEnabled
+      if collisionSetter ~= nil then
+        collisionSetter(sprite, (state & RESTORE_COLLISIONS) ~= 0)
       end
     end
+  elseif pauseMask == SCENE_PAUSE_UPDATES then
+    local setter = sprite.setUpdatesEnabled
+    if setter ~= nil then setter(sprite, (state & RESTORE_UPDATES) ~= 0) end
+  elseif pauseMask == SCENE_PAUSE_COLLISIONS then
+    local sceneSetter = sprite._setScenePauseCollisionsActive
+    if sceneSetter ~= nil then
+      sceneSetter(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+    else
+      local setter = sprite.setCollisionsEnabled
+      if setter ~= nil then setter(sprite, (state & RESTORE_COLLISIONS) ~= 0) end
+    end
+  elseif pauseMask == SCENE_PAUSE_PLAYBACK then
+    if (state & SHOULD_PLAY) ~= 0 then _runSpritePlay(sprite) end
+  else
+    local pausePlayback = _pauseMaskHasPlayback(pauseMask)
+    local pauseUpdates = _pauseMaskHasUpdates(pauseMask)
+    local pauseCollisions = _pauseMaskHasCollisions(pauseMask)
 
-    _clearScenePauseSnapshot(scene, sprite)
-    return
+    if pausePlayback and (state & SHOULD_PLAY) ~= 0 then _runSpritePlay(sprite) end
+    if pauseUpdates then
+      _setSpriteUpdatesActive(sprite, (state & RESTORE_UPDATES) ~= 0)
+    end
+    if pauseCollisions then
+      _setSpriteCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+    end
   end
 
-  if pauseMask == SCENE_PAUSE_COLLISIONS then
-    _resumeSceneCollisionSprite(scene, sprite)
-    return
-  end
-
-  if pauseMask == SCENE_PAUSE_UPDATES then
-    _resumeSceneUpdateSprite(scene, sprite)
-    return
-  end
-
-  local state = sprite._roxyScenePauseState or 0
-  local pausePlayback = _pauseMaskHasPlayback(pauseMask)
-  local pauseUpdates = _pauseMaskHasUpdates(pauseMask)
-  local pauseCollisions = _pauseMaskHasCollisions(pauseMask)
-
-  if pausePlayback and (state & SHOULD_PLAY) ~= 0 then _runSpritePlay(sprite) end
-  if pauseUpdates then
-    _setSpriteUpdatesActive(sprite, (state & RESTORE_UPDATES) ~= 0)
-  end
-  if pauseCollisions then
-    _setSpriteCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
-  end
-
-  _clearScenePauseSnapshot(scene, sprite)
+  _forgetScenePauseSnapshot(scene, sprite, pruneList)
 end
 
 -- ! Helper: Pause Registered Scene Sprite
 local function _pauseRegisteredSceneSprite(scene, sprite, pauseMask)
-  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-  if pauseMask == SCENE_PAUSE_COLLISIONS then
-    _pauseSceneCollisionSprite(scene, sprite)
-  elseif pauseMask == SCENE_PAUSE_UPDATES then
-    _pauseSceneUpdateSprite(scene, sprite)
-  elseif pauseMask ~= SCENE_PAUSE_NONE then
-    _pauseSceneSprite(scene, sprite, pauseMask)
-  end
+  pauseMask = pauseMask or getSpritePauseMask(sprite)
+  if pauseMask ~= SCENE_PAUSE_NONE then _pauseSceneSprite(scene, sprite, pauseMask) end
 end
 
 -- ! Helper: Resume Registered Scene Sprite
-local function _resumeRegisteredSceneSprite(scene, sprite, pauseMask)
-  pauseMask = pauseMask or sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-  if pauseMask == SCENE_PAUSE_COLLISIONS then
-    _resumeSceneCollisionSprite(scene, sprite)
-  elseif pauseMask == SCENE_PAUSE_UPDATES then
-    _resumeSceneUpdateSprite(scene, sprite)
-  elseif pauseMask ~= SCENE_PAUSE_NONE then
-    _resumeSceneSprite(scene, sprite)
-  end
+local function _resumeRegisteredSceneSprite(scene, sprite, pruneList)
+  _resumeSceneSprite(scene, sprite, nil, pruneList)
 end
 
 -- ! Helper: Restore Scene Pause Before Unregister
--- Normal removal detaches restored sprites; transfers preserve captured state.
-local function _restoreScenePauseBeforeUnregister(scene, sprite)
-  if not sprite or sprite._roxyScenePauseOwner ~= scene then return end
-
-  _resumeRegisteredSceneSprite(scene, sprite, sprite._roxyScenePauseMask)
+local function _restoreScenePauseBeforeUnregister(scene, sprite, pruneList)
+  _resumeRegisteredSceneSprite(scene, sprite, pruneList)
 end
 
 -- ! Helper: Get Color Callback
@@ -665,10 +656,10 @@ end
 -- Returns readable running state when the sequence exposes one
 local function _readSequencePlaying(sequence)
   if not sequence then return nil end
-  if type(sequence.isPlaying) == "function" then
+  if luaType(sequence.isPlaying) == "function" then
     return sequence:isPlaying() == true
   end
-  if type(sequence.isRunning) == "boolean" then
+  if luaType(sequence.isRunning) == "boolean" then
     return sequence.isRunning
   end
   return nil
@@ -692,7 +683,7 @@ local function _pauseSceneSequence(scene, sequence)
   sequence._roxyScenePauseOwner = scene
   sequence._roxyScenePauseWasRunning = shouldPause
 
-  if shouldPause and type(sequence.pause) == "function" then
+  if shouldPause and luaType(sequence.pause) == "function" then
     sequence:pause()
   end
 end
@@ -703,7 +694,7 @@ local function _resumeSceneSequence(scene, sequence)
   if not sequence or sequence._roxyScenePauseOwner ~= scene then return end
 
   local shouldResume = sequence._roxyScenePauseWasRunning ~= false
-  if shouldResume and type(sequence.play) == "function" then
+  if shouldResume and luaType(sequence.play) == "function" then
     sequence:play()
   end
 
@@ -736,12 +727,8 @@ function RoxyScene:init(background)
   self._spriteIndex = {}
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
-  self._pauseSprites = {}
-  self._pauseSpriteIndex = {}
-  self._pauseUpdateSprites = {}
-  self._pauseUpdateSpriteIndex = {}
-  self._pauseCollisionSprites = {}
-  self._pauseCollisionSpriteIndex = {}
+  self._pauseSpriteSnapshots = {}
+  self._pauseSpriteSnapshotList = {}
   self._sequenceAutoStartQueue = {}
   self._roxyCameraActivated = false
   self._roxyScenePauseCameraSnapshot = nil
@@ -846,10 +833,10 @@ function RoxyScene:activateCamera(opts)
   elseif opts.tilemap ~= nil then
     local tilemap = opts.tilemap
     local didApply = false
-    if type(tilemap) == "table" and type(tilemap.applyCameraBounds) == "function" then
+    if luaType(tilemap) == "table" and luaType(tilemap.applyCameraBounds) == "function" then
       didApply = tilemap:applyCameraBounds() == true
     end
-    if not didApply and type(tilemap) == "table" and type(tilemap.getCameraBounds) == "function" then
+    if not didApply and luaType(tilemap) == "table" and luaType(tilemap.getCameraBounds) == "function" then
       local bounds = tilemap:getCameraBounds()
       if bounds then setCameraBounds(bounds) end
     end
@@ -887,152 +874,134 @@ function RoxyScene:pause()
   if self.isPaused then return end
   Log.debug("[RoxyScene:pause] Pausing Scene: " .. self.name) --#DEBUG
   self.isPaused = true
+  local snapshots = {}
+  local snapshotList = {}
+  self._pauseSpriteSnapshots = snapshots
+  self._pauseSpriteSnapshotList = snapshotList
 
   if self._roxyCameraActivated and snapshotCameraState then
     self._roxyScenePauseCameraSnapshot = snapshotCameraState()
   end
 
-  -- Disable sprites from updating or colliding
-  local collisionSprites = self._pauseCollisionSprites
-  for i = #collisionSprites, 1, -1 do
-    local sprite = collisionSprites[i]
-    if sprite._roxyScenePauseOwner == self then
-      local setCollisionsActive = sprite._setScenePauseCollisionsActive
-      if setCollisionsActive then
-        setCollisionsActive(sprite, false)
-      else
-        local setCollisionsEnabled = sprite.setCollisionsEnabled
-        if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
-      end
-    else
-      if sprite._roxyScenePauseOwner ~= nil then
-        _clearScenePauseSnapshot(nil, sprite)
-      end
-
-      local collisionsEnabled = sprite.collisionsEnabled
-      local state = 0
-      if not collisionsEnabled then
-        state = RESTORE_COLLISIONS
-      else
-        local value = collisionsEnabled(sprite)
-        if value ~= false and value ~= 0 then
-          state = RESTORE_COLLISIONS
-        end
+  local sprites = self.sprites
+  local snapshotCount = 0
+  local scenePauseAll = SCENE_PAUSE_ALL
+  local scenePauseUpdates = SCENE_PAUSE_UPDATES
+  local scenePauseCollisions = SCENE_PAUSE_COLLISIONS
+  local scenePauseNone = SCENE_PAUSE_NONE
+  local restoreUpdates = RESTORE_UPDATES
+  local restoreCollisions = RESTORE_COLLISIONS
+  local shouldPlay = SHOULD_PLAY
+  local snapshotStateBits = SNAPSHOT_STATE_BITS
+  local snapshotUpdatesOff = SNAPSHOT_UPDATES_OFF
+  local snapshotUpdatesOn = SNAPSHOT_UPDATES_ON
+  local snapshotCollisionsOff = SNAPSHOT_COLLISIONS_OFF
+  local snapshotCollisionsOn = SNAPSHOT_COLLISIONS_ON
+  -- Before enter(), tracked sprites are only queued and sprite:add() has not
+  -- run. Skip sprite pause work so enter() snapshots after add; once entered,
+  -- keep the loop free of queued-state checks and trust scene ownership.
+  if self._didEnter then
+    for i = #sprites, 1, -1 do
+      local sprite = sprites[i]
+      local pauseMask = sprite._roxyScenePauseMask
+      if pauseMask == nil then
+        pauseMask = scenePauseAll
       end
 
-      sprite._roxyScenePauseOwner = self
-      sprite._roxyScenePauseState = state
+      if pauseMask == scenePauseAll then
+        local state = 0
 
-      if (state & RESTORE_COLLISIONS) ~= 0 then
-        local setCollisionsActive = sprite._setScenePauseCollisionsActive
-        if setCollisionsActive then
-          setCollisionsActive(sprite, false)
+        local getIsPaused = sprite.getIsPaused
+        if getIsPaused ~= nil then
+          local value = getIsPaused(sprite)
+          if value ~= true then state = state + shouldPlay end
         else
-          local setCollisionsEnabled = sprite.setCollisionsEnabled
-          if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
+          if sprite.isPaused ~= true then state = state + shouldPlay end
         end
-      end
-    end
-  end
 
-  local updateSprites = self._pauseUpdateSprites
-  for i = #updateSprites, 1, -1 do
-    local sprite = updateSprites[i]
-    if sprite._roxyScenePauseOwner == self then
-      local setUpdatesEnabled = sprite.setUpdatesEnabled
-      if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
-    else
-      if sprite._roxyScenePauseOwner ~= nil then
-        _clearScenePauseSnapshot(nil, sprite)
-      end
-
-      local updatesEnabled = sprite.updatesEnabled
-      local state = 0
-      if not updatesEnabled then
-        state = RESTORE_UPDATES
-      else
-        local value = updatesEnabled(sprite)
-        if value ~= false and value ~= 0 then
-          state = RESTORE_UPDATES
-        end
-      end
-
-      sprite._roxyScenePauseOwner = self
-      sprite._roxyScenePauseState = state
-
-      if (state & RESTORE_UPDATES) ~= 0 then
-        local setUpdatesEnabled = sprite.setUpdatesEnabled
-        if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
-      end
-    end
-  end
-
-  local sprites = self._pauseSprites
-  for i = #sprites, 1, -1 do
-    local sprite = sprites[i]
-    local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-
-    if pauseMask == SCENE_PAUSE_ALL and sprite._roxyScenePauseOwner ~= self then
-      if sprite._roxyScenePauseOwner ~= nil then
-        _clearScenePauseSnapshot(nil, sprite)
-      end
-
-      local state = 0
-      local getIsPaused = sprite.getIsPaused
-      if type(getIsPaused) == "function" then
-        local wasPaused = getIsPaused(sprite)
-        if type(wasPaused) ~= "boolean" or wasPaused == false then
-          state = state + SHOULD_PLAY
-        end
-      else
-        local wasPaused = sprite.isPaused
-        if type(wasPaused) ~= "boolean" or wasPaused == false then
-          state = state + SHOULD_PLAY
-        end
-      end
-
-      local updatesEnabled = sprite.updatesEnabled
-      if not updatesEnabled then
-        state = state + RESTORE_UPDATES
-      else
-        local value = updatesEnabled(sprite)
-        if value ~= false and value ~= 0 then
-          state = state + RESTORE_UPDATES
-        end
-      end
-
-      local collisionsEnabled = sprite.collisionsEnabled
-      if not collisionsEnabled then
-        state = state + RESTORE_COLLISIONS
-      else
-        local value = collisionsEnabled(sprite)
-        if value ~= false and value ~= 0 then
-          state = state + RESTORE_COLLISIONS
-        end
-      end
-
-      sprite._roxyScenePauseOwner = self
-      sprite._roxyScenePauseState = state
-
-      local pause = sprite.pause
-      if pause then pause(sprite) end
-
-      if (state & RESTORE_UPDATES) ~= 0 then
-        local setUpdatesEnabled = sprite.setUpdatesEnabled
-        if setUpdatesEnabled then setUpdatesEnabled(sprite, false) end
-      end
-
-      if (state & RESTORE_COLLISIONS) ~= 0 then
-        local setCollisionsActive = sprite._setScenePauseCollisionsActive
-        if setCollisionsActive then
-          setCollisionsActive(sprite, false)
+        local updatesEnabled = sprite.updatesEnabled
+        if updatesEnabled ~= nil then
+          local value = updatesEnabled(sprite)
+          if value ~= false and value ~= 0 then state = state + restoreUpdates end
         else
-          local setCollisionsEnabled = sprite.setCollisionsEnabled
-          if setCollisionsEnabled then setCollisionsEnabled(sprite, false) end
+          state = state + restoreUpdates
         end
+
+        local collisionsEnabled = sprite.collisionsEnabled
+        if collisionsEnabled ~= nil then
+          local value = collisionsEnabled(sprite)
+          if value ~= false and value ~= 0 then state = state + restoreCollisions end
+        else
+          state = state + restoreCollisions
+        end
+
+        local snapshot = (pauseMask << snapshotStateBits) + state
+        snapshots[sprite] = snapshot
+        snapshotCount = snapshotCount + 1
+        snapshotList[snapshotCount] = sprite
+
+        local pause = sprite.pause
+        if pause ~= nil then pause(sprite) end
+        if (state & restoreUpdates) ~= 0 then
+          local setter = sprite.setUpdatesEnabled
+          if setter ~= nil then setter(sprite, false) end
+        end
+        if (state & restoreCollisions) ~= 0 then
+          local sceneSetter = sprite._setScenePauseCollisionsActive
+          if sceneSetter ~= nil then
+            sceneSetter(sprite, false)
+          else
+            local setter = sprite.setCollisionsEnabled
+            if setter ~= nil then setter(sprite, false) end
+          end
+        end
+      elseif pauseMask == scenePauseUpdates then
+        local state = 0
+        local updatesEnabled = sprite.updatesEnabled
+        if updatesEnabled ~= nil then
+          local value = updatesEnabled(sprite)
+          if value ~= false and value ~= 0 then state = restoreUpdates end
+        else
+          state = restoreUpdates
+        end
+
+        local snapshot = state ~= 0 and snapshotUpdatesOn or snapshotUpdatesOff
+        snapshots[sprite] = snapshot
+        snapshotCount = snapshotCount + 1
+        snapshotList[snapshotCount] = sprite
+
+        if state ~= 0 then
+          local setter = sprite.setUpdatesEnabled
+          if setter ~= nil then setter(sprite, false) end
+        end
+      elseif pauseMask == scenePauseCollisions then
+        local state = 0
+        local collisionsEnabled = sprite.collisionsEnabled
+        if collisionsEnabled ~= nil then
+          local value = collisionsEnabled(sprite)
+          if value ~= false and value ~= 0 then state = restoreCollisions end
+        else
+          state = restoreCollisions
+        end
+
+        local snapshot = state ~= 0 and snapshotCollisionsOn or snapshotCollisionsOff
+        snapshots[sprite] = snapshot
+        snapshotCount = snapshotCount + 1
+        snapshotList[snapshotCount] = sprite
+
+        if state ~= 0 then
+          local sceneSetter = sprite._setScenePauseCollisionsActive
+          if sceneSetter ~= nil then
+            sceneSetter(sprite, false)
+          else
+            local setter = sprite.setCollisionsEnabled
+            if setter ~= nil then setter(sprite, false) end
+          end
+        end
+      elseif pauseMask ~= scenePauseNone then
+        _pauseSceneSprite(self, sprite, pauseMask)
+        snapshotCount = #snapshotList
       end
-    else
-      _pauseSceneSprite(self, sprite, pauseMask)
     end
   end
 
@@ -1051,72 +1020,96 @@ function RoxyScene:resume()
   Log.debug("[RoxyScene:resume] Resuming Scene: " .. self.name) --#DEBUG
   self.isPaused = false
 
-  -- Enable sprites for updating and colliding
-  local collisionSprites = self._pauseCollisionSprites
-  for i = #collisionSprites, 1, -1 do
-    local sprite = collisionSprites[i]
-    if sprite._roxyScenePauseOwner == self then
-      local state = sprite._roxyScenePauseState or 0
-      local restoreCollisions = (state & RESTORE_COLLISIONS) ~= 0
-      local setCollisionsActive = sprite._setScenePauseCollisionsActive
-      if setCollisionsActive then
-        setCollisionsActive(sprite, restoreCollisions)
-      else
-        local setCollisionsEnabled = sprite.setCollisionsEnabled
-        if setCollisionsEnabled then setCollisionsEnabled(sprite, restoreCollisions) end
-      end
-      sprite._roxyScenePauseOwner = nil
-      sprite._roxyScenePauseState = nil
-    end
-  end
-
-  local updateSprites = self._pauseUpdateSprites
-  for i = #updateSprites, 1, -1 do
-    local sprite = updateSprites[i]
-    if sprite._roxyScenePauseOwner == self then
-      local state = sprite._roxyScenePauseState or 0
-      local setUpdatesEnabled = sprite.setUpdatesEnabled
-      if setUpdatesEnabled then
-        setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
-      end
-      sprite._roxyScenePauseOwner = nil
-      sprite._roxyScenePauseState = nil
-    end
-  end
-
-  local sprites = self._pauseSprites
-  for i = #sprites, 1, -1 do
-    local sprite = sprites[i]
-    local pauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-    if pauseMask == SCENE_PAUSE_ALL and sprite._roxyScenePauseOwner == self then
-      local state = sprite._roxyScenePauseState or 0
-
-      if (state & SHOULD_PLAY) ~= 0 then
-        local play = sprite.play
-        if play then play(sprite) end
-      end
-
-      local setUpdatesEnabled = sprite.setUpdatesEnabled
-      if setUpdatesEnabled then
-        setUpdatesEnabled(sprite, (state & RESTORE_UPDATES) ~= 0)
-      end
-
-      local setCollisionsActive = sprite._setScenePauseCollisionsActive
-      if setCollisionsActive then
-        setCollisionsActive(sprite, (state & RESTORE_COLLISIONS) ~= 0)
-      else
-        local setCollisionsEnabled = sprite.setCollisionsEnabled
-        if setCollisionsEnabled then
-          setCollisionsEnabled(sprite, (state & RESTORE_COLLISIONS) ~= 0)
+  local snapshots = self._pauseSpriteSnapshots
+  local snapshotList = self._pauseSpriteSnapshotList
+  local scenePauseAll = SCENE_PAUSE_ALL
+  local scenePauseUpdates = SCENE_PAUSE_UPDATES
+  local scenePauseCollisions = SCENE_PAUSE_COLLISIONS
+  local scenePausePlayback = SCENE_PAUSE_PLAYBACK
+  local restoreUpdates = RESTORE_UPDATES
+  local restoreCollisions = RESTORE_COLLISIONS
+  local shouldPlay = SHOULD_PLAY
+  local snapshotStateMask = SNAPSHOT_STATE_MASK
+  local snapshotStateBits = SNAPSHOT_STATE_BITS
+  local snapshotUpdatesOff = SNAPSHOT_UPDATES_OFF
+  local snapshotUpdatesOn = SNAPSHOT_UPDATES_ON
+  local snapshotCollisionsOff = SNAPSHOT_COLLISIONS_OFF
+  local snapshotCollisionsOn = SNAPSHOT_COLLISIONS_ON
+  local snapshotAllBase = SNAPSHOT_ALL_BASE
+  for i = #snapshotList, 1, -1 do
+    local sprite = snapshotList[i]
+    local snapshot = snapshots[sprite]
+    if snapshot then
+      repeat
+        if snapshot < snapshotAllBase then
+          if snapshot == snapshotCollisionsOn or snapshot == snapshotCollisionsOff then
+            local restoreActive = snapshot == snapshotCollisionsOn
+            local sceneSetter = sprite._setScenePauseCollisionsActive
+            if sceneSetter ~= nil then
+              sceneSetter(sprite, restoreActive)
+            else
+              local setter = sprite.setCollisionsEnabled
+              if setter ~= nil then setter(sprite, restoreActive) end
+            end
+            snapshots[sprite] = nil
+            break
+          elseif snapshot == snapshotUpdatesOn or snapshot == snapshotUpdatesOff then
+            local setter = sprite.setUpdatesEnabled
+            if setter ~= nil then setter(sprite, snapshot == snapshotUpdatesOn) end
+            snapshots[sprite] = nil
+            break
+          end
         end
-      end
 
-      sprite._roxyScenePauseOwner = nil
-      sprite._roxyScenePauseState = nil
-    else
-      _resumeSceneSprite(self, sprite)
+        local pauseMask = snapshot >> snapshotStateBits
+        local state = snapshot & snapshotStateMask
+
+        if pauseMask == scenePauseAll then
+          if (state & shouldPlay) ~= 0 then
+            local play = sprite.play
+            if play ~= nil then play(sprite) end
+          end
+          local updateSetter = sprite.setUpdatesEnabled
+          if updateSetter ~= nil then
+            updateSetter(sprite, (state & restoreUpdates) ~= 0)
+          end
+          local sceneSetter = sprite._setScenePauseCollisionsActive
+          if sceneSetter ~= nil then
+            sceneSetter(sprite, (state & restoreCollisions) ~= 0)
+          else
+            local collisionSetter = sprite.setCollisionsEnabled
+            if collisionSetter ~= nil then
+              collisionSetter(sprite, (state & restoreCollisions) ~= 0)
+            end
+          end
+          snapshots[sprite] = nil
+        elseif pauseMask == scenePauseUpdates then
+          local setter = sprite.setUpdatesEnabled
+          if setter ~= nil then setter(sprite, (state & restoreUpdates) ~= 0) end
+          snapshots[sprite] = nil
+        elseif pauseMask == scenePauseCollisions then
+          local sceneSetter = sprite._setScenePauseCollisionsActive
+          if sceneSetter ~= nil then
+            sceneSetter(sprite, (state & restoreCollisions) ~= 0)
+          else
+            local setter = sprite.setCollisionsEnabled
+            if setter ~= nil then setter(sprite, (state & restoreCollisions) ~= 0) end
+          end
+          snapshots[sprite] = nil
+        elseif pauseMask == scenePausePlayback then
+          if (state & shouldPlay) ~= 0 then
+            local play = sprite.play
+            if play ~= nil then play(sprite) end
+          end
+          snapshots[sprite] = nil
+        else
+          _resumeSceneSprite(self, sprite, snapshot, false)
+        end
+      until true
     end
   end
+  self._pauseSpriteSnapshots = {}
+  self._pauseSpriteSnapshotList = {}
 
   -- Enable sequences for updating
   local sequences = self.sequences
@@ -1224,59 +1217,42 @@ end
 -- Sprites
 --------------------------------------------------------------------------------
 
+-- ! Sprite Pause Classification Did Change
+function RoxyScene:_spritePauseClassificationDidChange(sprite, oldMask, newMask)
+  if oldMask == newMask then return end
+  if not sprite or sprite.scene ~= self or self._spriteSet[sprite] ~= true then return end
+  if not self.isPaused then return end
+  if not self._didEnter or self._spriteAutoAddIndex[sprite] ~= nil then return end
+
+  _resumeSceneSprite(self, sprite)
+
+  if newMask ~= SCENE_PAUSE_NONE then
+    _pauseSceneSprite(self, sprite, newMask)
+  end
+end
+
 -- ! Add Sprite
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
 
-  local pauseMask = _getScenePauseMask(sprite)
-
   if self._spriteSet[sprite] == true then
     local isTracked = _hasIndexed(self.sprites, self._spriteIndex, sprite)
     local isQueued = self._didEnter or _hasIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
-    local cachedPauseMask = sprite._roxyScenePauseMask or SCENE_PAUSE_NONE
     if sprite.scene == self and isTracked and isQueued then
-      if cachedPauseMask == pauseMask then return end
-
-      if sprite._roxyScenePauseOwner == self then
-        _resumeRegisteredSceneSprite(self, sprite, cachedPauseMask)
-      end
-
-      _removeFromScenePauseBuckets(self, sprite)
-      _clearScenePauseRegistration(sprite)
-      _clearScenePauseSnapshot(self, sprite)
-
-      if pauseMask ~= SCENE_PAUSE_NONE then
-        sprite._roxyScenePauseMask = pauseMask
-        _addToScenePauseBucket(self, sprite, pauseMask)
-      end
-
-      if self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
-        _pauseRegisteredSceneSprite(self, sprite, pauseMask)
-      end
-
       return
     end
 
+    _restoreScenePauseBeforeUnregister(self, sprite, false)
     _removeIndexed(self.sprites, self._spriteIndex, sprite)
     _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
-    _removeFromScenePauseBuckets(self, sprite)
     self._spriteSet[sprite] = nil
-    _clearScenePauseRegistration(sprite)
-    _clearScenePauseSnapshot(self, sprite)
   end
 
   local currentScene = sprite.scene
-  local transferPauseMask = nil
-  local transferPauseState = nil
-  if currentScene ~= nil and currentScene ~= self and type(currentScene) == "table" then
-    if sprite._roxyScenePauseOwner == currentScene then
-      transferPauseMask = sprite._roxyScenePauseMask or _getScenePauseMask(sprite)
-      transferPauseState = sprite._roxyScenePauseState
-    end
-
-    if type(currentScene._unregisterSprite) == "function" then
-      currentScene:_unregisterSprite(sprite, true, true)
-    elseif type(currentScene.removeSprite) == "function" then
+  if currentScene ~= nil and currentScene ~= self and luaType(currentScene) == "table" then
+    if luaType(currentScene._unregisterSprite) == "function" then
+      currentScene:_unregisterSprite(sprite, true)
+    elseif luaType(currentScene.removeSprite) == "function" then
       currentScene:removeSprite(sprite)
     end
   end
@@ -1287,18 +1263,6 @@ function RoxyScene:addSprite(sprite)
   _appendIndexed(self.sprites, self._spriteIndex, sprite)
   self._spriteSet[sprite] = true
 
-  if pauseMask ~= SCENE_PAUSE_NONE then
-    sprite._roxyScenePauseMask = pauseMask
-    _addToScenePauseBucket(self, sprite, pauseMask)
-  else
-    _clearScenePauseRegistration(sprite)
-  end
-
-  if transferPauseMask ~= nil and self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
-    sprite._roxyScenePauseOwner = self
-    sprite._roxyScenePauseState = transferPauseState
-  end
-
   if self._didEnter then
     -- Scene is active -- attach immediately
     sprite:add()
@@ -1307,19 +1271,8 @@ function RoxyScene:addSprite(sprite)
     _appendIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
   end
 
-  if self.isPaused and pauseMask ~= SCENE_PAUSE_NONE then
-    _pauseRegisteredSceneSprite(self, sprite, pauseMask)
-  elseif transferPauseMask ~= nil then
-    local restoreMask = sprite._roxyScenePauseMask
-    sprite._roxyScenePauseMask = transferPauseMask
-    sprite._roxyScenePauseOwner = self
-    sprite._roxyScenePauseState = transferPauseState
-    _resumeRegisteredSceneSprite(self, sprite, transferPauseMask)
-    if pauseMask ~= SCENE_PAUSE_NONE then
-      sprite._roxyScenePauseMask = restoreMask or pauseMask
-    else
-      _clearScenePauseRegistration(sprite)
-    end
+  if self.isPaused and self._didEnter then
+    _pauseRegisteredSceneSprite(self, sprite)
   end
 end
 
@@ -1330,26 +1283,18 @@ end
 
 -- ! Unregister Sprite
 -- Private cleanup path used by tilemaps and direct scene sprite removal
-function RoxyScene:_unregisterSprite(sprite, removeFromDisplay, preserveScenePauseState)
+function RoxyScene:_unregisterSprite(sprite, removeFromDisplay)
   if not sprite then return end
 
   local wasSelfOwnedAtEntry = sprite.scene == self
-  local wasSelfTrackedAtEntry = self._spriteSet[sprite] == true
 
-  if preserveScenePauseState ~= true then
-    _restoreScenePauseBeforeUnregister(self, sprite)
-  end
+  _restoreScenePauseBeforeUnregister(self, sprite)
 
   -- Remove only this scene's ownership state
   -- Direct external writes to scene.sprites are unsupported, but removeAllSprites remains tolerant.
   _removeIndexed(self.sprites, self._spriteIndex, sprite)
   _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
-  _removeFromScenePauseBuckets(self, sprite)
   self._spriteSet[sprite] = nil
-  if wasSelfTrackedAtEntry then
-    _clearScenePauseRegistration(sprite)
-  end
-  _clearScenePauseSnapshot(self, sprite)
 
   if wasSelfOwnedAtEntry and sprite.scene == self then
     sprite.scene = nil -- Clear back-pointer
@@ -1384,18 +1329,12 @@ function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
   for i = 1, #targetList do
     local sprite = targetList[i]
     local wasSelfOwnedAtEntry = sprite.scene == self
-    local wasSelfTrackedAtEntry = self._spriteSet[sprite] == true
 
-    _restoreScenePauseBeforeUnregister(self, sprite)
+    _restoreScenePauseBeforeUnregister(self, sprite, false)
 
     _removeIndexed(self.sprites, self._spriteIndex, sprite)
     _removeIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
-    _removeFromScenePauseBuckets(self, sprite)
     self._spriteSet[sprite] = nil
-    if wasSelfTrackedAtEntry then
-      _clearScenePauseRegistration(sprite)
-    end
-    _clearScenePauseSnapshot(self, sprite)
 
     if wasSelfOwnedAtEntry and sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
@@ -1405,6 +1344,7 @@ function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
       sprite:remove()
     end
   end
+  _pruneScenePauseSnapshotList(self, targets)
 end
 
 -- ! Remove All Sprites
@@ -1416,22 +1356,16 @@ function RoxyScene:removeAllSprites()
   self._spriteIndex = {}
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
-  self._pauseSprites = {}
-  self._pauseSpriteIndex = {}
-  self._pauseUpdateSprites = {}
-  self._pauseUpdateSpriteIndex = {}
-  self._pauseCollisionSprites = {}
-  self._pauseCollisionSpriteIndex = {}
 
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
-    _restoreScenePauseBeforeUnregister(self, sprite)
-    _clearScenePauseRegistration(sprite)
-    _clearScenePauseSnapshot(self, sprite)
+    _restoreScenePauseBeforeUnregister(self, sprite, false)
     if sprite.scene == self then
       sprite.scene = nil -- Clear back-pointer
     end
   end
+  self._pauseSpriteSnapshots = {}
+  self._pauseSpriteSnapshotList = {}
 
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
@@ -1462,7 +1396,7 @@ function RoxyScene:addTilemap(tilemap)
     if self.tilemaps[i] == tilemap then return true end
   end
 
-  if type(tilemap.attachToScene) ~= "function" then
+  if luaType(tilemap.attachToScene) ~= "function" then
     Log.warn("[RoxyScene:addTilemap] Expected tilemap with attachToScene") --#DEBUG
     return false
   end
@@ -1481,7 +1415,7 @@ function RoxyScene:removeTilemap(tilemap)
   if not tilemap then return false end
   if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
 
-  if type(tilemap.destroy) ~= "function" then
+  if luaType(tilemap.destroy) ~= "function" then
     Log.warn("[RoxyScene:removeTilemap] Expected tilemap with destroy") --#DEBUG
     return false
   end
@@ -1496,7 +1430,7 @@ function RoxyScene:detachTilemap(tilemap)
   if not tilemap then return false end
   if tilemap.scene ~= self and not _hasItem(self.tilemaps, tilemap) then return false end
 
-  if type(tilemap.detachFromScene) ~= "function" then
+  if luaType(tilemap.detachFromScene) ~= "function" then
     Log.warn("[RoxyScene:detachTilemap] Expected tilemap with detachFromScene") --#DEBUG
     return false
   end
@@ -1528,7 +1462,7 @@ function RoxyScene:removeAllTilemaps()
 
   for i = #tilemaps, 1, -1 do
     local tilemap = tilemaps[i]
-    if type(tilemap.destroy) == "function" then
+    if luaType(tilemap.destroy) == "function" then
       tilemap:destroy()
     end
   end
@@ -1607,7 +1541,7 @@ end
 -- ! Set Input Handler
 function RoxyScene:addHandler()
   local inputHandler = self.inputHandler
-  if inputHandler and (type(inputHandler) == "table" or type(inputHandler) == "function") then
+  if inputHandler and (luaType(inputHandler) == "table" or luaType(inputHandler) == "function") then
     addHandler(self, inputHandler, 0)
   end
 end
@@ -1628,7 +1562,7 @@ end
 
 --[[
 
-RoxyScene owns scene lifecycle, input, sprites, tilemaps, sequences, and camera setup.
+RoxyScene owns scene lifecycle, input, sprites, tilemaps, sequences, camera setup, and pause state.
 
 -- Gameplay Scene
 local Graphics <const> = playdate.graphics
@@ -1651,7 +1585,12 @@ function GameplayScene:start()
   GameplayScene.super.start(self)
 
   self.player = RoxySprite({ name = "player" })
+  self.player:setPauseClassification(nil) -- Default dynamic pause behavior
   self:addSprite(self.player)
+
+  self.marker = Graphics.sprite.new()
+  self.marker:setPauseClassification({}) -- Static; skip scene pause work
+  self:addSprite(self.marker)
 
   self.map = self:spawnTilemap("assets/maps/level-01.json", {
     cameraBounds = true,
@@ -1676,6 +1615,7 @@ end
 function GameplayScene:cleanup()
   GameplayScene.super.cleanup(self)
   self.player = nil
+  self.marker = nil
   self.map = nil
   self.fadeIn = nil
 end
@@ -1692,7 +1632,7 @@ local player = RoxySprite({ name = "player" })
 local tilemap = RoxyOrthoTilemap("assets/maps/level-01.json")
 
 scene:addSprite(player)
-scene:addTilemap(tilemap)
+scene:addTilemap(tilemap) -- Tilemap sprites classify their own pause behavior
 scene:activateCamera({ tilemap = tilemap, target = player })
 
 scene:detachTilemap(tilemap)

--- a/core/sprites/RoxyActor.lua
+++ b/core/sprites/RoxyActor.lua
@@ -46,6 +46,21 @@ local function _resolveTerminal(self, startName)
   end
 end
 
+-- ! Helper: Manifest Needs Sheet
+-- Returns true when animation manifest fields require a sheet
+local function _manifestNeedsSheet(manifest)
+  return type(manifest) == "table"
+     and manifest.sheet == nil
+     and (
+       manifest.rows ~= nil
+       or manifest.frames ~= nil
+       or manifest.loop ~= nil
+       or manifest.next ~= nil
+       or manifest.default ~= nil
+       or manifest.transitions ~= nil
+     )
+end
+
 --------------------------------------------------------------------------------
 -- Class Definition & Init
 --------------------------------------------------------------------------------
@@ -99,7 +114,7 @@ function RoxyActor:_initializeProperties()
   self.facing       = 1
 
   --#DEBUG START
-  if not self.animation and not self._manifest.sheet then
+  if not self.animation and _manifestNeedsSheet(self._manifest) then
     Log.warn("[RoxyActor:init] No spritesheet/imagetable provided in manifest")
   end
   --#DEBUG END
@@ -113,12 +128,15 @@ function RoxyActor:_setupSheet()
     if sheetType == "string" then
       self:setView(sheet, true, false, false)
     elseif sheetType == "userdata" and sheet.getImage then
-      self:setView(RoxyAnimation.fromImagetable(sheet))
+      self:setView({ imagetable = sheet })
     elseif sheetType == "table" then
-      if sheet.isRoxyAnimation then
-        self:setView(sheet:retain())
+      if sheet.poolKey then
+        -- Pooled descriptors are owned and recycled by RoxySprite
+        self:setView(sheet)
+      elseif sheet.isRoxyAnimation then
+        self:setView(sheet)
       elseif sheet.animation and sheet.animation.isRoxyAnimation then
-        self:setView(sheet.animation:retain())
+        self:setView(sheet.animation)
       --#DEBUG START
       else
         Log.warn("[RoxyActor:init] Unsupported table for 'sheet'")
@@ -126,7 +144,7 @@ function RoxyActor:_setupSheet()
       end
     --#DEBUG START
     else
-      Log.warn("[RoxyActor:init] Unsupported sheet type; expected path, imagetable, RoxyAnimation, or {animation=...}")
+      Log.warn("[RoxyActor:init] Unsupported sheet type; expected path, imagetable, RoxyAnimation, {poolKey=...}, or {animation=...}")
     --#DEBUG END
     end
   end
@@ -198,8 +216,13 @@ end
 -- Helper so we centralize finishing semantics
 function RoxyActor:_finishPlayOnce()
   local fn = self._onPlayOnceFinish
+  local nextState = self.nextState
   self._onPlayOnceFinish = nil
   self._playOnceTerminal = nil
+  self.nextState = nil
+  if nextState then
+    self:setState(nextState)
+  end
   if fn then fn(self) end
 end
 
@@ -273,7 +296,7 @@ function RoxyActor:_maybeSettleHold(stateName)
 end
 
 -- ! Settle Then Default
--- Called when a non-loop clip with no next completes.
+-- Called when a non-loop clip with no next completes
 function RoxyActor:_settleThenDefault(stateName, clip)
   local default = self.defaultState or (self.manifest and self.manifest.default)
   if not (default and self.animations and self.animations[default]) then return end
@@ -352,7 +375,7 @@ function RoxyActor:_onAnimationComplete(stateName)
 end
 
 -- ! Evaluate Condition
--- Optimized condition evaluation with early exit
+-- Evaluates a pre-parsed transition condition
 function RoxyActor:_evaluateCondition(condition, opts)
   local optVal = opts[condition.option]
   if condition.type == "gt" then
@@ -406,7 +429,7 @@ function RoxyActor:setState(stateName, force)
 end
 
 -- ! Queue State
--- Queue up a state change to occur as soon as the current clip finishes.
+-- Queue up a state change to occur as soon as the current clip finishes
 function RoxyActor:queueState(stateName)
   --#DEBUG START
   if type(stateName) ~= "string" then
@@ -425,7 +448,7 @@ function RoxyActor:queueState(stateName)
 end
 
 -- ! Play Once
--- Play a one-shot animation state, then return to the previous/default.
+-- Play a one-shot animation state, then return to the previous/default
 function RoxyActor:playOnce(stateName, onFinish)
   if not self.animation or not self.animations or not self.animations[stateName] then return self end
 
@@ -515,7 +538,7 @@ function RoxyActor:updatePhysics(opts)
   -- Set facing based on desired velocity (intent, not actual)
   self:setFacing(desiredVx)
 
-  -- Cached transition rules with optimized condition checking
+  -- Use pre-parsed transition rules when available
   local cache = self._transitionRulesCache
   if cache and #cache > 0 then
     for _, rule in ipairs(cache) do
@@ -698,9 +721,9 @@ local actor1 = RoxyActor(manifest, scene)               -- 2-arg
 local actor2 = RoxyActor(manifest, "idle", opts, scene) -- 4-arg
 local actor3 = RoxyActor(manifest, "idle", scene)       -- 3-arg
 
--- Asset Pool Integration
+-- Asset Pool Integration (pooled sheet data, private animation state)
 local pooledActor = RoxyActor({
-  sheet = RoxyAnimation.fromPool("shared_character_animations")
+  sheet = { poolKey = "character_sheet_pool", kind = "sheet" }
 }, scene)
 
 -- Cleanup

--- a/core/sprites/RoxyParticles.lua
+++ b/core/sprites/RoxyParticles.lua
@@ -6,20 +6,20 @@ local Sprite    <const> = Graphics.sprite
 local r         <const> = roxy
 local Debug     <const> = r.Debug
 
-local max     <const> = math.max
-local floor   <const> = math.floor
-local clamp   <const> = r.Math.clamp
+local max   <const> = math.max
+local floor <const> = math.floor
+local clamp <const> = r.Math.clamp
 
 local tableUnpack         <const> = table.unpack
 local mergeTableImmutable <const> = r.Table.mergeImmutable
 
 local char <const> = string.char
 
-local setColor          <const> = Graphics.setColor
-local pushContext       <const> = Graphics.pushContext  --#DEBUG
-local popContext        <const> = Graphics.popContext   --#DEBUG
-local newImage          <const> = Graphics.image.new    --#DEBUG
-local fillRect          <const> = Graphics.fillRect
+local setColor    <const> = Graphics.setColor
+local pushContext <const> = Graphics.pushContext  --#DEBUG
+local popContext  <const> = Graphics.popContext   --#DEBUG
+local newImage    <const> = Graphics.image.new    --#DEBUG
+local fillRect    <const> = Graphics.fillRect
 
 -- C-side binding names updated for registered class/object API:
 local new_C           <const> = RoxyParticlesC.new
@@ -76,9 +76,9 @@ local DEFAULT_OPTS <const> = {
   frameRate  = 12,
 }
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Helpers
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 --#DEBUG START
 -- ! Crosshair Image
@@ -114,14 +114,19 @@ local function computeAABB(opts, frameW, frameH)
   )
 end
 
--- ----------------------------------------
--- ! Class Definition & Init
--- ----------------------------------------
+--------------------------------------------------------------------------------
+-- ! Class Definition and Initialize
+--------------------------------------------------------------------------------
 
 class("RoxyParticles").extends(RoxySprite)
 
+-- ! Initialize
 function RoxyParticles:init(x, y, opts)
   RoxySprite.super.init(self)
+  self._roxyScenePausePlayback = false
+  self._roxyScenePauseUpdates = true
+  self._roxyScenePauseCollisions = false
+
   local opts = mergeTableImmutable(DEFAULT_OPTS, (opts or EMPTY_TABLE))
 
   -- Clamp and validate ranges for safety
@@ -182,7 +187,7 @@ function RoxyParticles:init(x, y, opts)
     self:setPattern(opts.pattern)
   end
 
-  -- calculate AABB via C
+  -- Calculate AABB via C
   local left, right, top, bottom, boxW, boxH = computeAABB(opts, self.frameWidth or 0, self.frameHeight or 0)
   self.emitterOffsetX = -left
   self.emitterOffsetY = -top
@@ -207,9 +212,9 @@ function RoxyParticles:init(x, y, opts)
   --#DEBUG END
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Internal Methods
--- ----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Recalculate AABB
 -- Recalculate and apply AABB, reposition sprite
@@ -279,8 +284,8 @@ function RoxyParticles:update()
       -- Deduct the spawned particles from accumulator
       self.accumulator = self.accumulator - actualSpawned
 
-      -- If pool is full and we couldn't spawn anything, reset accumulator
-      -- to prevent it from growing indefinitely
+      -- If pool is full and nothing spawned, reset accumulator
+      -- This prevents it from growing indefinitely.
       if actualSpawned == 0 then
         self.accumulator = 0
       end
@@ -331,9 +336,9 @@ function RoxyParticles:draw()
   --#DEBUG END
 end
 
--- ----------------------------------------
+--------------------------------------------------------------------------------
 -- Public API
--- -----------------------------------------
+--------------------------------------------------------------------------------
 
 -- ! Reset
 -- Completely tear down and re-create the C-side pool so you can emit again
@@ -362,7 +367,7 @@ function RoxyParticles:destroy()
 end
 
 -- ! Burst Emit
--- Instantly spawn `count` particles regardless of rate
+-- Instantly spawn count particles regardless of rate
 function RoxyParticles:emit(count)
   count = floor(count or 1)
   if count <= 0 then return end
@@ -452,7 +457,7 @@ function RoxyParticles:setFrameRate(frameRate)
   self.opts.frameRate = frameRate or DEFAULT_OPTS.frameRate
   -- Push the new FPS into C so spawn/update use it
   setFrameRate_C(self.cpool, self.opts.frameRate)
-  -- Force a redraw so any timing‐sensitive visuals Pick up the new rate immediately
+  -- Force a redraw so any timing-sensitive visuals pick up the new rate immediately
   self:markDirty()
 end
 
@@ -520,7 +525,7 @@ end
 
 -- ! Set Loop
 function RoxyParticles:setLoop(loop)
-  -- false --> 0, true or nil --> 1
+  -- False --> 0, true or nil --> 1
   self.opts.loop = (loop == nil) or loop
 
   -- Push into C
@@ -605,7 +610,7 @@ function RoxyParticles:setPattern(pattern)
     setPattern_C(self.cpool, raw)
     self.opts.pattern = pattern
   elseif type(pattern) == "string" and pattern:match("^%s*{") then
-    -- Hex-list string like "{ 0xaa, 0x55, … }"
+    -- Hex-list string like "{ 0xaa, 0x55, ... }"
     local tbl   = {}
     local count = 0
     -- Each iteration is O(1)
@@ -645,3 +650,63 @@ function RoxyParticles:hasActiveParticles()
   -- Simply return the last-update result
   return self._hasActiveParticles or false
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+RoxyParticles creates sprite-backed particle emitters with C-side simulation.
+
+local Graphics <const> = playdate.graphics
+
+-- Burst Emitter
+local sparks = RoxyParticles(120, 80, {
+  maxCount = 80,
+  lifetime = { 0.25, 0.6 },
+  speed = { 40, 120 },
+  size = { 1, 4 },
+  angleRange = { -120, -60 },
+  color = Graphics.kColorBlack,
+})
+scene:addSprite(sparks)
+sparks:emit(24)
+
+-- Continuous Emitter
+local smoke = RoxyParticles(200, 180, {
+  rate = 12,
+  lifetime = { 1.0, 2.0 },
+  speed = { 8, 18 },
+  accel = { x = 0, y = -8 },
+  size = { 3, 8 },
+  shape = "outline-circle",
+})
+scene:addSprite(smoke)
+smoke:setRate(20)
+smoke:setAngleRange(-100, -80)
+
+-- Imagetable Particles
+local leaves = RoxyParticles(200, 40, {
+  imageTable = Graphics.imagetable.new("images/particles/leaves"),
+  frameMode = "random",
+  loop = false,
+  rate = 8,
+  accel = { x = 6, y = 18 },
+  speed = { 10, 30 },
+})
+scene:addSprite(leaves)
+leaves:setFrameRate(16)
+
+-- Pattern, Finish, and Cleanup
+sparks:setPattern({ 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55 })
+sparks.onFinished = function(emitter)
+  emitter:remove()
+  emitter:destroy()
+end
+
+smoke:clear()
+leaves:reset()
+leaves:setImageTable(nil)
+
+--]]

--- a/core/sprites/RoxyParticles.lua
+++ b/core/sprites/RoxyParticles.lua
@@ -5,6 +5,7 @@ local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 local r         <const> = roxy
 local Debug     <const> = r.Debug
+local Scene     <const> = r.Scene
 
 local max   <const> = math.max
 local floor <const> = math.floor
@@ -123,9 +124,11 @@ class("RoxyParticles").extends(RoxySprite)
 -- ! Initialize
 function RoxyParticles:init(x, y, opts)
   RoxySprite.super.init(self)
-  self._roxyScenePausePlayback = false
-  self._roxyScenePauseUpdates = true
-  self._roxyScenePauseCollisions = false
+  Scene.setSpritePauseClassification(self, {
+    playback = false,
+    updates = true,
+    collisions = false,
+  })
 
   local opts = mergeTableImmutable(DEFAULT_OPTS, (opts or EMPTY_TABLE))
 

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -17,6 +17,7 @@ local Camera  <const> = r.Camera
 local round <const> = r.Math.round
 
 local getAsset      <const> = Assets.getAsset
+local recycleAsset  <const> = Assets.recycleAsset
 local getPosition   <const> = Camera.getPosition
 local worldToScreen <const> = Camera.worldToScreen
 
@@ -42,13 +43,13 @@ local SCREEN_BOTTOM_LIMIT <const> = DISPLAY_HEIGHT
 --------------------------------------------------------------------------------
 
 -- ! Helper: Has Parallax
--- Returns true when the sprite needs camera-relative parallax updates.
+-- Returns true when the sprite needs camera-relative parallax updates
 local function _hasParallax(sprite)
   return sprite.parallaxX ~= nil or sprite.parallaxY ~= nil
 end
 
 -- ! Helper: Set Collisions Active
--- Toggles the Playdate collision system without changing Roxy's desired state.
+-- Toggles the Playdate collision system without changing Roxy's desired state
 local function _setCollisionsActive(sprite, flag)
   sprite._collisionsActive = flag == true
   RoxySprite.super.setCollisionsEnabled(sprite, flag)
@@ -71,7 +72,10 @@ function RoxySprite:init(options, scene)
   self.isPaused                 = true
   self.flip                     = UNFLIPPED
   self.animation                = nil
-  self._animationRetained       = false -- Track if we retained the current animation
+  self._animationRetained       = false -- Track if the current animation should be released
+  self._animationPoolKey        = nil   -- Track checked-out full animation objects
+  self._imagePoolKey            = nil
+  self._pooledImage             = nil
   self.simpleAnimation          = nil
   self._drawFn                  = nil
   self._ignoresDrawOffset       = false
@@ -128,7 +132,7 @@ function RoxySprite:setIgnoresDrawOffset(flag)
 end
 
 -- ! Set Collisions Enabled
--- Sets the desired collision state and applies it immediately.
+-- Sets the desired collision state and applies it immediately
 function RoxySprite:setCollisionsEnabled(flag)
   assert(type(flag) == "boolean", "[RoxySprite:setCollisionsEnabled] Expected boolean, got " .. tostring(type(flag)))
 
@@ -236,17 +240,26 @@ end
 -- View Management
 --------------------------------------------------------------------------------
 
--- ! Clear View Helper - Fixed memory leak by properly tracking retained animations
+-- ! Clear View
+-- Releases sprite-owned view resources and clears display state
 function RoxySprite:clearView()
-  -- Properly release retained animations to prevent memory leaks
+  -- Release current animation ownership
   if self.animation then
     self.animation:stop()
-    -- Only release if we retained it
-    if self._animationRetained and self.animation.release then
+    if self._animationPoolKey then
+      recycleAsset(self._animationPoolKey, self.animation)
+    elseif self._animationRetained and self.animation.release then
       self.animation:release()
     end
     self.animation = nil
     self._animationRetained = false
+    self._animationPoolKey = nil
+  end
+
+  if self._imagePoolKey and self._pooledImage then
+    recycleAsset(self._imagePoolKey, self._pooledImage)
+    self._imagePoolKey = nil
+    self._pooledImage = nil
   end
 
   self.simpleAnimation = nil -- Clear any previous simpleAnimation
@@ -272,40 +285,43 @@ local function _applySizeFromImageTable(sprite, imagetable)
   end
 end
 
--- ! Helper: Setup pooled animation with proper memory management
+-- ! Helper: Setup Pooled View
+-- Sets up pooled sheet, full-animation, or image descriptors
 local function _setupPooledAnimation(sprite, view)
   local kind = view.kind or "sheet"
 
   if kind == "sheet" then
-    -- Load imagetable from pool; wrap as RoxyAnimation
-    local imagetable = getAsset(view.poolKey)
-    if not imagetable then
-      error(("[RoxySprite:setView] Pool key not found: %s"):format(tostring(view.poolKey)), 3)
-    end
-    sprite.animation = RoxyAnimation.fromImagetable(imagetable) -- Refcount owned by this sprite
-    sprite._animationRetained = false -- We own this, don't need to release
-    _applySizeFromImageTable(sprite, imagetable)
+    -- Pooled sheets share image data with sprite-local playback state
+    sprite.animation = RoxyAnimation.fromPool(view.poolKey)
+    sprite._animationRetained = true
+    _applySizeFromImageTable(sprite, sprite.animation.imagetable)
     sprite._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
 
   elseif kind == "animation" then
-    -- Pooled/shared animation object in Assets pool
+    -- Pooled full animation object from an Assets pool
     local animation = getAsset(view.poolKey)
     if not (type(animation) == "table" and animation.isRoxyAnimation) then
+      if animation then
+        recycleAsset(view.poolKey, animation)
+      end
       error(("[RoxySprite:setView] Pool key does not resolve to RoxyAnimation: %s"):format(tostring(view.poolKey)), 3)
     end
-    if animation.retain then
-      animation:retain()
-      sprite._animationRetained = true -- Track that we retained this
-    end
     sprite.animation = animation
+    sprite._animationRetained = false
+    sprite._animationPoolKey = view.poolKey
     _applySizeFromImageTable(sprite, animation.imagetable)
     sprite._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
 
   elseif kind == "image" then
     local image = getAsset(view.poolKey)
     if not (image and image.draw) then
+      if image then
+        recycleAsset(view.poolKey, image)
+      end
       error(("[RoxySprite:setView] Pool key does not resolve to Image: %s"):format(tostring(view.poolKey)), 3)
     end
+    sprite._imagePoolKey = view.poolKey
+    sprite._pooledImage = image
     sprite:setImage(image) -- Sets sprite size from image
     sprite._drawFn = function(_, x, y, flip) image:draw(x, y, flip) end
 
@@ -334,7 +350,7 @@ local function _setupSimpleAnimation(sprite, imagetable, frameDuration, loop)
   }
 
   _applySizeFromImageTable(sprite, imagetable)
-  -- Optimized draw function for simpleAnimation
+  -- Use a cached draw function for simpleAnimation
   sprite._drawFn = function(s, x, y, flip)
     local simpleAnimation = s.simpleAnimation
     if simpleAnimation and simpleAnimation.imagetable then
@@ -358,7 +374,7 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
   end
   self:setVisible(true)
 
-  -- Clear previous state (handles memory cleanup properly)
+  -- Clear previous view state before installing the new one
   self:clearView()
 
   -- Handle descriptor table form
@@ -367,10 +383,13 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
     return self
   end
 
-  -- Handle direct pooled objects
-  if type(view) == "table" and view.imagetable then
-    self.animation = RoxyAnimation.fromImagetable(view.imagetable)
-    self._animationRetained = false
+  if type(view) == "table" and (view.isRoxyAnimation == true) then
+    -- Direct RoxyAnimation instances share playback state explicitly
+    if view.retain then
+      view:retain()
+      self._animationRetained = true
+    end
+    self.animation = view
     _applySizeFromImageTable(self, view.imagetable)
     self._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
     return self
@@ -378,12 +397,22 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
 
   if type(view) == "table" and view.animation and
      (type(view.animation) == "table" and view.animation.isRoxyAnimation) then
+    -- Wrapped RoxyAnimation instances share playback state explicitly
     if view.animation.retain then
       view.animation:retain()
       self._animationRetained = true
     end
     self.animation = view.animation
     _applySizeFromImageTable(self, view.animation.imagetable)
+    self._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
+    return self
+  end
+
+  -- Handle imagetable descriptor tables
+  if type(view) == "table" and view.imagetable then
+    self.animation = RoxyAnimation.fromImagetable(view.imagetable)
+    self._animationRetained = true
+    _applySizeFromImageTable(self, view.imagetable)
     self._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
     return self
   end
@@ -398,7 +427,7 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
       else
         -- Full RoxyAnimation
         self.animation = RoxyAnimation(view) -- Path-based constructor
-        self._animationRetained = false
+        self._animationRetained = true
         if not (self.animation and self.animation.imagetable) then
           error("[RoxySprite:setView] Failed to load spritesheet for RoxySprite", 2)
         end
@@ -417,16 +446,6 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
         if image then image:draw(x, y, flip) end
       end
     end
-
-  elseif type(view) == "table" and (view.isRoxyAnimation == true) then
-    -- Direct RoxyAnimation instance
-    if view.retain then
-      view:retain()
-      self._animationRetained = true
-    end
-    self.animation = view
-    _applySizeFromImageTable(self, view.imagetable)
-    self._drawFn = function(s, x, y, flip) s.animation:draw(x, y, flip) end
 
   elseif type(view) == "userdata" then
     -- Handle ImageTable or Image userdata
@@ -491,7 +510,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Add Animation
--- Accepts either an options table or legacy (name, opts) arguments.
+-- Accepts either an options table or legacy (name, opts) arguments
 function RoxySprite:addAnimation(optsOrName, legacyOpts)
   local animationOpts
 
@@ -573,7 +592,7 @@ function RoxySprite:play()
   return self
 end
 
--- ! Play With Delay - Fixed race condition
+-- ! Play With Delay
 function RoxySprite:playWithDelay(delay, animationName)
   if not (type(delay) == "number" and delay > 0) then
     Log.warn("[RoxySprite:playWithDelay] Delay must be a positive number") --#DEBUG
@@ -582,7 +601,7 @@ function RoxySprite:playWithDelay(delay, animationName)
 
   if self.animation or self.simpleAnimation then
     performAfterDelay(delay * MS_PER_SECOND, function()
-      -- Check if sprite still exists and hasn't been destroyed
+      -- Skip delayed resume if the sprite was destroyed
       if not self._destroyed and self.animation then
         if animationName then
           self:setAnimation(animationName)
@@ -748,7 +767,7 @@ function RoxySprite:stepFrame(direction)
 end
 
 --------------------------------------------------------------------------------
--- Rendering - Optimized to cache camera position once
+-- Rendering
 --------------------------------------------------------------------------------
 
 -- ! Update
@@ -787,7 +806,7 @@ function RoxySprite:update()
     local oldFrame = simpleAnimation.currentFrame -- Track if frame changes
     simpleAnimation.accumulator += dt
 
-    -- Handle large delta times properly
+    -- Handle large delta times
     while simpleAnimation.accumulator >= simpleAnimation.frameDuration do
       simpleAnimation.currentFrame += 1
       if simpleAnimation.currentFrame > simpleAnimation.endFrame then
@@ -832,7 +851,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Add Sprite
--- Re-adds the sprite and restores state needed by pooled scene reuse.
+-- Re-adds the sprite and restores state needed by pooled scene reuse
 function RoxySprite:add()
   RoxySprite.super.add(self)
   self._added = true
@@ -850,7 +869,7 @@ function RoxySprite:add()
 end
 
 -- ! Remove Sprite
--- Removes the sprite while remembering state that should resume on add().
+-- Removes the sprite while remembering state that should resume on add()
 function RoxySprite:remove()
   if self.isRoxySprite and (self.animation or self.simpleAnimation) then
     self:stop()
@@ -872,6 +891,14 @@ function RoxySprite:remove()
 
   self._added = false
   RoxySprite.super.remove(self)
+  return self
+end
+
+-- ! Remove and Clear View
+-- Fully releases sprite-owned view resources during scene cleanup
+function RoxySprite:removeAndClearView()
+  self:remove()
+  self:clearView()
   return self
 end
 
@@ -927,18 +954,7 @@ function RoxySprite:destroy()
 
   self._destroyed = true
   self:remove()
-
-  -- Release retained animations to prevent memory leaks
-  if self.animation and self._animationRetained and self.animation.release then
-    self.animation:release()
-  end
-
-  self.animation = nil
-  self._animationRetained = false
-  self.simpleAnimation = nil
-  self:setImage(nil)
-  self:setSize(0, 0)
-  self._drawFn = nil
+  self:clearView()
 end
 
 --------------------------------------------------------------------------------

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -144,6 +144,15 @@ function RoxySprite:setCollisionsEnabled(flag)
   return self
 end
 
+-- ! Set Scene Pause Collisions Active
+-- Temporarily toggles collision participation without changing desired state.
+function RoxySprite:_setScenePauseCollisionsActive(flag)
+  assert(type(flag) == "boolean", "[RoxySprite:_setScenePauseCollisionsActive] Expected boolean, got " .. tostring(type(flag)))
+
+  _setCollisionsActive(self, flag)
+  return self
+end
+
 -- ! Set Z-Index
 function RoxySprite:setZIndex(zIndex)
   assert(type(zIndex) == "number", "[RoxySprite:setZIndex] Expected number, got " .. tostring(type(zIndex)))
@@ -963,29 +972,57 @@ end
 
 --[[
 
--- Basic sprite creation
-local sprite = RoxySprite({
+RoxySprite wraps Playdate sprites with image, animation, parallax, and scene ownership helpers.
+
+-- Static Image Sprite
+local player = RoxySprite({
   name = "PlayerSprite",
-  view = "images/player-idle"
+  view = "images/player-idle",
 }, scene)
 
--- Animated sprite with spritesheet
-local animatedSprite = RoxySprite({
+player:moveTo(100, 100)
+player:setZIndex(10)
+player:setCenter(0.5, 1.0)
+player:setCollisionsEnabled(false)
+
+-- Full Animation Sprite
+local enemy = RoxySprite({
   name = "Enemy",
   view = "images/enemy-walk",
-  isSheet = true
-})
+  isSheet = true,
+}, scene)
 
--- Simple looping animation
-local simpleSprite = RoxySprite({
+enemy:addAnimation({
+  name = "walk",
+  startFrame = 1,
+  endFrame = 4,
+  loop = true,
+})
+enemy:addAnimation({
+  name = "attack",
+  startFrame = 5,
+  endFrame = 7,
+  next = "walk",
+})
+enemy:setAnimation("walk"):play()
+enemy:setSpeed(1.5)
+enemy:setFrameDuration(0.08)
+enemy:drawSpecificFrame(1, true)
+enemy:stepFrame(1)
+
+-- Simple Looping Spritesheet
+local coin = RoxySprite({
+  name = "Coin",
   view = "images/coin-spin",
   isSheet = true,
-  singleAnim = true,
-  frameDuration = 0.2
-})
+  singleAnimation = true,
+  singleAnimationLoop = true,
+  frameDuration = 0.12,
+}, scene)
+coin:play()
 
--- Parallax background layer
-local backgroundSprite = RoxySprite({
+-- Parallax Background Layer
+local mountains = RoxySprite({
   name = "Mountains",
   view = "images/mountains",
   worldX = 400,
@@ -993,72 +1030,20 @@ local backgroundSprite = RoxySprite({
   parallaxX = 0.3, -- Moves slower than camera
   parallaxY = 0.1,
   parallaxOriginX = 200,
-  parallaxOriginY = 120
-})
+  parallaxOriginY = 120,
+}, scene)
+mountains:setWorldPosition(420, 240)
+mountains:setParallax(0.25, 0.1)
+mountains:setParallaxOrigin(200, 120)
 
--- Setup and positioning
-sprite:moveTo(100, 100)
-sprite:setZIndex(10)
-sprite:setCenter(0.5, 1.0) -- Bottom-center anchor
+-- Scene Ownership and Cleanup
+local looseSprite = RoxySprite({ name = "LooseSprite", view = "images/item" })
+scene:addSprite(looseSprite)
+local screenX, screenY = looseSprite:getScreenPosition()
+local onScreen = looseSprite:isOnScreen()
 
--- Animation control
-animatedSprite:addAnimation({
-  name = "walk",
-  startFrame = 1,
-  endFrame = 4,
-  loop = true
-})
-animatedSprite:addAnimation({
-  name = "attack",
-  startFrame = 5,
-  endFrame = 7,
-  next = "walk"
-})
--- Legacy signature also works:
-animatedSprite:addAnimation("walk", { loop = true })
-animatedSprite:play()
+looseSprite:flipX()
+looseSprite:removeAndClearView()
+looseSprite:destroy()
 
--- Playback control
-sprite:pause()
-sprite:play()
-sprite:setSpeed(2.0) -- Double speed
-sprite:setFrameDuration(0.05) -- 20 FPS
-
--- Parallax control can be added later
-sprite:setParallax(0.5, 0.8)
-sprite:setWorldPosition(200, 150)
-sprite:setParallaxOrigin(100, 75)
-
--- Pooled scene reuse restores parallax updates and desired collisions on add()
-backgroundSprite:remove()
-backgroundSprite:add()
-
-sprite:setCollisionsEnabled(false)
-sprite:remove()
-sprite:add()
-
--- Sprite management
-local looseSprite = RoxySprite({ name = "LooseSprite" })
-looseSprite:add()            -- Add to display list
-looseSprite:remove()         -- Remove from display list
-scene:addSprite(looseSprite) -- Add through scene ownership
-scene:removeSprite(looseSprite)
-looseSprite:destroy()        -- Clean up resources
-
--- Utility methods
-local onScreen = sprite:isOnScreen()
-local screenX, screenY = sprite:getScreenPosition()
-local isParallax = sprite:isParallaxEnabled()
-
--- Flip states
-sprite:flipX()
-sprite:flipY()
-sprite:flipXY()
-sprite:unflip()
-
--- Frame control for animations
-sprite:drawSpecificFrame(5, true) -- Jump to frame 5 and pause
-sprite:stepFrame(1)               -- Step forward one frame
-sprite:stepFrame(-1)              -- Step backward one frame
-
-]]--
+--]]

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -8,6 +8,7 @@ local Sprite    <const> = Graphics.sprite
 local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
 local Camera      <const> = r.Camera
+local Scene       <const> = r.Scene
 
 local round <const> = r.Math.round
 
@@ -63,9 +64,11 @@ end
 
 -- ! Helper: Set Scene Pause Classification
 local function _setScenePauseClassification(sprite, playback, updates, collisions)
-  sprite._roxyScenePausePlayback = playback
-  sprite._roxyScenePauseUpdates = updates
-  sprite._roxyScenePauseCollisions = collisions
+  Scene.setSpritePauseClassification(sprite, {
+    playback = playback,
+    updates = updates,
+    collisions = collisions,
+  })
 end
 
 --------------------------------------------------------------------------------

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -61,6 +61,13 @@ local function _removeSpritesFromScene(scene, sprites)
   end
 end
 
+-- ! Helper: Set Scene Pause Classification
+local function _setScenePauseClassification(sprite, playback, updates, collisions)
+  sprite._roxyScenePausePlayback = playback
+  sprite._roxyScenePauseUpdates = updates
+  sprite._roxyScenePauseCollisions = collisions
+end
+
 --------------------------------------------------------------------------------
 -- ! Class Definition and Initialize
 --------------------------------------------------------------------------------
@@ -89,7 +96,7 @@ function LayerManager:setScene(scene)
 end
 
 -- ! Add Layer
--- Register/replace layer data. Does NOT create a sprite yet.
+-- Register or replace layer data without creating a sprite yet
 function LayerManager:addLayer(layerData)
   if layerData.visible == nil then layerData.visible = true end
   self.layers[layerData.name] = layerData
@@ -101,7 +108,13 @@ function LayerManager:ensureSprite(name)
   local layer = self.layers[name]; if not layer then return nil end
   if self._opts.wrapInSprites == false then return layer.sprite end
 
+  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
+  local useParallax = (not layer.layerOptions) or (layer.layerOptions.parallax ~= false)
+  local hasParallax = useParallax and (parallaxX ~= 1 or parallaxY ~= 1)
+
   if layer.sprite then
+    -- Keep classification current before addSprite's same-owner fast path.
+    _setScenePauseClassification(layer.sprite, false, hasParallax, false)
     if self._autoAdd and self._sceneHasAdd then
       self.scene:addSprite(layer.sprite)
     end
@@ -112,10 +125,10 @@ function LayerManager:ensureSprite(name)
   sprite:setTilemap(layer.tilemap)
   if (layer.anchor or self._opts.anchor) == "topLeft" then sprite:setCenter(0, 0) else sprite:setCenter(0.5, 0.5) end
   sprite:setZIndex(layer.zIndex or 0)
+  -- Keep classification current before addSprite's same-owner fast path.
+  _setScenePauseClassification(sprite, false, hasParallax, false)
 
-  local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
-  local useParallax = (not layer.layerOptions) or (layer.layerOptions.parallax ~= false)
-  if useParallax and (parallaxX ~= 1 or parallaxY ~= 1) then
+  if hasParallax then
     sprite:setIgnoresDrawOffset(true)
     sprite:setUpdatesEnabled(true)
     sprite.update = _createParallaxUpdate(
@@ -411,9 +424,11 @@ end
 
 --[[
 
+LayerManager owns tile layer sprites for RoxyTilemap. Most callers use it through
+RoxyTilemap, but direct usage is useful for advanced tilemap tooling.
+
 local Graphics <const> = playdate.graphics
 
--- Advanced/direct usage; RoxyTilemap usually creates the manager for you.
 local scene = RoxyScene()
 local layers = {}
 local sprites = {}
@@ -424,6 +439,7 @@ local manager = LayerManager({
   anchor = "topLeft",
 }, scene, layers, sprites)
 
+-- Register a Layer
 local imageTable = Graphics.imagetable.new("images/terrain")
 local tilemap = Graphics.tilemap.new()
 tilemap:setImageTable(imageTable)
@@ -443,23 +459,33 @@ manager:addLayer({
   zIndex = 0,
   visible = true,
   anchor = "topLeft",
+  parallaxx = 0.5,
+  parallaxy = 1,
+  parallaxoriginx = 200,
+  parallaxoriginy = 120,
 })
 
-local groundSprite = manager:ensureSprite("Ground")
+-- Sprite Lifecycle and Visibility
+manager:ensureSpritesForAll()
+local groundSprite = manager:getSprite("Ground")
+local groundTilemap = manager:getTilemap("Ground")
+local allLayerSprites = manager:getAllSprites()
+
 manager:hide("Ground")
 manager:show("Ground")
 manager:setOrigin("Ground", 32, 16)
+manager:setOriginForAll(0, 0)
 
--- Runtime image table swap with a compact remap table
+-- Runtime Image Table Swap
 local winterTiles = Graphics.imagetable.new("images/terrain-winter")
 manager:setImageTable("Ground", winterTiles, {
   [1] = 2,
   [2] = 1,
 })
 
--- Detach for pooled scene reuse, or destroy during tilemap teardown.
+-- Cleanup
 manager:detach()
 manager:remove("Ground")
 manager:destroy()
 
-]]
+--]]

--- a/core/tilemaps/ObjectLayerProcessor.lua
+++ b/core/tilemaps/ObjectLayerProcessor.lua
@@ -10,6 +10,7 @@ local Sprite    <const> = Graphics.sprite
 
 local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
+local Scene       <const> = r.Scene
 
 local tableCreate <const> = table.create
 local tableInsert <const> = table.insert
@@ -140,9 +141,11 @@ function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fa
     end
   end
 
-  sprite._roxyScenePausePlayback = false
-  sprite._roxyScenePauseUpdates = hasParallax
-  sprite._roxyScenePauseCollisions = layerOptions.collidable == true
+  Scene.setSpritePauseClassification(sprite, {
+    playback = false,
+    updates = hasParallax,
+    collisions = layerOptions.collidable == true,
+  })
 
   -- Track retained image path for cleanup
   sprite._retainedImagePath = didRetain and imagePath or nil

--- a/core/tilemaps/ObjectLayerProcessor.lua
+++ b/core/tilemaps/ObjectLayerProcessor.lua
@@ -33,6 +33,8 @@ local OBJECT_TAG <const> = 2
 
 local COLOR_BLACK <const> = Graphics.kColorBlack
 
+local EMPTY_TABLE <const> = {}
+
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
@@ -52,6 +54,8 @@ end
 
 -- ! Create Default Object Sprite
 function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fallbackParallaxX, fallbackParallaxY)
+  layerOptions = layerOptions or EMPTY_TABLE
+
   -- Initialize parallax values and object properties
   local parallaxX, parallaxY = 1, 1
   local parallaxOriginX, parallaxOriginY = 0, 0
@@ -135,6 +139,10 @@ function ObjectLayerProcessor.createDefaultObjectSprite(object, layerOptions, fa
     --#DEBUG END
     end
   end
+
+  sprite._roxyScenePausePlayback = false
+  sprite._roxyScenePauseUpdates = hasParallax
+  sprite._roxyScenePauseCollisions = layerOptions.collidable == true
 
   -- Track retained image path for cleanup
   sprite._retainedImagePath = didRetain and imagePath or nil

--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -170,14 +170,22 @@ end
 function RoxyIsoTilemap:_createNativeRenderer(layerData)
   if not layerData or not layerData.imageTable or not newTileRenderer_C then return end
 
-  sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
-
   --#DEBUG START
   if (layerData.tileWidth or 0) <= 0 or (layerData.tileHeight or 0) <= 0
      or (layerData.halfWidth or 0) <= 0 or (layerData.halfHeight or 0) <= 0 then
     Log.error("[RoxyIsoTilemap] Invalid tile metrics; width/height/halves must be > 0")
   end
   --#DEBUG END
+
+  local halfWidth = layerData.halfWidth or 0
+  local halfHeight = layerData.halfHeight or 0
+  if halfWidth ~= floor(halfWidth) or halfHeight ~= floor(halfHeight) then
+    layerData._nativeRenderer = nil
+    Log.warn("[RoxyIsoTilemap] Fractional half-tile metrics; using Lua renderer fallback") --#DEBUG
+    return
+  end
+
+  sanitizeTilesInPlace(layerData.tilesFlat, layerData.imageCount)
 
   layerData._nativeRenderer = newTileRenderer_C(
     1,                        -- Isometric
@@ -1157,10 +1165,6 @@ local row = map:getRowFromScreen(200, 120, "blocks")
 map:drawLayerRows("blocks", 1, row, 1, 12)
 
 local previewImage, offsetX, offsetY = map:getLayerImage("ground", {
-  tileX = 1,
-  tileY = 1,
-  tileWidth = 6,
-  tileHeight = 6,
   compositeLayers = { "blocks" },
 })
 

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -74,6 +74,73 @@ local function _drawLayerRegionToBuffer(layerData, destinationX, destinationY, s
   layerData.tilemap:drawIgnoringOffset(destinationX, destinationY, sourceX, sourceY, width, height)
 end
 
+-- ! Helper: Resolve Render Image Rect
+local function _resolveRenderImageRect(primaryLayer, opts)
+  local defaultWidth = primaryLayer.mapPixelWidth or 0
+  local defaultHeight = primaryLayer.mapPixelHeight or 0
+
+  local tileWidth = primaryLayer.tileWidth or 0
+  local tileHeight = primaryLayer.tileHeight or 0
+
+  local sourceX = 0
+  local sourceY = 0
+  local pixelWidth = defaultWidth
+  local pixelHeight = defaultHeight
+
+  if opts then
+    if opts.tileX or opts.tileY then
+      local tileX = tonumber(opts.tileX)
+      local tileY = tonumber(opts.tileY)
+
+      if tileX then sourceX = (tileX - 1) * tileWidth end
+      if tileY then sourceY = (tileY - 1) * tileHeight end
+    end
+
+    if opts.tileWidth or opts.tileHeight then
+      local widthTiles = tonumber(opts.tileWidth)
+      local heightTiles = tonumber(opts.tileHeight)
+
+      if widthTiles then pixelWidth = widthTiles * tileWidth end
+      if heightTiles then pixelHeight = heightTiles * tileHeight end
+    end
+
+    if opts.sourceX ~= nil then sourceX = tonumber(opts.sourceX) or sourceX end
+    if opts.sourceY ~= nil then sourceY = tonumber(opts.sourceY) or sourceY end
+
+    if opts.width ~= nil then pixelWidth = tonumber(opts.width) or pixelWidth end
+    if opts.height ~= nil then pixelHeight = tonumber(opts.height) or pixelHeight end
+
+    if opts.pixelWidth ~= nil then pixelWidth = tonumber(opts.pixelWidth) or pixelWidth end
+    if opts.pixelHeight ~= nil then pixelHeight = tonumber(opts.pixelHeight) or pixelHeight end
+  end
+
+  sourceX = floor(sourceX or 0)
+  sourceY = floor(sourceY or 0)
+  pixelWidth = max(0, floor(pixelWidth or 0))
+  pixelHeight = max(0, floor(pixelHeight or 0))
+
+  if pixelWidth <= 0 or pixelHeight <= 0 then return nil end
+
+  if sourceX < 0 then sourceX = 0 end
+  if sourceY < 0 then sourceY = 0 end
+
+  return sourceX, sourceY, pixelWidth, pixelHeight
+end
+
+-- ! Helper: Layer Image Anchor Offset
+local function _layerImageAnchorOffset(self, primaryLayer, sourceX, sourceY, pixelWidth, pixelHeight)
+  local originX = primaryLayer.originX or 0
+  local originY = primaryLayer.originY or 0
+  local anchor = (primaryLayer.anchor or (self._opts and self._opts.anchor)) or "center"
+
+  if anchor == "topLeft" then
+    return originX - sourceX, originY - sourceY
+  end
+
+  return originX - (sourceX + pixelWidth * 0.5),
+         originY - (sourceY + pixelHeight * 0.5)
+end
+
 --------------------------------------------------------------------------------
 -- ! Class Definition and Initialization
 --------------------------------------------------------------------------------
@@ -290,6 +357,24 @@ function RoxyOrthoTilemap:_renderLayerToImage(layerName, opts)
   local primaryLayer = self:_getValidLayer(layerName)
   if not primaryLayer then return nil end
 
+  local sourceX, sourceY, pixelWidth, pixelHeight = _resolveRenderImageRect(primaryLayer, opts)
+  if sourceX == nil then return nil end
+
+  local compositeLayers = opts and opts.compositeLayers
+  if type(compositeLayers) ~= "table" or #compositeLayers == 0 then
+    local image = newImage(pixelWidth, pixelHeight)
+    if not image then return nil end
+
+    pushContext(image)
+      clear(COLOR_CLEAR)
+      _drawLayerRegionToBuffer(primaryLayer, 0, 0, sourceX, sourceY, pixelWidth, pixelHeight)
+    popContext()
+
+    local offsetX, offsetY =
+      _layerImageAnchorOffset(self, primaryLayer, sourceX, sourceY, pixelWidth, pixelHeight)
+    return image, offsetX, offsetY
+  end
+
   local renderQueue = {}
   local order = 0
 
@@ -314,12 +399,10 @@ function RoxyOrthoTilemap:_renderLayerToImage(layerName, opts)
 
   enqueueLayer(layerName, primaryLayer)
 
-  if opts and opts.compositeLayers then
-    for index = 1, #opts.compositeLayers do
-      local compositeName = opts.compositeLayers[index]
-      if type(compositeName) == "string" then
-        enqueueLayer(compositeName, self:_getValidLayer(compositeName))
-      end
+  for index = 1, #compositeLayers do
+    local compositeName = compositeLayers[index]
+    if type(compositeName) == "string" then
+      enqueueLayer(compositeName, self:_getValidLayer(compositeName))
     end
   end
 
@@ -329,54 +412,6 @@ function RoxyOrthoTilemap:_renderLayerToImage(layerName, opts)
     if a.z == b.z then return a.order < b.order end
     return a.z < b.z
   end)
-
-  local defaultWidth = primaryLayer.mapPixelWidth or 0
-  local defaultHeight = primaryLayer.mapPixelHeight or 0
-
-  local tileWidth = primaryLayer.tileWidth or 0
-  local tileHeight = primaryLayer.tileHeight or 0
-
-  local sourceX = 0
-  local sourceY = 0
-  local pixelWidth = defaultWidth
-  local pixelHeight = defaultHeight
-
-  if opts then
-    if opts.tileX or opts.tileY then
-      local tileX = tonumber(opts.tileX)
-      local tileY = tonumber(opts.tileY)
-
-      if tileX then sourceX = (tileX - 1) * tileWidth end
-      if tileY then sourceY = (tileY - 1) * tileHeight end
-    end
-
-    if opts.tileWidth or opts.tileHeight then
-      local widthTiles = tonumber(opts.tileWidth)
-      local heightTiles = tonumber(opts.tileHeight)
-
-      if widthTiles then pixelWidth = widthTiles * tileWidth end
-      if heightTiles then pixelHeight = heightTiles * tileHeight end
-    end
-
-    if opts.sourceX ~= nil then sourceX = tonumber(opts.sourceX) or sourceX end
-    if opts.sourceY ~= nil then sourceY = tonumber(opts.sourceY) or sourceY end
-
-    if opts.width ~= nil then pixelWidth = tonumber(opts.width) or pixelWidth end
-    if opts.height ~= nil then pixelHeight = tonumber(opts.height) or pixelHeight end
-
-    if opts.pixelWidth ~= nil then pixelWidth = tonumber(opts.pixelWidth) or pixelWidth end
-    if opts.pixelHeight ~= nil then pixelHeight = tonumber(opts.pixelHeight) or pixelHeight end
-  end
-
-  sourceX = floor(sourceX or 0)
-  sourceY = floor(sourceY or 0)
-  pixelWidth = max(0, floor(pixelWidth or 0))
-  pixelHeight = max(0, floor(pixelHeight or 0))
-
-  if pixelWidth <= 0 or pixelHeight <= 0 then return nil end
-
-  if sourceX < 0 then sourceX = 0 end
-  if sourceY < 0 then sourceY = 0 end
 
   local image = newImage(pixelWidth, pixelHeight)
   if not image then return nil end
@@ -389,19 +424,8 @@ function RoxyOrthoTilemap:_renderLayerToImage(layerName, opts)
     end
   popContext()
 
-  local originX = primaryLayer.originX or 0
-  local originY = primaryLayer.originY or 0
-  local anchor = (primaryLayer.anchor or (self._opts and self._opts.anchor)) or "center"
-
-  local offsetX, offsetY
-  if anchor == "topLeft" then
-    offsetX = originX - sourceX
-    offsetY = originY - sourceY
-  else
-    offsetX = originX - (sourceX + pixelWidth * 0.5)
-    offsetY = originY - (sourceY + pixelHeight * 0.5)
-  end
-
+  local offsetX, offsetY =
+    _layerImageAnchorOffset(self, primaryLayer, sourceX, sourceY, pixelWidth, pixelHeight)
   return image, offsetX, offsetY
 end
 

--- a/core/tilemaps/RoxyOrthoTilemap.lua
+++ b/core/tilemaps/RoxyOrthoTilemap.lua
@@ -11,6 +11,7 @@ local Cache   <const> = r.Cache
 local min   <const> = math.min
 local max   <const> = math.max
 local floor <const> = math.floor
+local ceil  <const> = math.ceil
 local round <const> = r.Math.round
 
 local tableInsert <const> = table.insert
@@ -40,6 +41,7 @@ local findFirstAvailableLayer <const> = TilemapHelpers.findFirstAvailableLayer
 local DEFAULT_CHUNK_SIZE    <const> = 320
 local DEFAULT_CHUNK_CACHE   <const> = 200
 local DEFAULT_CHUNK_OVERLAP <const> = 32
+local ROUNDING_GUARD_TILES  <const> = 1
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
 local DISPLAY_HEIGHT  <const> = r.Graphics.displayHeight
@@ -146,6 +148,55 @@ end
 --------------------------------------------------------------------------------
 
 class("RoxyOrthoTilemap").extends(RoxyTilemap)
+
+-- ! Helper: Orthographic Visible Tile Bounds Fast
+-- Direct orthographic bounds path for draw visibility; avoids inverse projection.
+function RoxyOrthoTilemap:_getVisibleTileBoundsFast(layerData, cameraX, cameraY)
+  if not layerData then return 1, 1, 0, 0 end
+
+  local tileWidth, tileHeight = layerData.tileWidth, layerData.tileHeight
+  local mapWidth, mapHeight = layerData.mapWidth, layerData.mapHeight
+  if not tileWidth or tileWidth <= 0
+     or not tileHeight or tileHeight <= 0
+     or not mapWidth or mapWidth <= 0
+     or not mapHeight or mapHeight <= 0
+  then
+    return 1, 1, 0, 0
+  end
+
+  if cameraX == nil or cameraY == nil then
+    cameraX, cameraY = getCameraPosition()
+  end
+
+  local originX, originY = layerData.originX or 0, layerData.originY or 0
+  local parallaxX, parallaxY = layerData.parallaxx or 1, layerData.parallaxy or 1
+  local parallaxOriginX = layerData.parallaxoriginx or 0
+  local parallaxOriginY = layerData.parallaxoriginy or 0
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+
+  local screenX = round(originX + pivotAdjustX - cameraX * parallaxX)
+  local screenY = round(originY + pivotAdjustY - cameraY * parallaxY)
+  local sourceX, sourceY = -screenX, -screenY
+
+  local tileMargin = 0
+  if layerData.imageTable then
+    local maxImageHeight = layerData.maxImageHeight or 0
+    local overdraw = max(0, maxImageHeight - tileHeight)
+    tileMargin = ceil(overdraw / max(1, tileHeight * 0.5)) + 1
+  end
+
+  local paddedTileMargin = tileMargin + ROUNDING_GUARD_TILES
+  local padX = paddedTileMargin * tileWidth
+  local padY = paddedTileMargin * tileHeight
+
+  local minTileX = max(1, floor((sourceX - padX) / tileWidth) + 1)
+  local maxTileX = min(mapWidth, ceil((sourceX + DISPLAY_WIDTH + padX) / tileWidth) + 1)
+  local minTileY = max(1, floor((sourceY - padY) / tileHeight) + 1)
+  local maxTileY = min(mapHeight, ceil((sourceY + DISPLAY_HEIGHT + padY) / tileHeight) + 1)
+
+  return minTileX, minTileY, maxTileX, maxTileY
+end
 
 -- ! Initialize
 function RoxyOrthoTilemap:init(jsonPath, opts, scene)
@@ -487,8 +538,9 @@ function RoxyOrthoTilemap:draw(layerName)
     self:_drawStaticLayerChunked(layerName); return
   end
 
-  -- Use base helper so tall tiles near edges are included
-  local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+  local cameraX, cameraY = getCameraPosition()
+  local minTileX, minTileY, maxTileX, maxTileY =
+    self:_getVisibleTileBoundsFast(layerData, cameraX, cameraY)
   self:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
 end
 
@@ -496,6 +548,7 @@ end
 -- Draw all visible tile layers by zIndex (ascending)
 function RoxyOrthoTilemap:drawVisible()
   local ordered = self._orderedLayers
+  local cameraX, cameraY
   for i = 1, #ordered do
     local item = ordered[i]
     if item.type == "chunked" then
@@ -503,7 +556,11 @@ function RoxyOrthoTilemap:drawVisible()
     else
       local layerData = item.layer
       if layerData.tilemap and layerData.visible ~= false then
-        local minTileX, minTileY, maxTileX, maxTileY = self:getVisibleTileBounds(layerData)
+        if cameraX == nil then
+          cameraX, cameraY = getCameraPosition()
+        end
+        local minTileX, minTileY, maxTileX, maxTileY =
+          self:_getVisibleTileBoundsFast(layerData, cameraX, cameraY)
         self:_drawLayerRegionData(layerData, minTileX, maxTileX, minTileY, maxTileY)
       end
     end

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -112,6 +112,56 @@ local function _cameraPositionFor(self)
   return getCameraPosition()
 end
 
+-- ! Helper: Staggered Layer Image Bounds
+local function _staggeredLayerImageBounds(self, layer)
+  local mapWidth = layer.mapWidth or 0
+  local mapHeight = layer.mapHeight or 0
+  if mapWidth <= 0 or mapHeight <= 0 then return nil end
+
+  local tileWidth = layer.tileWidth or 0
+  local tileHeight = layer.tileHeight or 0
+  local halfWidth = layer.halfWidth or tileWidth * 0.5
+  local halfHeight = layer.halfHeight or tileHeight * 0.5
+
+  local maxImageHeight = layer.maxImageHeight or tileHeight
+  if maxImageHeight < tileHeight then
+    maxImageHeight = tileHeight
+  end
+
+  local originX = layer.originX or 0
+  local originY = layer.originY or 0
+
+  local minShift = math.huge
+  local maxShift = -math.huge
+  for row0 = 0, mapHeight - 1 do
+    local shift = _rowShiftX_for_row0(self, row0, halfWidth)
+    if shift < minShift then minShift = shift end
+    if shift > maxShift then maxShift = shift end
+  end
+  if minShift == math.huge then minShift = 0 end
+  if maxShift == -math.huge then maxShift = 0 end
+
+  local layerMinX = originX + minShift
+  local layerMaxX = originX + (mapWidth - 1) * tileWidth + maxShift + tileWidth
+
+  local layerMinY = originY + tileHeight - maxImageHeight
+  local layerMaxY = originY + (mapHeight - 1) * halfHeight + tileHeight
+
+  return layerMinX, layerMinY, layerMaxX, layerMaxY
+end
+
+-- ! Helper: Layer Image Anchor Offset
+local function _layerImageAnchorOffset(self, primaryLayer, minPixelX, minPixelY, pixelWidth, pixelHeight)
+  local anchor = (primaryLayer.anchor or (self._opts and self._opts.anchor)) or "center"
+  if anchor == "topLeft" then
+    return (primaryLayer.originX or 0) - minPixelX,
+      (primaryLayer.originY or 0) - minPixelY
+  end
+
+  return (primaryLayer.originX or 0) - (minPixelX + pixelWidth * 0.5),
+    (primaryLayer.originY or 0) - (minPixelY + pixelHeight * 0.5)
+end
+
 --------------------------------------------------------------------------------
 -- ! Class Definition / Initialize
 --------------------------------------------------------------------------------
@@ -387,6 +437,36 @@ function RoxyStagTilemap:_renderLayerToImage(layerName, opts)
   local primaryLayer = self:_getValidLayer(layerName)
   if not primaryLayer then return nil end
 
+  local compositeLayers = opts and opts.compositeLayers
+  if type(compositeLayers) ~= "table" or #compositeLayers == 0 then
+    -- Fast path avoids queue, entry, and sort overhead for common single-layer renders
+    local minScreenX, minScreenY, maxScreenX, maxScreenY = _staggeredLayerImageBounds(self, primaryLayer)
+    if not minScreenX then return nil end
+
+    local minPixelX = floor(minScreenX)
+    local minPixelY = floor(minScreenY)
+    local maxPixelX = ceil(maxScreenX)
+    local maxPixelY = ceil(maxScreenY)
+
+    local pixelWidth = max(0, maxPixelX - minPixelX)
+    local pixelHeight = max(0, maxPixelY - minPixelY)
+    if pixelWidth <= 0 or pixelHeight <= 0 then return nil end
+
+    local image = newImage(pixelWidth, pixelHeight)
+    if not image then return nil end
+
+    pushContext(image)
+      clear(COLOR_CLEAR)
+      local bufferOffsetX = (primaryLayer.originX or 0) - minPixelX
+      local bufferOffsetY = (primaryLayer.originY or 0) - minPixelY
+      self:_renderLayerToBuffer(primaryLayer, image, bufferOffsetX, bufferOffsetY, pixelWidth, pixelHeight)
+    popContext()
+
+    local anchorOffsetX, anchorOffsetY =
+      _layerImageAnchorOffset(self, primaryLayer, minPixelX, minPixelY, pixelWidth, pixelHeight)
+    return image, anchorOffsetX, anchorOffsetY
+  end
+
   local renderQueue = {}
   local seen = {}
   local order = 0
@@ -408,12 +488,10 @@ function RoxyStagTilemap:_renderLayerToImage(layerName, opts)
 
   enqueueLayer(layerName, primaryLayer)
 
-  if opts and opts.compositeLayers then
-    for index = 1, #opts.compositeLayers do
-      local compositeName = opts.compositeLayers[index]
-      if type(compositeName) == "string" then
-        enqueueLayer(compositeName, self:_getValidLayer(compositeName))
-      end
+  for index = 1, #compositeLayers do
+    local compositeName = compositeLayers[index]
+    if type(compositeName) == "string" then
+      enqueueLayer(compositeName, self:_getValidLayer(compositeName))
     end
   end
 
@@ -429,42 +507,8 @@ function RoxyStagTilemap:_renderLayerToImage(layerName, opts)
 
   for index = 1, #renderQueue do
     local layer = renderQueue[index].layer
-    local mapWidth = layer.mapWidth or 0
-    local mapHeight = layer.mapHeight or 0
-    if mapWidth > 0 and mapHeight > 0 then
-      local tileWidth = layer.tileWidth or 0
-      local tileHeight = layer.tileHeight or 0
-      local halfWidth = layer.halfWidth or tileWidth * 0.5
-      local halfHeight = layer.halfHeight or tileHeight * 0.5
-
-      local maxImageHeight = layer.maxImageHeight or tileHeight
-      if maxImageHeight < tileHeight then
-        maxImageHeight = tileHeight
-      end
-
-      local originX = layer.originX or 0
-      local originY = layer.originY or 0
-
-      local minShift = 0
-      local maxShift = 0
-      if mapHeight > 0 then
-        minShift = math.huge
-        maxShift = -math.huge
-        for row0 = 0, mapHeight - 1 do
-          local shift = _rowShiftX_for_row0(self, row0, halfWidth)
-          if shift < minShift then minShift = shift end
-          if shift > maxShift then maxShift = shift end
-        end
-        if minShift == math.huge then minShift = 0 end
-        if maxShift == -math.huge then maxShift = 0 end
-      end
-
-      local layerMinX = originX + minShift
-      local layerMaxX = originX + (mapWidth - 1) * tileWidth + maxShift + tileWidth
-
-      local layerMinY = originY + tileHeight - maxImageHeight
-      local layerMaxY = originY + (mapHeight - 1) * halfHeight + tileHeight
-
+    local layerMinX, layerMinY, layerMaxX, layerMaxY = _staggeredLayerImageBounds(self, layer)
+    if layerMinX then
       if layerMinX < minScreenX then minScreenX = layerMinX end
       if layerMaxX > maxScreenX then maxScreenX = layerMaxX end
       if layerMinY < minScreenY then minScreenY = layerMinY end
@@ -498,16 +542,8 @@ function RoxyStagTilemap:_renderLayerToImage(layerName, opts)
     end
   popContext()
 
-  local anchor = (primaryLayer.anchor or (self._opts and self._opts.anchor)) or "center"
-  local offsetX, offsetY
-  if anchor == "topLeft" then
-    offsetX = (primaryLayer.originX or 0) - minPixelX
-    offsetY = (primaryLayer.originY or 0) - minPixelY
-  else
-    offsetX = (primaryLayer.originX or 0) - (minPixelX + pixelWidth * 0.5)
-    offsetY = (primaryLayer.originY or 0) - (minPixelY + pixelHeight * 0.5)
-  end
-
+  local offsetX, offsetY =
+    _layerImageAnchorOffset(self, primaryLayer, minPixelX, minPixelY, pixelWidth, pixelHeight)
   return image, offsetX, offsetY
 end
 

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -102,6 +102,32 @@ local function _rowShiftX_for_row0(self, row0, halfWidth)
   return (direction == "right") and halfWidth or -halfWidth
 end
 
+-- ! Helper: Row Shift Range
+-- Min/max row shift, in pixels, for a staggered-y layer.
+local function _rowShiftRange(self, mapHeight, halfWidth)
+  if self.staggerAxis ~= "y" or mapHeight <= 0 then return 0, 0 end
+
+  local shiftedRowsExist
+  local unshiftedRowsExist
+  if self.staggerIndex == "odd" then
+    shiftedRowsExist = mapHeight >= 2
+    unshiftedRowsExist = true
+  elseif self.staggerIndex == "even" then
+    shiftedRowsExist = true
+    unshiftedRowsExist = mapHeight >= 2
+  else
+    return 0, 0
+  end
+
+  if not shiftedRowsExist then return 0, 0 end
+
+  local direction = self.staggerDirection or "right"
+  local shiftedValue = (direction == "right") and halfWidth or -halfWidth
+  if not unshiftedRowsExist then return shiftedValue, shiftedValue end
+
+  return min(0, shiftedValue), max(0, shiftedValue)
+end
+
 -- ! Helper: Camera Position
 -- Reuse drawVisible's camera stamp during a frame; otherwise query once.
 local function _cameraPositionFor(self)
@@ -131,15 +157,7 @@ local function _staggeredLayerImageBounds(self, layer)
   local originX = layer.originX or 0
   local originY = layer.originY or 0
 
-  local minShift = math.huge
-  local maxShift = -math.huge
-  for row0 = 0, mapHeight - 1 do
-    local shift = _rowShiftX_for_row0(self, row0, halfWidth)
-    if shift < minShift then minShift = shift end
-    if shift > maxShift then maxShift = shift end
-  end
-  if minShift == math.huge then minShift = 0 end
-  if maxShift == -math.huge then maxShift = 0 end
+  local minShift, maxShift = _rowShiftRange(self, mapHeight, halfWidth)
 
   local layerMinX = originX + minShift
   local layerMaxX = originX + (mapWidth - 1) * tileWidth + maxShift + tileWidth

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -12,6 +12,7 @@ local r           <const> = roxy
 local AssetStore  <const> = r.AssetStore
 local Camera      <const> = r.Camera
 local Cache       <const> = r.Cache
+local Scene       <const> = r.Scene
 
 local min   <const> = math.min
 local max   <const> = math.max
@@ -636,9 +637,11 @@ function RoxyTilemap:_configureCollisionSprites(sprites, config)
   if not sprites or not config then return end
 
   for _, sprite in ipairs(sprites) do
-    sprite._roxyScenePausePlayback = false
-    sprite._roxyScenePauseUpdates = false
-    sprite._roxyScenePauseCollisions = true
+    Scene.setSpritePauseClassification(sprite, {
+      playback = false,
+      updates = false,
+      collisions = true,
+    })
 
     sprite:setTag(WALL_TAG)
     sprite:setCollideRect(0, 0, sprite:getSize())

--- a/core/tilemaps/RoxyTilemap.lua
+++ b/core/tilemaps/RoxyTilemap.lua
@@ -636,6 +636,10 @@ function RoxyTilemap:_configureCollisionSprites(sprites, config)
   if not sprites or not config then return end
 
   for _, sprite in ipairs(sprites) do
+    sprite._roxyScenePausePlayback = false
+    sprite._roxyScenePauseUpdates = false
+    sprite._roxyScenePauseCollisions = true
+
     sprite:setTag(WALL_TAG)
     sprite:setCollideRect(0, 0, sprite:getSize())
 

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -139,6 +139,11 @@ static void roxy_tileRenderer_free(RoxyTileRendererC* tileRenderer)
         tileRenderer->imageTableUserData = NULL;
     }
 
+    if (tileRenderer->images) {
+        pd_free(tileRenderer->images);
+        tileRenderer->images = NULL;
+    }
+
     if (tileRenderer->offsetX) {
         pd_free(tileRenderer->offsetX);
         tileRenderer->offsetX = NULL;
@@ -213,6 +218,13 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         return 0;
     }
     tileRenderer->imageTableUserData = pd->lua->retainObject(userDataObject);
+    if (!tileRenderer->imageTableUserData) {
+        pd->system->logToConsole("RoxyTileRendererC.new: failed to retain imagetable userdata");
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
+
     tileRenderer->imageCount = pd->lua->getArgInt(12);
     if (tileRenderer->imageCount < 0) tileRenderer->imageCount = 0; // Sanitize
 
@@ -225,6 +237,15 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         pd_free(tileRenderer);
         return 0;
     }
+    if (countWithZero > SIZE_MAX / sizeof(*tileRenderer->images)) {
+        pd->system->logToConsole("RoxyTileRendererC.new: image pointer array size overflow");
+        roxy_tileRenderer_free(tileRenderer);
+        pd_free(tileRenderer);
+        return 0;
+    }
+
+    tileRenderer->images = (LCDBitmap**)pd_alloc(countWithZero * sizeof(*tileRenderer->images));
+    if (tileRenderer->images) ROXY_LABEL(tileRenderer->images, "RoxyTileRendererC.images");
 
     tileRenderer->offsetX = (int16_t*)pd_alloc(countWithZero * sizeof(int16_t));
     if (tileRenderer->offsetX) ROXY_LABEL(tileRenderer->offsetX, "RoxyTileRendererC.offsetX");
@@ -232,12 +253,13 @@ static int roxy_tileRenderer_newobject(lua_State* L)
     tileRenderer->offsetY = (int16_t*)pd_alloc(countWithZero * sizeof(int16_t));
     if (tileRenderer->offsetY) ROXY_LABEL(tileRenderer->offsetY, "RoxyTileRendererC.offsetY");
 
-    if (!tileRenderer->offsetX || !tileRenderer->offsetY) {
+    if (!tileRenderer->images || !tileRenderer->offsetX || !tileRenderer->offsetY) {
         roxy_tileRenderer_free(tileRenderer);
         pd_free(tileRenderer);
         return 0;
     }
 
+    tileRenderer->images[0] = NULL;
     tileRenderer->offsetX[0] = 0;
     tileRenderer->offsetY[0] = 0;
 
@@ -245,6 +267,7 @@ static int roxy_tileRenderer_newobject(lua_State* L)
         // Convert 1-based tile index to 0-based bitmap table index
         const int bitmapIndex = i - 1;
         LCDBitmap* cell = pd->graphics->getTableBitmap(tileRenderer->imageTable, bitmapIndex);
+        tileRenderer->images[i] = cell;
         if (!cell) {
             tileRenderer->offsetX[i] = 0;
             tileRenderer->offsetY[i] = 0;
@@ -474,11 +497,9 @@ static int roxy_tileRenderer_setTileAt(lua_State* L)
 
 // ! Draw Cell Unchecked
 // Core draw for a range-checked tile using cached renderer fields.
-static inline void drawCellUnchecked(LCDBitmapTable* imageTable, const int16_t* offsetX, const int16_t* offsetY, int tileIndex, int sx, int sy)
+static inline void drawCellUnchecked(LCDBitmap* const* images, const int16_t* offsetX, const int16_t* offsetY, int tileIndex, int sx, int sy)
 {
-    // Convert 1-based tile index to 0-based bitmap table index
-    const int bitmapIndex = tileIndex - 1;
-    LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
+    LCDBitmap* cell = images[tileIndex];
     if (!cell) return;
 
     const int dx = sx + offsetX[tileIndex];
@@ -506,10 +527,10 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
     const int halfTileHeight = tileRenderer->halfTileHeight;
     const int imageCount = tileRenderer->imageCount;
     const int32_t* tiles = tileRenderer->tiles;
+    LCDBitmap* const* images = tileRenderer->images;
     const int16_t* offsetX = tileRenderer->offsetX;
     const int16_t* offsetY = tileRenderer->offsetY;
-    LCDBitmapTable* imageTable = tileRenderer->imageTable;
-    if (!imageTable || !offsetX || !offsetY) return 0;
+    if (!images || !offsetX || !offsetY) return 0;
 
     int minRow = pd->lua->getArgInt(2);
     int maxRow = pd->lua->getArgInt(3);
@@ -552,7 +573,7 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
             for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
                 const int currentTileIndex = tiles[tileIndex];
                 if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
-                    drawCellUnchecked(imageTable, offsetX, offsetY, currentTileIndex, screenX, baseY);
+                    drawCellUnchecked(images, offsetX, offsetY, currentTileIndex, screenX, baseY);
                 }
                 screenX += tileWidth;
             }
@@ -572,7 +593,7 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
 
                 const int currentTileIndex = tiles[tileIndex];
                 if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
-                    drawCellUnchecked(imageTable, offsetX, offsetY, currentTileIndex, isoX, isoY);
+                    drawCellUnchecked(images, offsetX, offsetY, currentTileIndex, isoX, isoY);
                 }
             }
         }
@@ -599,10 +620,10 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
     const int maxImageHeight = tileRenderer->maxImageHeight;
     const int imageCount = tileRenderer->imageCount;
     const int32_t* tiles = tileRenderer->tiles;
+    LCDBitmap* const* images = tileRenderer->images;
     const int16_t* offsetXTable = tileRenderer->offsetX;
     const int16_t* offsetYTable = tileRenderer->offsetY;
-    LCDBitmapTable* imageTable = tileRenderer->imageTable;
-    if (!imageTable || !offsetXTable || !offsetYTable) return 0;
+    if (!images || !offsetXTable || !offsetYTable) return 0;
 
     LCDBitmap* targetBitmap = pd->lua->getBitmap(2); // May be NULL
     const int offsetX = pd->lua->getArgInt(3);
@@ -658,9 +679,7 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
                         const int dx = drawX + offsetXTable[currentTileIndex];
                         const int dy = baseY + offsetYTable[currentTileIndex];
                         if (dx < bufferWidth && dy < bufferHeight && dx > -tileWidth && dy > -cullHeight) {
-                            // Convert 1-based tile index to 0-based bitmap table index
-                            const int bitmapIndex = currentTileIndex - 1;
-                            LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
+                            LCDBitmap* cell = images[currentTileIndex];
                             if (cell) pd->graphics->drawBitmap(cell, dx, dy, kBitmapUnflipped);
                         }
                     }
@@ -717,9 +736,7 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
                     const int drawX = screenX + offsetXTable[currentTileIndex];
                     const int drawY = screenY + offsetYTable[currentTileIndex];
                     if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileWidth && drawY > -cullHeight) {
-                        // Convert 1-based tile index to 0-based bitmap table index
-                        const int bitmapIndex = currentTileIndex - 1;
-                        LCDBitmap* cell = pd->graphics->getTableBitmap(imageTable, bitmapIndex);
+                        LCDBitmap* cell = images[currentTileIndex];
                         if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
                     }
                 }

--- a/core/tilemaps/roxy_tileRenderer.c
+++ b/core/tilemaps/roxy_tileRenderer.c
@@ -120,6 +120,19 @@ static inline int rowShiftX_for_row0(const RoxyTileRendererC* tileRenderer, int 
     return tileRenderer->staggerDirectionRight ? tileRenderer->halfTileWidth : -tileRenderer->halfTileWidth;
 }
 
+static inline int isoRowNeedsFullProjection(float start, int step, int count)
+{
+    // Integer-step incremental rounding only differs when a negative .5 row
+    // crosses into positive coordinates, because roundf rounds halves away from zero.
+    if (count <= 1 || step <= 0) return 0;
+
+    const float end = start + (float)step * (float)(count - 1);
+    if (start >= 0.f || end <= 0.f) return 0;
+
+    const float fraction = start - floorf(start);
+    return fabsf(fraction - 0.5f) <= 0.000001f;
+}
+
 // -----------------------------------------------------------------------------
 // Lifetime
 // -----------------------------------------------------------------------------
@@ -580,21 +593,43 @@ static int roxy_tileRenderer_drawRows(lua_State* L)
         }
     } else {
         // Isometric
+        const int minColumnZeroBased = minColumn - 1;
+        const int columnCount = maxColumn - minColumn + 1;
         for (int tileY = minRow; tileY <= maxRow; ++tileY) {
             const int rowZeroBased = tileY - 1;
-            const int rowIndexBase = rowZeroBased * mapWidth + (minColumn - 1);
-            for (int tileX = minColumn, tileIndex = rowIndexBase; tileX <= maxColumn; ++tileX, ++tileIndex) {
-                const int columnZeroBased = tileX - 1;
-                const float worldX = (float)columnZeroBased;
-                const float worldY = (float)rowZeroBased;
+            const int rowBaseIndex = rowZeroBased * mapWidth + minColumnZeroBased;
+            const float worldX = (float)minColumnZeroBased;
+            const float worldY = (float)rowZeroBased;
 
-                const int isoX = roxy_math_roundInt(originX + (worldX - worldY) * halfTileWidth + pivotAdjustX - cameraX * parallaxX);
-                const int isoY = roxy_math_roundInt(originY + (worldX + worldY) * halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+            const float rowStartX = originX + (worldX - worldY) * halfTileWidth + pivotAdjustX - cameraX * parallaxX;
+            const float rowStartY = originY + (worldX + worldY) * halfTileHeight + pivotAdjustY - cameraY * parallaxY;
 
+            if (isoRowNeedsFullProjection(rowStartX, halfTileWidth, columnCount) ||
+                isoRowNeedsFullProjection(rowStartY, halfTileHeight, columnCount)) {
+                for (int tileX = minColumn, tileIndex = rowBaseIndex; tileX <= maxColumn; ++tileX, ++tileIndex) {
+                    const int columnZeroBased = tileX - 1;
+                    const float currentWorldX = (float)columnZeroBased;
+                    const int isoX = roxy_math_roundInt(originX + (currentWorldX - worldY) * halfTileWidth + pivotAdjustX - cameraX * parallaxX);
+                    const int isoY = roxy_math_roundInt(originY + (currentWorldX + worldY) * halfTileHeight + pivotAdjustY - cameraY * parallaxY);
+
+                    const int currentTileIndex = tiles[tileIndex];
+                    if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
+                        drawCellUnchecked(images, offsetX, offsetY, currentTileIndex, isoX, isoY);
+                    }
+                }
+                continue;
+            }
+
+            int screenX = roxy_math_roundInt(rowStartX);
+            int screenY = roxy_math_roundInt(rowStartY);
+
+            for (int tileX = minColumn, tileIndex = rowBaseIndex; tileX <= maxColumn; ++tileX, ++tileIndex) {
                 const int currentTileIndex = tiles[tileIndex];
                 if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
-                    drawCellUnchecked(images, offsetX, offsetY, currentTileIndex, isoX, isoY);
+                    drawCellUnchecked(images, offsetX, offsetY, currentTileIndex, screenX, screenY);
                 }
+                screenX += halfTileWidth;
+                screenY += halfTileHeight;
             }
         }
     }
@@ -724,15 +759,17 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
         const int maxRowZeroBased    = roxy_math_clampi((int)ceilf(maxRow)     + 1, 0, mapHeight - 1);
 
         for (int rowZeroBased = minRowZeroBased; rowZeroBased <= maxRowZeroBased; ++rowZeroBased) {
-            int tileIndex = rowZeroBased * mapWidth + minColumnZeroBased;
+            const int rowBaseIndex = rowZeroBased * mapWidth + minColumnZeroBased;
+            const float worldX = (float)minColumnZeroBased;
+            const float worldY = (float)rowZeroBased;
+
+            int screenX = roxy_math_roundInt((worldX - worldY) * halfTileWidth  + offsetX);
+            int screenY = roxy_math_roundInt((worldX + worldY) * halfTileHeight + offsetY);
+
+            int tileIndex = rowBaseIndex;
             for (int columnZeroBased = minColumnZeroBased; columnZeroBased <= maxColumnZeroBased; ++columnZeroBased, ++tileIndex) {
                 const int currentTileIndex = tiles[tileIndex];
                 if (currentTileIndex > 0 && currentTileIndex <= imageCount) {
-                    const float worldX = (float)columnZeroBased;
-                    const float worldY = (float)rowZeroBased;
-                    const int screenX = roxy_math_roundInt((worldX - worldY) * halfTileWidth  + offsetX);
-                    const int screenY = roxy_math_roundInt((worldX + worldY) * halfTileHeight + offsetY);
-
                     const int drawX = screenX + offsetXTable[currentTileIndex];
                     const int drawY = screenY + offsetYTable[currentTileIndex];
                     if (drawX < bufferWidth && drawY < bufferHeight && drawX > -tileWidth && drawY > -cullHeight) {
@@ -740,6 +777,8 @@ static int roxy_tileRenderer_renderToBuffer(lua_State* L)
                         if (cell) pd->graphics->drawBitmap(cell, drawX, drawY, kBitmapUnflipped);
                     }
                 }
+                screenX += halfTileWidth;
+                screenY += halfTileHeight;
             }
         }
     }

--- a/core/tilemaps/roxy_tileRenderer.h
+++ b/core/tilemaps/roxy_tileRenderer.h
@@ -21,7 +21,8 @@ typedef struct {
     LuaUDObject*    imageTableUserData; // Retained UD to keep it alive
     int             imageCount;
 
-    // Precomputed per-index offsets (1-based)
+    // Precomputed per-index images and offsets (1-based)
+    LCDBitmap** images; // [imageCount + 1], cells owned by imageTable
     int16_t* offsetX; // [imageCount + 1]
     int16_t* offsetY; // [imageCount + 1]
 

--- a/core/transitions/RoxyTransition.lua
+++ b/core/transitions/RoxyTransition.lua
@@ -6,29 +6,31 @@ local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
--- Graphics helpers
-local getDisplayImage <const> = Graphics.getDisplayImage
-
 -- Roxy Framework
 local r     <const> = roxy
 local Scene <const> = r.Scene
 
--- Sprite helpers used during scene switching
+-- Graphics
+local getDisplayImage       <const> = Graphics.getDisplayImage
 local redrawBackground      <const> = Sprite.redrawBackground
 local setBackgroundDrawing  <const> = Sprite.setBackgroundDrawingCallback
-
-local STACK_OP_REPLACE  <const> = 0
-local STACK_OP_PUSH     <const> = 1
-local STACK_OP_POP      <const> = 2
 
 -- Scene management
 local pushRaw     <const> = Scene.pushRaw
 local popRaw      <const> = Scene.popRaw
 local replaceRaw  <const> = Scene.replaceRaw
 
--- Bit-flags that track where we are in the life-cycle
+-- Stack operations
+local STACK_OP_REPLACE  <const> = 0
+local STACK_OP_PUSH     <const> = 1
+local STACK_OP_POP      <const> = 2
+
+-- State flags
 local STATE_MIDPOINT_REACHED  <const> = 1
 local STATE_HOLD_ELAPSED      <const> = 2
+
+-- Utility constants
+local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
 --------------------------------------------------------------------------------
 -- ! Class Definition & Initialization
@@ -36,6 +38,7 @@ local STATE_HOLD_ELAPSED      <const> = 2
 
 class("RoxyTransition").extends(Object)
 
+-- ! Initialize
 function RoxyTransition:init(opts)
   opts = opts or {}
 
@@ -44,7 +47,7 @@ function RoxyTransition:init(opts)
   self.type = opts.type or "Base"
   self.stackOp  = opts.stackOp or STACK_OP_REPLACE
 
-  -- bookkeeping
+  -- Bookkeeping
   self.state = 0
 
   -- Screenshot
@@ -53,14 +56,14 @@ function RoxyTransition:init(opts)
 
   -- Scene references
   self._newScene = nil
-  self._currentScene= nil
+  self._currentScene = nil
 end
 
 --------------------------------------------------------------------------------
 -- Transition Lifecycle
 --------------------------------------------------------------------------------
 
--- !  On Start
+-- ! On Start
 function RoxyTransition:_onStart()
   Log.debug("Transition '" .. self.name .. "' started") --#DEBUG
 
@@ -97,6 +100,9 @@ function RoxyTransition:_onMidpoint()
     end
     if newScene then
       newScene:resume()
+      local backgroundDrawFn = newScene.backgroundDrawFn or NO_OP_BG_DRAW
+      setBackgroundDrawing(backgroundDrawFn)
+      redrawBackground()
     end
   elseif stackOp == STACK_OP_PUSH then
     if oldScene then
@@ -104,6 +110,9 @@ function RoxyTransition:_onMidpoint()
     end
     if newScene then
       newScene:enter()
+      local backgroundDrawFn = newScene.backgroundDrawFn or NO_OP_BG_DRAW
+      setBackgroundDrawing(backgroundDrawFn)
+      redrawBackground()
     end
   else -- Replace
     if oldScene then
@@ -111,7 +120,7 @@ function RoxyTransition:_onMidpoint()
     end
     if newScene then
       newScene:enter()
-      local backgroundDrawFn = newScene.backgroundDrawFn or function() end
+      local backgroundDrawFn = newScene.backgroundDrawFn or NO_OP_BG_DRAW
       setBackgroundDrawing(backgroundDrawFn)
       redrawBackground()
     end
@@ -193,3 +202,69 @@ RoxyTransition.STATE_HOLD_ELAPSED     = STATE_HOLD_ELAPSED
 RoxyTransition.STACK_OP_REPLACE       = STACK_OP_REPLACE
 RoxyTransition.STACK_OP_PUSH          = STACK_OP_PUSH
 RoxyTransition.STACK_OP_POP           = STACK_OP_POP
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+RoxyTransition is the base lifecycle helper for transition effects.
+Subclasses call the lifecycle hooks when their visual timing reaches each phase.
+
+-- Custom Instant Transition
+class("FlashCut").extends(RoxyTransition)
+
+function FlashCut:init(opts)
+  opts = opts or {}
+  FlashCut.super.init(self, {
+    name = opts.name or "FlashCut",
+    type = "Custom",
+    stackOp = opts.stackOp or RoxyTransition.STACK_OP_REPLACE,
+    captureScreenshot = opts.captureScreenshot or false,
+  })
+end
+
+function FlashCut:execute(newScene, currentScene)
+  FlashCut.super.execute(self, newScene, currentScene)
+  self:_onStart()
+  self:_onMidpoint()
+  self:_onHoldElapsed()
+  self:_onComplete()
+end
+
+-- Timed Transition Skeleton
+class("HoldThenCut").extends(RoxyTransition)
+
+function HoldThenCut:init(opts)
+  opts = opts or {}
+  HoldThenCut.super.init(self, {
+    name = opts.name or "HoldThenCut",
+    type = "Custom",
+    stackOp = opts.stackOp or RoxyTransition.STACK_OP_REPLACE,
+    captureScreenshot = true,
+  })
+  self.duration = opts.duration or 0.4
+end
+
+function HoldThenCut:execute(newScene, currentScene)
+  HoldThenCut.super.execute(self, newScene, currentScene)
+  self:_onStart()
+
+  playdate.timer.performAfterDelay(self.duration * 500, function()
+    self:_onMidpoint()
+  end)
+  playdate.timer.performAfterDelay(self.duration * 1000, function()
+    self:_onHoldElapsed()
+    self:_onComplete()
+  end)
+end
+
+-- Register With Transition Module
+roxy.Transition.loadTransitions({
+  FlashCut = FlashCut,
+  HoldThenCut = HoldThenCut,
+})
+roxy.Transition.replaceScene(GameplayScene, "FlashCut")
+
+--]]


### PR DESCRIPTION
### Overview
This release improves runtime performance in tilemap rendering and scene pause/resume handling while tightening animation and sprite lifecycle behavior. It adds an explicit sprite pause classification API so static sprites and tilemap layers can skip unnecessary pause work, while dynamic sprites still restore their playback, update, collision, camera, and transition state correctly.

### Key Changes
- Added `Sprite:setPauseClassification(...)` and `roxy.Scene.setSpritePauseClassification(...)` for explicit scene pause behavior.
- Optimized scene sprite ownership tracking so add, remove, transfer, cleanup, pause, and resume paths avoid repeated scans.
- Improved orthographic, isometric, and staggered tilemap rendering with native bitmap-cell caching, faster visible bounds, incremental draw positions, and single-layer image fast paths.
- Fixed animation factories so each animation gets fresh playback state while cached image data remains shared.
- Hardened sprite, actor, scene, and pooled-resource cleanup paths.

### Challenges/Notes
- Scene pause internals now use the public `setPauseClassification(...)` API instead of raw sprite fields.
- `nil` pause classification keeps the default dynamic behavior.
- Use `{}` for static sprites that should skip scene pause/resume work, or pass `{ playback = true }`, `{ updates = true }`, and/or `{ collisions = true }` to opt into specific pause responsibilities.