### PR TITLE
[0.17.1] - Add Frame Rate Cadence and Stack Visibility

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -1,44 +1,48 @@
 -- core/animations/RoxyAnimation.lua
 
 --------------------------------------------------------------------------------
--- Standard Lua Function Aliases
+-- RoxyAnimation - Spritesheet Playback and Shared Image Data
+--------------------------------------------------------------------------------
+--
+-- Manages named frame ranges over a Playdate imagetable. Each instance owns
+-- private playback state while factory helpers can share retained image data
+-- to reduce memory pressure.
+--
+-- Key Features:
+--  - Path, imagetable, and pool-backed construction
+--  - Named clips with speed, loop, chaining, nextDelay, and callbacks
+--  - frameRate config with frameDuration compatibility
+--  - Optional display refresh-rate resolution for animation cadence
+--  - Retain/release lifecycle for shared image data
+--
+-- Timing Contract:
+--  - frameDuration is the runtime cadence in seconds per animation frame
+--  - frameRate is converted to frameDuration when config or setter code runs
+--  - frameDuration takes precedence when both frameDuration and frameRate are set
+--
 --------------------------------------------------------------------------------
 
--- Math functions
 local max   <const> = math.max
 local min   <const> = math.min
 local fmod  <const> = math.fmod
 
---------------------------------------------------------------------------------
--- Playdate SDK Aliases
---------------------------------------------------------------------------------
-
--- Core Playdate
 local pd        <const> = playdate
 local Object    <const> = pd.object
 local Graphics  <const> = pd.graphics
 
--- Timer functions
 local performAfterDelay <const> = pd.timer.performAfterDelay
-
--- Graphics functions
 local newImagetable <const> = Graphics.imagetable.new
 local drawImage     <const> = Graphics.imagetable.drawImage
 
---------------------------------------------------------------------------------
--- Roxy Framework Aliases
---------------------------------------------------------------------------------
+local r             <const> = roxy
+local Math          <const> = r.Math
+local Cache         <const> = r.Cache
+local AssetStore    <const> = r.AssetStore
+local Assets        <const> = r.Assets
+local Registry      <const> = r.AssetPoolRegistry
+local Animation     <const> = r.Animation
+local RoxyGraphics  <const> = r.Graphics
 
--- Roxy core
-local r           <const> = roxy
-local Math        <const> = r.Math
-local Cache       <const> = r.Cache
-local AssetStore  <const> = r.AssetStore
-local Assets      <const> = r.Assets
-local Registry    <const> = r.AssetPoolRegistry
-local Animation   <const> = r.Animation
-
--- Roxy framework function aliases
 local clamp           <const> = Math.clamp
 local truncateDecimal <const> = Math.truncateDecimal
 local getCachedAsset  <const> = Cache.getCachedAsset
@@ -48,32 +52,19 @@ local getAsset        <const> = Assets.getAsset
 local recycleAsset    <const> = Assets.recycleAsset
 local isFromPool      <const> = Registry.isFromPool
 local updateAnimation <const> = Animation.update -- C Function
+local getRefreshRate  <const> = RoxyGraphics.getRefreshRate
 
---------------------------------------------------------------------------------
--- Graphics Constants
---------------------------------------------------------------------------------
-
--- Image flip states
 local UNFLIPPED <const> = Graphics.kImageUnflipped
 
---------------------------------------------------------------------------------
--- Animation Constants
---------------------------------------------------------------------------------
-
-local FRAME_DURATION_DEFAULT        <const> = 0.033 -- About 30 FPS
+local FRAME_RATE_DEFAULT            <const> = 30
+local FRAME_DURATION_DEFAULT        <const> = 1 / FRAME_RATE_DEFAULT
 local MIN_FRAME_DURATION            <const> = 0.016 -- Guard against >60 FPS
 local MAX_FRAME_DURATION            <const> = 10    -- Sensible upper limit (sec)
 local MAX_ANIMATION_SPEED           <const> = 100   -- UI clamp for setSpeed
 local PATH_IMAGETABLE_CACHE_PREFIX  <const> = "RoxyAnimation.imagetable:"
 
 --------------------------------------------------------------------------------
--- Class Definition
---------------------------------------------------------------------------------
-
-class("RoxyAnimation").extends(Object)
-
---------------------------------------------------------------------------------
--- Static Factory Methods
+-- Private Helper Functions
 --------------------------------------------------------------------------------
 
 -- ! Helper: Is Image Table
@@ -107,7 +98,58 @@ local function _getPathCacheKey(path)
   return PATH_IMAGETABLE_CACHE_PREFIX .. path
 end
 
+-- ! Helper: Resolve Frame Rate
+local function _resolveFrameRate(frameRate, fallbackDuration, label, warnOnInvalid)
+  local frameRateType = type(frameRate)
+  if frameRateType == "number" and frameRate > 0 then
+    return 1 / frameRate
+  end
+
+  if frameRate == "display" then
+    local displayRate = getRefreshRate(true)
+    if type(displayRate) == "number" and displayRate > 0 then
+      return 1 / displayRate
+    end
+    if warnOnInvalid then
+      Log.warn("[" .. label .. "] frameRate=\"display\" could not resolve a positive display refresh rate, got " .. tostring(displayRate)) --#DEBUG
+    end
+    return fallbackDuration
+  end
+
+  if warnOnInvalid then
+    Log.warn("[" .. label .. "] frameRate must be a positive number or \"display\", got " .. frameRateType) --#DEBUG
+  end
+  return fallbackDuration
+end
+
+-- ! Helper: Resolve Frame Duration Config
+local function _resolveFrameDurationConfig(opts, fallbackDuration, label)
+  if opts.frameDuration ~= nil then
+    return opts.frameDuration
+  end
+  if opts.frameRate ~= nil then
+    return _resolveFrameRate(opts.frameRate, fallbackDuration, label, true)
+  end
+  return fallbackDuration
+end
+
+-- ! Helper: Resolve Frame Rate Setter
+local function _resolveFrameRateSetter(frameRate, label)
+  local duration = _resolveFrameRate(frameRate, nil, label, true)
+  return duration and clamp(duration, MIN_FRAME_DURATION, MAX_FRAME_DURATION) or nil
+end
+
+--------------------------------------------------------------------------------
+-- Class Definition
+--------------------------------------------------------------------------------
+
+class("RoxyAnimation").extends(Object)
+
 RoxyAnimation.PATH_IMAGETABLE_CACHE_PREFIX = PATH_IMAGETABLE_CACHE_PREFIX
+
+--------------------------------------------------------------------------------
+-- Static Factory Methods
+--------------------------------------------------------------------------------
 
 -- ! Get Path Cache Key
 -- Returns the AssetStore key used for a path-backed animation imagetable
@@ -125,7 +167,7 @@ end
 -- Creates fresh playback state over an existing imagetable
 function RoxyAnimation.fromImagetable(imagetable)
   if not _isImageTable(imagetable) then
-    error("[RoxyAnimation.fromImagetable] Expected imagetable") --#DEBUG
+    error("[RoxyAnimation.fromImagetable] Expected imagetable")
     return nil
   end
 
@@ -353,7 +395,7 @@ function RoxyAnimation:_buildAnimationConfig(opts)
     next                = opts.next,
     onCompleteCallback  = opts.onCompleteCallback or opts.onComplete,
     speed               = opts.speed or 1,
-    frameDuration       = opts.frameDuration or FRAME_DURATION_DEFAULT
+    frameDuration       = _resolveFrameDurationConfig(opts, FRAME_DURATION_DEFAULT, "RoxyAnimation:addAnimation")
   }
 
   -- Ensure start <= end (swap if needed)
@@ -474,6 +516,14 @@ function RoxyAnimation:getFrameDuration()
   return self.currentAnimation and self.currentAnimation.frameDuration or nil
 end
 
+-- ! Get Frame Rate
+-- Get current frame rate in frames per second
+function RoxyAnimation:getFrameRate()
+  local frameDuration = self:getFrameDuration()
+  if not frameDuration or frameDuration <= 0 then return nil end
+  return 1 / frameDuration
+end
+
 -- ! Set Frame Duration
 -- Set frame duration (affects all animations unless currentOnly=true)
 function RoxyAnimation:setFrameDuration(frameDuration, currentOnly)
@@ -493,6 +543,14 @@ function RoxyAnimation:setFrameDuration(frameDuration, currentOnly)
   end
 
   return self
+end
+
+-- ! Set Frame Rate
+-- Set frame rate (affects all animations unless currentOnly=true)
+function RoxyAnimation:setFrameRate(frameRate, currentOnly)
+  local frameDuration = _resolveFrameRateSetter(frameRate, "RoxyAnimation:setFrameRate")
+  if not frameDuration then return self end
+  return self:setFrameDuration(frameDuration, currentOnly)
 end
 
 -- ! Validate Frame Duration Input
@@ -837,75 +895,67 @@ end
 --------------------------------------------------------------------------------
 
 --[[
+RoxyAnimation manages spritesheet playback state over retained or shared imagetables.
 
--- Basic Usage
-local myAnimation = RoxyAnimation("path/to/spritesheet")
-myAnimation:addAnimation({
+-- Path-backed animation with named clips
+local playerAnimation = RoxyAnimation("images/player")
+playerAnimation:addAnimation({
   name = "idle",
   startFrame = 1,
   endFrame = 4,
   loop = true,
-  speed = 1
+  frameRate = 12,
 })
-
--- Multiple Animations with Chaining
-myAnimation:addAnimation({
-  name = "walk",
+:addAnimation({
+  name = "run",
   startFrame = 5,
   endFrame = 12,
-  loop = true
+  frameRate = "display",
 })
 :addAnimation({
   name = "jump",
   startFrame = 13,
   endFrame = 20,
   loop = false,
-  next = "idle", -- Auto-transition back to idle
+  next = "idle",
+  nextDelay = 0.1,
+  frameRate = 12,
+  frameDuration = 0.05, -- Takes precedence over frameRate
   onComplete = function()
-    Log.debug("Jump completed!") --#DEBUG
-  end
+    Log.debug("[PlayerAnimation] jump complete") --#DEBUG
+  end,
 })
 
--- Frame Control
-myAnimation:setAnimation("walk")
-myAnimation:jumpToFrame(8)
-myAnimation:stepFrame(1)      -- Step forward
-myAnimation:stepFrame("back") -- Step backward
+playerAnimation:setAnimation("idle")
+playerAnimation:setSpeed(1.25)
+playerAnimation:setFrameRate(10, true)
 
--- Playback Control
-myAnimation:setSpeed(2)         -- Double speed for all animations
-myAnimation:setSpeed(0.5, true) -- Half speed for current animation only
-myAnimation:reverse()           -- Play backwards
-myAnimation:stop()              -- Stop playback
+-- Manual frame control
+playerAnimation:setAnimation("run")
+playerAnimation:jumpToFrame(8)
+playerAnimation:stepFrame(1)
+playerAnimation:stepFrame("back")
+playerAnimation:reverse()
 
 -- Delayed Start
-myAnimation:startWithDelay(1500, "jump") -- Start jump animation after 1500 ms
+playerAnimation:startWithDelay(1500, "jump")
 
--- Animation Queries
-if myAnimation:isPlaying() then
-  Log.debug("Current animation:", myAnimation:getCurrentAnimation())  --#DEBUG
-  Log.debug("Current frame:", myAnimation:getCurrentFrame())          --#DEBUG
-end
-
--- Factory Methods share image data while returning fresh playback state
-local pathAnimation = RoxyAnimation.fromPath("images/shared-sheet")
-local poolAnimation = RoxyAnimation.fromPool("character_animations")
-local existingImagetable = playdate.graphics.imagetable.new("images/shared-sheet")
+-- Factory helpers share image data while returning fresh playback state
+local sharedPathAnimation = RoxyAnimation.fromPath("images/player")
+local existingImagetable = playdate.graphics.imagetable.new("images/player")
 local tableAnimation = RoxyAnimation.fromImagetable(existingImagetable)
 
--- Explicit sharing is opt-in by retaining a known animation instance
-local myAnimation2 = myAnimation:retain() -- Increment reference count
-myAnimation:release()                     -- Decrement reference count
-myAnimation2:release()                    -- Final release cleans up resources
-
--- In your update loop
+-- Update and draw from your sprite or scene loop
 function MySprite:update()
   self.animation:update()
 end
 
--- In your draw method
 function MySprite:draw()
   self.animation:draw(self.x, self.y, self.flip)
 end
 
+-- Release retained image data when the owner is done
+sharedPathAnimation:release()
+tableAnimation:release()
+playerAnimation:release()
 --]]

--- a/core/modules/Scene.lua
+++ b/core/modules/Scene.lua
@@ -41,6 +41,8 @@ local stack
 local updateList
 local bgList
 local drawList
+local stackHiddenScenes
+local stackHiddenSceneList
 
 --------------------------------------------------------------------------------
 -- Utilities
@@ -68,7 +70,7 @@ function Scene.setSpritePauseClassification(sprite, opts)
     newMask = SCENE_PAUSE_ALL
   else
     if type(opts) ~= "table" then
-      Log.error("[Scene.setSpritePauseClassification] Expected table or nil", 2)
+      error("[Scene.setSpritePauseClassification] Expected table or nil", 3)
     end
 
     local playback = opts.playback
@@ -77,13 +79,13 @@ function Scene.setSpritePauseClassification(sprite, opts)
 
     -- Validate in all builds; silent coercion makes pause state difficult to trace.
     if playback ~= nil and type(playback) ~= "boolean" then
-      Log.error("[Scene.setSpritePauseClassification] playback must be a boolean when supplied", 2)
+      error("[Scene.setSpritePauseClassification] playback must be a boolean when supplied", 3)
     end
     if updates ~= nil and type(updates) ~= "boolean" then
-      Log.error("[Scene.setSpritePauseClassification] updates must be a boolean when supplied", 2)
+      error("[Scene.setSpritePauseClassification] updates must be a boolean when supplied", 3)
     end
     if collisions ~= nil and type(collisions) ~= "boolean" then
-      Log.error("[Scene.setSpritePauseClassification] collisions must be a boolean when supplied", 2)
+      error("[Scene.setSpritePauseClassification] collisions must be a boolean when supplied", 3)
     end
 
     newMask = SCENE_PAUSE_NONE
@@ -103,10 +105,74 @@ function Scene.setSpritePauseClassification(sprite, opts)
   return sprite
 end
 
-if type(Sprite.setPauseClassification) ~= "function" then
-  function Sprite:setPauseClassification(opts)
-    return Scene.setSpritePauseClassification(self, opts)
+-- ! Utility: Set Scene Stack Sprites Hidden
+local function setSceneStackSpritesHidden(scene, hidden)
+  local setter = scene and scene._setSceneStackSpritesHidden
+  if type(setter) == "function" then
+    setter(scene, hidden == true)
   end
+end
+
+-- ! Utility: Restore All Stack Hidden Scenes
+local function restoreAllStackHiddenScenes()
+  local hiddenList = stackHiddenSceneList
+  if hiddenList then
+    for i = #hiddenList, 1, -1 do
+      local scene = hiddenList[i]
+      if scene then
+        setSceneStackSpritesHidden(scene, false)
+      end
+    end
+  end
+
+  stackHiddenScenes = {}
+  stackHiddenSceneList = {}
+end
+
+-- ! Utility: Sync Stack Sprite Visibility
+local function syncStackSpriteVisibility(sceneStack, depth)
+  local blockingIndex = nil
+
+  for i = depth, 1, -1 do
+    local scene = sceneStack[i]
+    if scene and scene.blocksLowerDraw == true then
+      blockingIndex = i
+      break
+    end
+  end
+
+  local nextHiddenScenes = {}
+  local nextHiddenSceneList = {}
+  local nextHiddenCount = 0
+  local hideThrough = blockingIndex and blockingIndex - 1 or 0
+
+  for i = 1, hideThrough do
+    local scene = sceneStack[i]
+    if scene and nextHiddenScenes[scene] ~= true then
+      nextHiddenScenes[scene] = true
+      nextHiddenCount += 1
+      nextHiddenSceneList[nextHiddenCount] = scene
+
+      if not stackHiddenScenes or stackHiddenScenes[scene] ~= true then
+        setSceneStackSpritesHidden(scene, true)
+      end
+    end
+  end
+
+  local hiddenList = stackHiddenSceneList
+  if hiddenList then
+    for i = #hiddenList, 1, -1 do
+      local scene = hiddenList[i]
+      if scene and nextHiddenScenes[scene] ~= true then
+        setSceneStackSpritesHidden(scene, false)
+      end
+    end
+  end
+
+  stackHiddenScenes = nextHiddenScenes
+  stackHiddenSceneList = nextHiddenSceneList
+
+  return blockingIndex or 1
 end
 
 -- ! Utility: Rebuild Lists
@@ -122,6 +188,7 @@ local function rebuildLists()
   local bList = bgList
   local dList = drawList
   local depth = #sceneStack
+  local startIndex = syncStackSpriteVisibility(sceneStack, depth)
 
   -- Early out for empty stack
   if depth == 0 then
@@ -146,16 +213,6 @@ local function rebuildLists()
   end
 
   -- (2) Build draw list honoring scene stacking rules
-  -- Find the highest scene that blocks lower draw, scanning from top downward.
-  local startIndex = 1
-  for i = depth, 1, -1 do
-    local scene = sceneStack[i]
-    if scene and scene.blocksLowerDraw == true then
-      startIndex = i
-      break
-    end
-  end
-
   -- Collect visible scenes from startIndex --> top (bottom-to-top draw order)
   for i = startIndex, depth do
     local scene = sceneStack[i]
@@ -217,12 +274,16 @@ end
 --------------------------------------------------------------------------------
 
 function Scene.init()
+  restoreAllStackHiddenScenes()
+
   -- Clear registered scenes, stack and lists
   scenes = {}     -- Registered scenes
   stack = {}      -- Scene stack
   updateList = {} -- Pre-filtered update list
   bgList = {}     -- Pre-filtered bg update lists
   drawList = {}   -- Pre-filtered draw list
+  stackHiddenScenes = {}
+  stackHiddenSceneList = {}
 
   Scene.currentScene = nil -- Currently active scene (top of stack)
 
@@ -243,11 +304,11 @@ function Scene.registerScenes(...)
     local sceneName, sceneTable = args[1], args[2]
 
     if type(sceneName) ~= "string" then
-      Log.error("[Scene.registerScenes] First argument must be a string scene name.", 2) --#DEBUG
+      error("[Scene.registerScenes] First argument must be a string scene name.", 2) --#DEBUG
       return
     end
     if type(sceneTable) ~= "table" then
-      Log.error("[Scene.registerScenes] Second argument must be a table.", 2) --#DEBUG
+      error("[Scene.registerScenes] Second argument must be a table.", 2) --#DEBUG
       return
     end
 
@@ -260,17 +321,17 @@ function Scene.registerScenes(...)
     local sceneTable = args[1]
 
     if type(sceneTable) ~= "table" then
-      Log.error("[Scene.registerScenes] Single argument must be a table of scenes.", 2) --#DEBUG
+      error("[Scene.registerScenes] Single argument must be a table of scenes.", 2) --#DEBUG
       return
     end
 
     for name, table in pairs(sceneTable) do
       -- TODO: Should the if statement be removed from release build or just the error log?
       if type(name) ~= "string" then
-        Log.error("[Scene.registerScenes] Skipping scene - key is not a string.", 2) --#DEBUG
+        error("[Scene.registerScenes] Skipping scene - key is not a string.", 2) --#DEBUG
         return
       elseif type(table) ~= "table" then
-        Log.error("[Scene.registerScenes] Skipping scene '" .. tostring(name) .. "' - value is not a table.", 2) --#DEBUG
+        error("[Scene.registerScenes] Skipping scene '" .. tostring(name) .. "' - value is not a table.", 2) --#DEBUG
         return
       else
         scenes[name] = table
@@ -279,7 +340,7 @@ function Scene.registerScenes(...)
     return
   end
 
-  Log.error("[Scene.registerScenes] Invalid parameters to roxy.Scene.registerScenes.", 2) --#DEBUG
+  error("[Scene.registerScenes] Invalid parameters to roxy.Scene.registerScenes.", 2) --#DEBUG
 end
 
 --------------------------------------------------------------------------------
@@ -289,7 +350,7 @@ end
 -- ! Replace Scene Raw
 function Scene.replaceRaw(newScene)
   if type(newScene) ~= "table" then
-    Log.error("[Scene.replaceRaw] A valid scene table must be provided.", 2) --#DEBUG
+    error("[Scene.replaceRaw] A valid scene table must be provided.", 2) --#DEBUG
     return
   end
 
@@ -308,7 +369,7 @@ end
 -- ! Replace Scene
 function Scene.replaceScene(newScene)
   if type(newScene) ~= "table" then
-    Log.error("[Scene.replaceScene] A valid scene table must be provided.", 2) --#DEBUG
+    error("[Scene.replaceScene] A valid scene table must be provided.", 2) --#DEBUG
     return
   end
 
@@ -328,13 +389,13 @@ end
 -- ! Push Scene Raw
 function Scene.pushRaw(newScene)
   if type(newScene) ~= "table" then
-    Log.error("[Scene.pushRaw] A valid scene table must be provided.", 2) --#DEBUG
+    error("[Scene.pushRaw] A valid scene table must be provided.", 2) --#DEBUG
     return
   end
 
   -- Soft stack overflow cap
   if #stack >= MAX_SCENE_DEPTH then
-    Log.error("[Scene.pushRaw] Stack depth exceeded (limit: " .. MAX_SCENE_DEPTH .. ")", 2) --#DEBUG
+    error("[Scene.pushRaw] Stack depth exceeded (limit: " .. MAX_SCENE_DEPTH .. ")", 2) --#DEBUG
     return
   end
 
@@ -348,7 +409,7 @@ end
 -- ! Push Scene
 function Scene.pushScene(newScene)
   if type(newScene) ~= "table" then
-    Log.error("[Scene.pushScene] A valid scene table must be provided.", 2) --#DEBUG
+    error("[Scene.pushScene] A valid scene table must be provided.", 2) --#DEBUG
     return
   end
 
@@ -365,7 +426,7 @@ end
 function Scene.popRaw()
   local depth = #stack
   if depth == 0 then
-    Log.warn("[Scene.popRaw] Stack already empty.")
+    Log.warn("[Scene.popRaw] Stack already empty.") --#DEBUG
     Scene.currentScene = nil
     rebuildLists()
     return
@@ -445,22 +506,28 @@ end
 
 --[[
 
-Scene manages registration, stack flow, background updates, and sprite pause classification.
+Scene manages registration, stack flow, stack visibility, background updates, and sprite pause classification.
 
 -- Register and Start Scenes
 Scene.init()
 Scene.registerScenes({
-  Title    = TitleScene,
-  Gameplay = GameplayScene,
-  Pause    = PauseScene,
+  Title     = TitleScene,
+  Gameplay  = GameplayScene,
+  Pause     = PauseScene,
+  Inventory = InventoryScene,
 })
 
 Scene.replaceScene(TitleScene)
 
--- Stack a Pause Scene
+-- Stack Overlay and Full-Screen Scenes
+PauseScene.blocksLowerDraw = false -- Keep lower draw and scene-owned sprites visible
 Scene.pushScene(PauseScene)
 local currentScene = Scene.getCurrentScene()
 local depth = Scene.getStackDepth()
+Scene.popScene()
+
+InventoryScene.blocksLowerDraw = true -- Hide lower draw and scene-owned sprites
+Scene.pushScene(InventoryScene)
 Scene.popScene()
 
 -- Keep a Background Scene Updating
@@ -473,10 +540,10 @@ local player = RoxySprite({ name = "player" })
 player:setPauseClassification(nil) -- Default dynamic behavior
 
 local decoration = playdate.graphics.sprite.new()
-decoration:setPauseClassification({}) -- Static; skip pause/resume work
+Scene.setSpritePauseClassification(decoration, {}) -- Static; skip pause/resume work
 
 local parallaxLayer = playdate.graphics.sprite.new()
-parallaxLayer:setPauseClassification({ updates = true })
+Scene.setSpritePauseClassification(parallaxLayer, { updates = true })
 
 local wall = playdate.graphics.sprite.new()
 Scene.setSpritePauseClassification(wall, { collisions = true })

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -13,6 +13,8 @@ local Scene   <const> = r.Scene
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
 local setMetatable <const> = setmetatable
+local rawGet <const> = rawget
+local rawSet <const> = rawset
 
 local clearScreen         <const> = Graphics.clear
 local setColor            <const> = Graphics.setColor
@@ -58,20 +60,20 @@ local SCENE_PAUSE_PLAYBACK_COLLISIONS <const> = SCENE_PAUSE_PLAYBACK + SCENE_PAU
 local SCENE_PAUSE_UPDATES_COLLISIONS <const> = SCENE_PAUSE_UPDATES + SCENE_PAUSE_COLLISIONS
 local SCENE_PAUSE_ALL <const> = Scene._SCENE_PAUSE_ALL
 
-local RESTORE_UPDATES     <const> = 1
-local RESTORE_COLLISIONS  <const> = 2
-local SHOULD_PLAY         <const> = 4
-local SNAPSHOT_STATE_MASK <const> = 7
-local SNAPSHOT_STATE_BITS <const> = 3
-local SNAPSHOT_UPDATES_OFF <const> = SCENE_PAUSE_UPDATES << SNAPSHOT_STATE_BITS
-local SNAPSHOT_UPDATES_ON <const> = SNAPSHOT_UPDATES_OFF + RESTORE_UPDATES
+local RESTORE_UPDATES         <const> = 1
+local RESTORE_COLLISIONS      <const> = 2
+local SHOULD_PLAY             <const> = 4
+local SNAPSHOT_STATE_MASK     <const> = 7
+local SNAPSHOT_STATE_BITS     <const> = 3
+local SNAPSHOT_UPDATES_OFF    <const> = SCENE_PAUSE_UPDATES << SNAPSHOT_STATE_BITS
+local SNAPSHOT_UPDATES_ON     <const> = SNAPSHOT_UPDATES_OFF + RESTORE_UPDATES
 local SNAPSHOT_COLLISIONS_OFF <const> = SCENE_PAUSE_COLLISIONS << SNAPSHOT_STATE_BITS
-local SNAPSHOT_COLLISIONS_ON <const> = SNAPSHOT_COLLISIONS_OFF + RESTORE_COLLISIONS
-local SNAPSHOT_ALL_BASE <const> = SCENE_PAUSE_ALL << SNAPSHOT_STATE_BITS
+local SNAPSHOT_COLLISIONS_ON  <const> = SNAPSHOT_COLLISIONS_OFF + RESTORE_COLLISIONS
+local SNAPSHOT_ALL_BASE       <const> = SCENE_PAUSE_ALL << SNAPSHOT_STATE_BITS
 
-local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
-local getSpritePauseMask <const> = Scene._getSpritePauseMask
-local luaType <const> = type
+local NO_OP_BG_DRAW       <const> = function(x, y, width, height) end
+local getSpritePauseMask  <const> = Scene._getSpritePauseMask
+local luaType             <const> = type
 
 local _colorCallbacks = {} -- Cache: color --> fn
 local _imageCallbacks = setMetatable({}, { __mode = "k" }) -- Cache: image --> fn, weak keys
@@ -432,6 +434,187 @@ local function _pruneScenePauseSnapshotList(scene, sprites)
   end
 end
 
+-- ! Helper: Read Scene Stack Sprite Visibility
+local function _readSceneStackSpriteVisibility(sprite)
+  local reader = sprite and sprite.isVisible
+  if luaType(reader) ~= "function" then return true end
+
+  local value = reader(sprite)
+  return value ~= false and value ~= 0
+end
+
+-- ! Helper: Scene Stack Visibility SetVisible Wrapper
+local function _sceneStackVisibilitySetVisible(sprite, value)
+  if not sprite or sprite._roxySceneStackVisibilityOwner == nil then
+    local setter = sprite and sprite._roxySceneStackSavedSetVisible
+    if luaType(setter) == "function" then return setter(sprite, value) end
+    return
+  end
+
+  sprite._roxySceneStackWasVisible = value ~= false
+
+  local setter = sprite._roxySceneStackSavedSetVisible
+  if luaType(setter) == "function" then return setter(sprite, false) end
+end
+
+-- ! Helper: Scene Stack Visibility IsVisible Wrapper
+local function _sceneStackVisibilityIsVisible(sprite)
+  if sprite and sprite._roxySceneStackVisibilityOwner ~= nil then
+    return sprite._roxySceneStackWasVisible ~= false
+  end
+
+  local reader = sprite and sprite._roxySceneStackSavedIsVisible
+  if luaType(reader) == "function" then return reader(sprite) end
+  return true
+end
+
+-- ! Helper: Mark Scene Stack Visibility Snapshot Pruned
+local function _markSceneStackVisibilitySnapshotPruned(scene, sprite)
+  local snapshotList = scene and scene._sceneStackVisibilitySnapshotList
+  if not snapshotList then return end
+
+  for i = #snapshotList, 1, -1 do
+    if snapshotList[i] == sprite then
+      snapshotList[i] = false
+      return
+    end
+  end
+end
+
+-- ! Helper: Prune Scene Stack Visibility Snapshot List
+local function _pruneSceneStackVisibilitySnapshotList(scene, sprites)
+  local snapshotList = scene._sceneStackVisibilitySnapshotList
+  if not snapshotList or not sprites then return end
+
+  for i = #snapshotList, 1, -1 do
+    if sprites[snapshotList[i]] == true then
+      snapshotList[i] = false
+    end
+  end
+end
+
+-- ! Helper: Clear Scene Stack Visibility Snapshot
+local function _clearSceneStackVisibilitySnapshot(scene, sprite, pruneList)
+  if not scene or not sprite then return end
+
+  if sprite._roxySceneStackVisibilityOwner ~= scene then
+    if pruneList ~= false then _markSceneStackVisibilitySnapshotPruned(scene, sprite) end
+    return
+  end
+
+  local desiredVisible = sprite._roxySceneStackWasVisible ~= false
+  local savedSetVisible = sprite._roxySceneStackSavedSetVisible
+  local savedIsVisible = sprite._roxySceneStackSavedIsVisible
+  local setVisibleWasOwn = sprite._roxySceneStackSetVisibleWasOwn == true
+  local isVisibleWasOwn = sprite._roxySceneStackIsVisibleWasOwn == true
+
+  if rawGet(sprite, "setVisible") == _sceneStackVisibilitySetVisible then
+    if setVisibleWasOwn then
+      rawSet(sprite, "setVisible", savedSetVisible)
+    else
+      rawSet(sprite, "setVisible", nil)
+    end
+  end
+
+  if rawGet(sprite, "isVisible") == _sceneStackVisibilityIsVisible then
+    if isVisibleWasOwn then
+      rawSet(sprite, "isVisible", savedIsVisible)
+    else
+      rawSet(sprite, "isVisible", nil)
+    end
+  end
+
+  local currentSetter = sprite.setVisible
+
+  sprite._roxySceneStackVisibilityOwner = nil
+  sprite._roxySceneStackWasVisible = nil
+  sprite._roxySceneStackSavedSetVisible = nil
+  sprite._roxySceneStackSetVisibleWasOwn = nil
+  sprite._roxySceneStackSavedIsVisible = nil
+  sprite._roxySceneStackIsVisibleWasOwn = nil
+
+  if luaType(currentSetter) == "function" then
+    currentSetter(sprite, desiredVisible)
+  end
+
+  if pruneList ~= false then
+    _markSceneStackVisibilitySnapshotPruned(scene, sprite)
+  end
+end
+
+-- ! Helper: Hide Scene Sprite For Stack
+local function _hideSceneSpriteForStack(scene, sprite)
+  if not scene or not sprite or sprite.scene ~= scene then return end
+
+  if sprite._roxySceneStackVisibilityOwner == scene then
+    local setter = sprite._roxySceneStackSavedSetVisible
+    if luaType(setter) == "function" then setter(sprite, false) end
+    return
+  end
+
+  local oldOwner = sprite._roxySceneStackVisibilityOwner
+  if oldOwner then
+    _clearSceneStackVisibilitySnapshot(oldOwner, sprite)
+  end
+
+  local ownSetVisible = rawGet(sprite, "setVisible")
+  local ownIsVisible = rawGet(sprite, "isVisible")
+  local setVisibleWasOwn = ownSetVisible ~= nil
+  local isVisibleWasOwn = ownIsVisible ~= nil
+  local savedSetVisible = setVisibleWasOwn and ownSetVisible or sprite.setVisible
+  local savedIsVisible = isVisibleWasOwn and ownIsVisible or sprite.isVisible
+
+  sprite._roxySceneStackVisibilityOwner = scene
+  sprite._roxySceneStackWasVisible = _readSceneStackSpriteVisibility(sprite)
+  sprite._roxySceneStackSavedSetVisible = savedSetVisible
+  sprite._roxySceneStackSetVisibleWasOwn = setVisibleWasOwn
+  sprite._roxySceneStackSavedIsVisible = savedIsVisible
+  sprite._roxySceneStackIsVisibleWasOwn = isVisibleWasOwn
+
+  rawSet(sprite, "setVisible", _sceneStackVisibilitySetVisible)
+  rawSet(sprite, "isVisible", _sceneStackVisibilityIsVisible)
+
+  local snapshotList = scene._sceneStackVisibilitySnapshotList
+  if not snapshotList then
+    snapshotList = {}
+    scene._sceneStackVisibilitySnapshotList = snapshotList
+  end
+  snapshotList[#snapshotList + 1] = sprite
+
+  if luaType(savedSetVisible) == "function" then
+    savedSetVisible(sprite, false)
+  end
+end
+
+-- ! Helper: Hide Scene Sprites For Stack
+local function _hideSceneSpritesForStack(scene)
+  if not scene then return end
+  scene._sceneStackSpritesHidden = true
+
+  if not scene._didEnter then return end
+
+  local sprites = scene.sprites
+  for i = #sprites, 1, -1 do
+    _hideSceneSpriteForStack(scene, sprites[i])
+  end
+end
+
+-- ! Helper: Restore Scene Sprites For Stack
+local function _restoreSceneSpritesForStack(scene)
+  if not scene then return end
+  scene._sceneStackSpritesHidden = false
+
+  local snapshotList = scene._sceneStackVisibilitySnapshotList
+  if snapshotList then
+    for i = #snapshotList, 1, -1 do
+      local sprite = snapshotList[i]
+      if sprite then _clearSceneStackVisibilitySnapshot(scene, sprite, false) end
+    end
+  end
+
+  scene._sceneStackVisibilitySnapshotList = {}
+end
+
 -- ! Helper: Pause Scene Sprite
 -- Snapshots update, collision, and playback state before any mutation.
 local function _pauseSceneSprite(scene, sprite, pauseMask)
@@ -616,8 +799,9 @@ local function _resumeRegisteredSceneSprite(scene, sprite, pruneList)
   _resumeSceneSprite(scene, sprite, nil, pruneList)
 end
 
--- ! Helper: Restore Scene Pause Before Unregister
+-- ! Helper: Restore Scene State Before Unregister
 local function _restoreScenePauseBeforeUnregister(scene, sprite, pruneList)
+  _clearSceneStackVisibilitySnapshot(scene, sprite, pruneList)
   _resumeRegisteredSceneSprite(scene, sprite, pruneList)
 end
 
@@ -729,6 +913,8 @@ function RoxyScene:init(background)
   self._spriteAutoAddIndex = {}
   self._pauseSpriteSnapshots = {}
   self._pauseSpriteSnapshotList = {}
+  self._sceneStackSpritesHidden = false
+  self._sceneStackVisibilitySnapshotList = {}
   self._sequenceAutoStartQueue = {}
   self._roxyCameraActivated = false
   self._roxyScenePauseCameraSnapshot = nil
@@ -759,6 +945,9 @@ function RoxyScene:enter()
   for i = 1, #spriteQueue do
     local sprite = spriteQueue[i]
     sprite:add()
+    if self._sceneStackSpritesHidden then
+      _hideSceneSpriteForStack(self, sprite)
+    end
     if self.isPaused then
       _pauseRegisteredSceneSprite(self, sprite)
     end
@@ -1155,6 +1344,8 @@ function RoxyScene:cleanup()
   self._spriteAutoAddQueue = {}
   self._spriteAutoAddIndex = {}
   self._sequenceAutoStartQueue = {}
+  self._sceneStackSpritesHidden = false
+  self._sceneStackVisibilitySnapshotList = {}
 
   self.backgroundColor = nil
   self.backgroundImage = nil
@@ -1231,6 +1422,15 @@ function RoxyScene:_spritePauseClassificationDidChange(sprite, oldMask, newMask)
   end
 end
 
+-- ! Set Scene Stack Sprites Hidden
+function RoxyScene:_setSceneStackSpritesHidden(hidden)
+  if hidden == true then
+    _hideSceneSpritesForStack(self)
+  else
+    _restoreSceneSpritesForStack(self)
+  end
+end
+
 -- ! Add Sprite
 function RoxyScene:addSprite(sprite)
   if not sprite then return end
@@ -1266,6 +1466,9 @@ function RoxyScene:addSprite(sprite)
   if self._didEnter then
     -- Scene is active -- attach immediately
     sprite:add()
+    if self._sceneStackSpritesHidden then
+      _hideSceneSpriteForStack(self, sprite)
+    end
   else
     -- Scene isn't active yet -- queue for enter()
     _appendIndexed(self._spriteAutoAddQueue, self._spriteAutoAddIndex, sprite)
@@ -1345,11 +1548,13 @@ function RoxyScene:_unregisterSprites(sprites, removeFromDisplay)
     end
   end
   _pruneScenePauseSnapshotList(self, targets)
+  _pruneSceneStackVisibilitySnapshotList(self, targets)
 end
 
 -- ! Remove All Sprites
 function RoxyScene:removeAllSprites()
   local sprites = self.sprites
+  local wasStackHidden = self._sceneStackSpritesHidden == true
 
   self.sprites = {}
   self._spriteSet = {}
@@ -1366,6 +1571,8 @@ function RoxyScene:removeAllSprites()
   end
   self._pauseSpriteSnapshots = {}
   self._pauseSpriteSnapshotList = {}
+  self._sceneStackSpritesHidden = wasStackHidden
+  self._sceneStackVisibilitySnapshotList = {}
 
   for i = #sprites, 1, -1 do
     local sprite = sprites[i]
@@ -1562,7 +1769,7 @@ end
 
 --[[
 
-RoxyScene owns scene lifecycle, input, sprites, tilemaps, sequences, camera setup, and pause state.
+RoxyScene owns scene lifecycle, input, sprites, tilemaps, sequences, camera setup, stack visibility, and pause state.
 
 -- Gameplay Scene
 local Graphics <const> = playdate.graphics
@@ -1573,6 +1780,7 @@ class("GameplayScene").extends(RoxyScene)
 
 function GameplayScene:init()
   GameplayScene.super.init(self, COLOR_WHITE)
+  self.blocksLowerDraw = true
 
   self.inputHandler = {
     BButtonDown = function()
@@ -1589,7 +1797,7 @@ function GameplayScene:start()
   self:addSprite(self.player)
 
   self.marker = Graphics.sprite.new()
-  self.marker:setPauseClassification({}) -- Static; skip scene pause work
+  roxy.Scene.setSpritePauseClassification(self.marker, {})
   self:addSprite(self.marker)
 
   self.map = self:spawnTilemap("assets/maps/level-01.json", {
@@ -1623,8 +1831,12 @@ end
 -- Overlay Scene
 local pauseScene = RoxyScene(Graphics.kColorBlack)
 pauseScene.isVisible = true
-pauseScene.blocksLowerDraw = false
+pauseScene.blocksLowerDraw = false -- Keep lower draw and scene-owned sprites visible
 pauseScene.updateBackground = true
+
+-- Full-Screen Pushed Scene
+local inventoryScene = RoxyScene(COLOR_WHITE)
+inventoryScene.blocksLowerDraw = true -- Hide lower draw and scene-owned sprites
 
 -- Manual Ownership
 local scene = RoxyScene()

--- a/core/sprites/RoxyActor.lua
+++ b/core/sprites/RoxyActor.lua
@@ -1,31 +1,46 @@
 -- core/sprites/RoxyActor.lua
 
--- Math functions
+--------------------------------------------------------------------------------
+-- RoxyActor - State-Driven Animated Sprite Actor
+--------------------------------------------------------------------------------
+--
+-- Builds on RoxySprite with manifest-driven animation states, transition rules,
+-- one-shot animation handling, facing, and optional physics integration.
+--
+-- Key Features:
+--  - Flexible manifest construction with optional scene and sprite options
+--  - Row-based RoxyAnimation clip setup with frameRate/frameDuration metadata
+--  - State, queued-state, and playOnce helpers
+--  - Transition-rule evaluation for updatePhysics
+--  - Reversible physics update integration
+--
+-- Manifest Contract:
+--  - sheet may be a path, imagetable, RoxyAnimation, pool descriptor, or wrapper
+--  - rows map state names to row numbers or explicit start/finish ranges
+--  - frameDuration and frameRate are forwarded to RoxyAnimation clip config
+--
+--------------------------------------------------------------------------------
+
 local abs   <const> = math.abs
 local floor <const> = math.floor
 local max   <const> = math.max
 local min   <const> = math.min
 
--- Table functions
 local tableInsert <const> = table.insert
 
--- Core Playdate
-local pd        <const> = playdate
-local Graphics  <const> = pd.graphics
+local pd <const> = playdate
 
--- Timer functions
 local performAfterDelay <const> = pd.timer.performAfterDelay
 
--- Roxy core
 local r <const> = roxy
 
 --------------------------------------------------------------------------------
--- Helpers
+-- Private Helper Functions
 --------------------------------------------------------------------------------
 
 -- ! Resolve Terminal
--- When starting a one-shot, find the last NON-looping clip in the .next chain.
--- Stops before a loop, on missing next, or on cycles.
+-- Finds the last non-looping clip in a one-shot .next chain
+-- Stops before a loop, missing next, or cycle
 local function _resolveTerminal(self, startName)
   local seen, prev = {}, nil
   local name = startName
@@ -62,16 +77,21 @@ local function _manifestNeedsSheet(manifest)
 end
 
 --------------------------------------------------------------------------------
--- Class Definition & Init
+-- Class Definition
 --------------------------------------------------------------------------------
 
 class("RoxyActor").extends(RoxySprite)
+
+--------------------------------------------------------------------------------
+-- Initialization
+--------------------------------------------------------------------------------
 
 -- ! Initialize
 -- Manifest may include:
 --   sheet, rows, frames, loop, next, default, transitions
 -- Sprite options (forwarded to RoxySprite) may include:
---   name, worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY, view, isSheet, singleAnimation, frameDuration
+--   name, worldX, worldY, parallaxX, parallaxY, parallaxOriginX,
+--   parallaxOriginY, view, isSheet, singleAnimation, frameDuration, frameRate
 function RoxyActor:init(manifest, defaultState, opts, scene)
   self:_parseInitArgs(manifest, defaultState, opts, scene)
 
@@ -171,6 +191,7 @@ function RoxyActor:_buildAnimationsFromRows()
         next          = doNext[stateName],
         speed         = (type(info) == "table") and info.speed or nil,
         frameDuration = (type(info) == "table") and info.frameDuration or nil,
+        frameRate     = (type(info) == "table") and info.frameRate or nil,
         onCompleteCallback = function() self:_onAnimationComplete(stateName) end,
       }
     end
@@ -622,118 +643,62 @@ end
 --------------------------------------------------------------------------------
 
 --[[
+RoxyActor builds a state-driven animated RoxySprite from a manifest.
 
--- Basic Setup with Manifest
 local playerManifest = {
-  sheet = "images/player-spritesheet", -- Path to spritesheet
+  sheet = "images/player",
+  frames = 8,
   rows = {
-    idle = 1, -- Row 1 for idle animation
-    run = 2,  -- Row 2 for running
-    jump = 3, -- Row 3 for jumping
-    fall = 4  -- Row 4 for falling
-  },
-  frames = 8, -- 8 frames per row
-  default = "idle", -- Starting state
-  loop = {
-    idle = true,
-    run = true,
-    jump = false, -- One-shot animation
-    fall = false
-  },
-  next = {
-    jump = "fall",  -- Jump chains to fall
-    fall = "idle"   -- Fall returns to idle
-  }
-}
-
-local player = RoxyActor(playerManifest)
-
--- Advanced Manifest with Transition Rules
-local advancedManifest = {
-  sheet = "images/character",
-  rows = {
-    idle = { start = 1, finish = 4, speed = 1 },
-    run = { start = 9, finish = 16, speed = 2 },
+    idle = { start = 1, finish = 4, frameRate = 12 },
+    run = { start = 9, finish = 16, frameRate = "display" },
     jump = { start = 17, finish = 24, frameDuration = 0.05 },
-    attack = { start = 25, finish = 32 }
+    fall = 4,
+    attack = { start = 33, finish = 40, frameRate = 18 },
   },
   default = "idle",
+  loop = { jump = false, fall = false, attack = false },
+  next = {
+    jump = "fall",
+    fall = "idle",
+  },
   transitions = {
-    { state = "run", vxGreaterThan = 10, onGround = true },
+    { state = "run", intentVXGreaterThan = 0, onGround = true },
     { state = "jump", vy = -50, onGround = false },
     { state = "fall", vyGreaterThan = 0, onGround = false },
-    { state = "idle", vx = 0, onGround = true }
-  }
+    { state = "idle", intentVX = 0, onGround = true },
+  },
 }
-local advancedActor = RoxyActor(advancedManifest)
 
--- State Management
-player:setState("run")        -- Immediate state change
-player:queueState("jump")     -- Queue next state
-player:setState("idle", true) -- Force restart even if already idle
+local player = RoxyActor(playerManifest, "idle", {
+  name = "player",
+  worldX = 120,
+  worldY = 80,
+}, scene)
 
--- One-Shot Animations
+player:setState("run")
+player:queueState("idle")
 player:playOnce("attack", function(actor)
-  Log.debug("Attack animation completed!")
-  -- Automatically returns to previous state
+  Log.debug("[PlayerActor] attack finished") --#DEBUG
 end)
 
--- Physics Integration
-local physicsBody = RoxyPhysicsBody({ -- placeholder: provided by caller
-  x = 100, y = 100,
-  width = 32, height = 48
-})
-
-player:addPhysics(physicsBody)
-
--- Custom updatePhysics override
-function player:updatePhysics(opts)
-  opts = opts or {}
-
-  if opts.isAttacking then
-    if self.currentState ~= "attack" then
-      self:playOnce("attack")
-    end
-  else
-    -- Reuse the built-in transition logic from RoxyActor
-    RoxyActor.updatePhysics(self, opts)
-  end
-end
-
--- Manual Physics Updates
 player:updatePhysics({
-  vx = 15,            -- Current horizontal velocity
-  vy = -20,           -- Current vertical velocity
-  intentVX = 25,      -- Desired horizontal velocity (for facing)
-  onGround = false,   -- Ground collision state
-  isSliding = true,   -- Custom condition
-  healthAtLeast = 50  -- Custom condition with suffix
+  vx = 15,
+  vy = -20,
+  intentVX = 25,
+  onGround = false,
+  healthAtLeast = 50,
 })
 
--- Facing Direction
-player:setFacing(20) -- Positive = right, negative = left
+-- Optional physics object supplied by the caller
+player:addPhysics(playerBody)
+player:clearPhysics()
 
--- Multiple Initialization Patterns
-local manifest = playerManifest
-local scene = currentScene -- placeholder: provided by caller
-local opts = { worldX = 120, worldY = 80 }
-local actor1 = RoxyActor(manifest, scene)               -- 2-arg
-local actor2 = RoxyActor(manifest, "idle", opts, scene) -- 4-arg
-local actor3 = RoxyActor(manifest, "idle", scene)       -- 3-arg
-
--- Asset Pool Integration (pooled sheet data, private animation state)
+-- Pooled sheet descriptors keep private playback state per actor
 local pooledActor = RoxyActor({
   sheet = { poolKey = "character_sheet_pool", kind = "sheet" }
 }, scene)
 
 -- Cleanup
-player:clearPhysics() -- Remove physics integration
-player:remove()       -- Remove from scene
-player:destroy()      -- Full cleanup
-
--- Querying Actor State
-if player.currentState == "jump" then
-  Log.debug("Player is jumping!")
-end
-
+pooledActor:remove()
+player:remove()
 --]]

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -13,6 +13,7 @@ local newImageTable     <const> = Graphics.imagetable.new
 local r       <const> = roxy
 local Assets  <const> = r.Assets
 local Camera  <const> = r.Camera
+local Scene   <const> = r.Scene
 
 local round <const> = r.Math.round
 
@@ -121,6 +122,11 @@ end
 --------------------------------------------------------------------------------
 -- Sprite Setup
 --------------------------------------------------------------------------------
+
+-- ! Set Pause Classification
+function RoxySprite:setPauseClassification(opts)
+  return Scene.setSpritePauseClassification(self, opts)
+end
 
 -- ! Set Ignores Draw Offset
 function RoxySprite:setIgnoresDrawOffset(flag)
@@ -984,6 +990,7 @@ player:moveTo(100, 100)
 player:setZIndex(10)
 player:setCenter(0.5, 1.0)
 player:setCollisionsEnabled(false)
+player:setPauseClassification(nil) -- Default dynamic scene pause behavior
 
 -- Full Animation Sprite
 local enemy = RoxySprite({

--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -1,5 +1,27 @@
 -- core/sprites/RoxySprite.lua
 
+--------------------------------------------------------------------------------
+-- RoxySprite - Scene-Aware Sprite, Animation, and Parallax Wrapper
+--------------------------------------------------------------------------------
+--
+-- Extends Playdate sprites with Roxy scene ownership, view management,
+-- animation helpers, simple spritesheet playback, parallax positioning,
+-- pause classification, and pooled asset cleanup.
+--
+-- Key Features:
+--  - Static image, simple spritesheet, full RoxyAnimation, and pooled views
+--  - frameRate config with frameDuration compatibility for simple animations
+--  - Scene-aware pause, update, collision, and remove behavior
+--  - Camera-relative parallax positioning
+--  - Retained and pooled view-resource lifecycle cleanup
+--
+-- Timing Contract:
+--  - Simple animations default to 30 FPS when no cadence is provided
+--  - frameDuration is stored as seconds per animation frame
+--  - frameDuration takes precedence when both frameDuration and frameRate are set
+--
+--------------------------------------------------------------------------------
+
 local floor <const> = math.floor
 
 local pd        <const> = playdate
@@ -10,17 +32,19 @@ local performAfterDelay <const> = pd.timer.performAfterDelay
 local newImage          <const> = Graphics.image.new
 local newImageTable     <const> = Graphics.imagetable.new
 
-local r       <const> = roxy
-local Assets  <const> = r.Assets
-local Camera  <const> = r.Camera
-local Scene   <const> = r.Scene
+local r             <const> = roxy
+local Assets        <const> = r.Assets
+local Camera        <const> = r.Camera
+local Scene         <const> = r.Scene
+local RoxyGraphics  <const> = r.Graphics
 
-local round <const> = r.Math.round
+local clamp <const> = r.Math.clamp
 
-local getAsset      <const> = Assets.getAsset
-local recycleAsset  <const> = Assets.recycleAsset
-local getPosition   <const> = Camera.getPosition
-local worldToScreen <const> = Camera.worldToScreen
+local getAsset        <const> = Assets.getAsset
+local recycleAsset    <const> = Assets.recycleAsset
+local getPosition     <const> = Camera.getPosition
+local worldToScreen   <const> = Camera.worldToScreen
+local getRefreshRate  <const> = RoxyGraphics.getRefreshRate
 
 local UNFLIPPED   <const> = Graphics.kImageUnflipped
 local FLIPPED_X   <const> = Graphics.kImageFlippedX
@@ -28,7 +52,6 @@ local FLIPPED_Y   <const> = Graphics.kImageFlippedY
 local FLIPPED_X_Y <const> = Graphics.kImageFlippedXY
 
 local MS_PER_SECOND <const> = 1000
-
 local DELAY_DEFAULT <const> = 1 -- Seconds
 
 local DISPLAY_WIDTH   <const> = r.Graphics.displayWidth
@@ -39,8 +62,13 @@ local SCREEN_TOP_LIMIT    <const> = 0
 local SCREEN_RIGHT_LIMIT  <const> = DISPLAY_WIDTH
 local SCREEN_BOTTOM_LIMIT <const> = DISPLAY_HEIGHT
 
+local FRAME_RATE_DEFAULT      <const> = 30
+local FRAME_DURATION_DEFAULT  <const> = 1 / FRAME_RATE_DEFAULT
+local MIN_FRAME_DURATION      <const> = 0.016
+local MAX_FRAME_DURATION      <const> = 10
+
 --------------------------------------------------------------------------------
--- Helpers
+-- Private Helper Functions
 --------------------------------------------------------------------------------
 
 -- ! Helper: Has Parallax
@@ -56,11 +84,67 @@ local function _setCollisionsActive(sprite, flag)
   RoxySprite.super.setCollisionsEnabled(sprite, flag)
 end
 
+-- ! Helper: Resolve Simple Frame Rate
+local function _resolveSimpleFrameRate(frameRate, fallbackDuration, label, warnOnInvalid)
+  local frameRateType = type(frameRate)
+  if frameRateType == "number" and frameRate > 0 then
+    return 1 / frameRate
+  end
+
+  if frameRate == "display" then
+    local displayRate = getRefreshRate(true)
+    if type(displayRate) == "number" and displayRate > 0 then
+      return 1 / displayRate
+    end
+    if warnOnInvalid then
+      Log.warn("[" .. label .. "] frameRate=\"display\" could not resolve a positive display refresh rate, got " .. tostring(displayRate)) --#DEBUG
+    end
+    return fallbackDuration
+  end
+
+  if warnOnInvalid then
+    Log.warn("[" .. label .. "] frameRate must be a positive number or \"display\", got " .. frameRateType) --#DEBUG
+  end
+  return fallbackDuration
+end
+
+-- ! Helper: Resolve Simple Frame Duration Config
+local function _resolveSimpleFrameDuration(frameDuration, frameRate, fallbackDuration, label)
+  if frameDuration ~= nil then
+    return frameDuration
+  end
+  if frameRate ~= nil then
+    return _resolveSimpleFrameRate(frameRate, fallbackDuration, label, true)
+  end
+  return fallbackDuration
+end
+
+-- ! Helper: Resolve Simple Frame Rate Setter
+local function _resolveSimpleFrameRateSetter(frameRate)
+  assert(
+    (type(frameRate) == "number" and frameRate > 0) or frameRate == "display",
+    "[RoxySprite:setFrameRate] Frame rate must be a positive number or \"display\""
+  )
+
+  if frameRate == "display" then
+    local displayRate = getRefreshRate(true)
+    assert(type(displayRate) == "number" and displayRate > 0,
+           "[RoxySprite:setFrameRate] Display refresh rate must be a positive number")
+    return 1 / displayRate
+  end
+
+  return 1 / frameRate
+end
+
 --------------------------------------------------------------------------------
--- Class Definition and Init
+-- Class Definition
 --------------------------------------------------------------------------------
 
 class("RoxySprite").extends(Sprite)
+
+--------------------------------------------------------------------------------
+-- Initialization
+--------------------------------------------------------------------------------
 
 -- ! Initialize
 function RoxySprite:init(options, scene)
@@ -109,7 +193,8 @@ function RoxySprite:init(options, scene)
       options.isSheet,
       options.singleAnimation,
       options.singleAnimationLoop ~= false,
-      options.frameDuration or 0.1
+      options.frameDuration,
+      options.frameRate
     )
   end
 
@@ -353,6 +438,7 @@ local function _setupSimpleAnimation(sprite, imagetable, frameDuration, loop)
   if not frameDuration or frameDuration <= 0 then
     error("[RoxySprite:setView] frameDuration must be > 0 for simpleAnimation", 3)
   end
+  frameDuration = clamp(frameDuration, MIN_FRAME_DURATION, MAX_FRAME_DURATION)
 
   sprite.simpleAnimation = {
     imagetable    = imagetable,
@@ -375,12 +461,10 @@ local function _setupSimpleAnimation(sprite, imagetable, frameDuration, loop)
 end
 
 -- ! Set View
-function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnimationLoop, frameDuration)
-  --#DEBUG START
+function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnimationLoop, frameDuration, frameRate)
   if self._destroyed then
     error("[RoxySprite:setView] Cannot set view on destroyed sprite", 2)
   end
-  --#DEBUG END
 
   if not view then
     self:setVisible(false)
@@ -438,7 +522,13 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
       if singleAnimation then
         -- Simple looping spritesheet
         local imagetable = newImageTable(view)
-        _setupSimpleAnimation(self, imagetable, frameDuration or 0.1, singleAnimationLoop ~= false)
+        local resolvedFrameDuration = _resolveSimpleFrameDuration(
+          frameDuration,
+          frameRate,
+          FRAME_DURATION_DEFAULT,
+          "RoxySprite:setView"
+        )
+        _setupSimpleAnimation(self, imagetable, resolvedFrameDuration, singleAnimationLoop ~= false)
       else
         -- Full RoxyAnimation
         self.animation = RoxyAnimation(view) -- Path-based constructor
@@ -466,7 +556,13 @@ function RoxySprite:setView(view, viewIsSpritesheet, singleAnimation, singleAnim
     -- Handle ImageTable or Image userdata
     if view.drawImage then
       -- ImageTable - treat as simple animation
-      _setupSimpleAnimation(self, view, frameDuration or 0.1, singleAnimationLoop ~= false)
+      local resolvedFrameDuration = _resolveSimpleFrameDuration(
+        frameDuration,
+        frameRate,
+        FRAME_DURATION_DEFAULT,
+        "RoxySprite:setView"
+      )
+      _setupSimpleAnimation(self, view, resolvedFrameDuration, singleAnimationLoop ~= false)
     elseif view.draw then
       -- Image
       self:setImage(view)
@@ -719,6 +815,9 @@ function RoxySprite:getFrameDuration()
   if self.animation then
     return self.animation:getFrameDuration()
   end
+  if self.simpleAnimation then
+    return self.simpleAnimation.frameDuration
+  end
   return nil
 end
 
@@ -729,6 +828,8 @@ function RoxySprite:setFrameDuration(frameDuration, currentOnly)
 
   if self.animation then
     self.animation:setFrameDuration(frameDuration, currentOnly)
+  elseif self.simpleAnimation then
+    self.simpleAnimation.frameDuration = clamp(frameDuration, MIN_FRAME_DURATION, MAX_FRAME_DURATION)
   --#DEBUG START
   else
     Log.warn("[RoxySprite:setFrameDuration] Sprite has no animation system")
@@ -736,6 +837,19 @@ function RoxySprite:setFrameDuration(frameDuration, currentOnly)
   end
 
   return self
+end
+
+-- ! Get Frame Rate
+function RoxySprite:getFrameRate()
+  local frameDuration = self:getFrameDuration()
+  if not frameDuration or frameDuration <= 0 then return nil end
+  return 1 / frameDuration
+end
+
+-- ! Set Frame Rate
+function RoxySprite:setFrameRate(frameRate, currentOnly)
+  local frameDuration = _resolveSimpleFrameRateSetter(frameRate)
+  return self:setFrameDuration(frameDuration, currentOnly)
 end
 
 --------------------------------------------------------------------------------
@@ -977,10 +1091,8 @@ end
 --------------------------------------------------------------------------------
 
 --[[
-
 RoxySprite wraps Playdate sprites with image, animation, parallax, and scene ownership helpers.
 
--- Static Image Sprite
 local player = RoxySprite({
   name = "PlayerSprite",
   view = "images/player-idle",
@@ -992,7 +1104,6 @@ player:setCenter(0.5, 1.0)
 player:setCollisionsEnabled(false)
 player:setPauseClassification(nil) -- Default dynamic scene pause behavior
 
--- Full Animation Sprite
 local enemy = RoxySprite({
   name = "Enemy",
   view = "images/enemy-walk",
@@ -1004,37 +1115,39 @@ enemy:addAnimation({
   startFrame = 1,
   endFrame = 4,
   loop = true,
+  frameRate = 10,
 })
 enemy:addAnimation({
   name = "attack",
   startFrame = 5,
   endFrame = 7,
   next = "walk",
+  frameRate = "display",
 })
 enemy:setAnimation("walk"):play()
 enemy:setSpeed(1.5)
-enemy:setFrameDuration(0.08)
+enemy:setFrameRate(12) -- Applies to all full-animation clips
 enemy:drawSpecificFrame(1, true)
 enemy:stepFrame(1)
 
--- Simple Looping Spritesheet
 local coin = RoxySprite({
   name = "Coin",
   view = "images/coin-spin",
   isSheet = true,
   singleAnimation = true,
   singleAnimationLoop = true,
-  frameDuration = 0.12,
+  frameRate = "display",
 }, scene)
+-- Omit frameRate/frameDuration for the 30 FPS simple-animation default
 coin:play()
+coin:setFrameRate(15)
 
--- Parallax Background Layer
 local mountains = RoxySprite({
   name = "Mountains",
   view = "images/mountains",
   worldX = 400,
   worldY = 240,
-  parallaxX = 0.3, -- Moves slower than camera
+  parallaxX = 0.3,
   parallaxY = 0.1,
   parallaxOriginX = 200,
   parallaxOriginY = 120,
@@ -1043,14 +1156,19 @@ mountains:setWorldPosition(420, 240)
 mountains:setParallax(0.25, 0.1)
 mountains:setParallaxOrigin(200, 120)
 
--- Scene Ownership and Cleanup
+-- After registering an image pool with Assets.registerPool
+local pooledItem = RoxySprite({
+  name = "PooledItem",
+  view = { poolKey = "item_image_pool", kind = "image" },
+}, scene)
+
 local looseSprite = RoxySprite({ name = "LooseSprite", view = "images/item" })
 scene:addSprite(looseSprite)
 local screenX, screenY = looseSprite:getScreenPosition()
 local onScreen = looseSprite:isOnScreen()
 
 looseSprite:flipX()
+pooledItem:clearView()
 looseSprite:removeAndClearView()
-looseSprite:destroy()
-
+enemy:destroy()
 --]]

--- a/utilities/Graphics.lua
+++ b/utilities/Graphics.lua
@@ -13,8 +13,9 @@ local PLAYDATE_HEIGHT <const>       = 240 -- Native Playdate screen height (px)
 
 -- ! Get Refresh Rate
 -- Returns cached display refresh rate, or 30 FPS fallback on failure.
-function RoxyGraphics.getRefreshRate()
-  if not RoxyGraphics.refreshRate then
+-- Pass forceRefresh=true after changing playdate.display refresh rate.
+function RoxyGraphics.getRefreshRate(forceRefresh)
+  if forceRefresh or not RoxyGraphics.refreshRate then
     local success, rate = pcall(Display.getRefreshRate)
     RoxyGraphics.refreshRate = success and rate or DEFAULT_REFRESH_RATE
     --#DEBUG START


### PR DESCRIPTION
### Overview
This release adds frame-rate-based animation cadence controls and fixes stacked scene rendering so full-screen scenes that block lower drawing also hide lower scene-owned sprites. It gives Playdate developers clearer animation timing options while tightening scene stack behavior for overlays, menus, and full-screen pushed scenes.

### Key Changes
- Added `frameRate` support alongside `frameDuration` for `RoxyAnimation` clips, `RoxySprite` simple animations, and `RoxyActor` row manifests.
- Added `getFrameRate` / `setFrameRate` helpers, including support for `frameRate = "display"` to resolve cadence from the Playdate display refresh rate.
- Kept `frameDuration` as the stored runtime cadence and precedence winner when both `frameDuration` and `frameRate` are provided.
- Updated simple `RoxySprite` animations to default to 30 FPS for smoother out-of-the-box playback.
- Fixed `blocksLowerDraw` scene stacking so lower scene-owned sprites are hidden while a blocking full-screen scene is on top, then restored to their desired visibility afterward.
- Preserved raw Playdate sprite pause classification through `roxy.Scene.setSpritePauseClassification(sprite, opts)` while keeping `RoxySprite:setPauseClassification(opts)` available.

### Breaking Changes
- Simple `RoxySprite` animations now default to 30 FPS instead of 10 FPS. Set `frameRate = 10` or `frameDuration = 0.1` to keep the old cadence.
- Raw Playdate sprites should use `roxy.Scene.setSpritePauseClassification(sprite, opts)` instead of relying on a patched SDK sprite method. `RoxySprite:setPauseClassification(opts)` remains available for Roxy sprites.

### Challenges/Notes
- `blocksLowerDraw = false` remains the right setting for overlay scenes that should keep lower scenes visible.
- `blocksLowerDraw = true` now hides both lower scene draw output and lower scene-owned sprites, which is the intended behavior for full-screen pushed scenes.