### PR TITLE
[0.17.2] - Fix Animation Completion and Optimize CrossDissolve

### DIFF
--- a/core/animations/RoxyAnimation.lua
+++ b/core/animations/RoxyAnimation.lua
@@ -277,6 +277,10 @@ function RoxyAnimation:_initCommon()
   self.isFirstCycle     = true
   self.isReversed       = false
   self.accumulator      = 0
+  self._completeFired   = false
+  self._pendingNext     = nil
+  self._switchNextTick  = nil
+  self._tailHoldSec     = 0
   self._refcount        = 1
   self._destroyed       = false
   self._path            = nil
@@ -412,8 +416,9 @@ function RoxyAnimation:_buildAnimationConfig(opts)
   animation.exitTime = (opts.exitTime ~= nil) and max(0, min(1, opts.exitTime)) or 1.0
   animation.nextDelay = (type(opts.nextDelay) == "number" and opts.nextDelay > 0) and opts.nextDelay or 0
 
-  -- Precompute frame count for performance
+  -- Precompute frame counts for performance
   animation.range = animation.endFrame - animation.startFrame + 1
+  animation.progressDenominator = max(1, animation.endFrame - animation.startFrame)
 
   return animation
 end
@@ -441,6 +446,8 @@ function RoxyAnimation:setAnimation(name, nextContinuity, unlessThisAnimation)
   -- Reset cycle state unless continuing from previous animation
   if not nextContinuity then
     self:resetAnimationStart()
+  else
+    self:_clearCompletionState()
   end
 
   return self
@@ -451,6 +458,7 @@ end
 function RoxyAnimation:stop()
   self.currentAnimation = nil
   self.currentName = nil
+  self:_clearCompletionState()
   return self
 end
 
@@ -466,7 +474,20 @@ end
 function RoxyAnimation:resetAnimationStart()
   self.isFirstCycle = true
   self.accumulator = 0
+  if self.currentAnimation then
+    self.currentFrame = self.currentAnimation.startFrame
+  end
+  self:_clearCompletionState()
   return self
+end
+
+-- ! Clear Completion State
+-- Reset completion guards and any deferred completion transition
+function RoxyAnimation:_clearCompletionState()
+  self._completeFired = false
+  self._pendingNext = nil
+  self._switchNextTick = nil
+  self._tailHoldSec = 0
 end
 
 --------------------------------------------------------------------------------
@@ -755,21 +776,28 @@ end
 -- ! Handle Non-Loop Completion
 -- Handle completion behavior for non-looping animations
 function RoxyAnimation:_handleNonLoopCompletion(animation)
+  if self._completeFired then return end
+
   local exitTime  = animation.exitTime or 1
   local nextDelay = animation.nextDelay or 0
 
   -- Compute normalized progress 0..1
-  local range = animation.endFrame - animation.startFrame
-  local denominator = (range ~= 0) and range or 1
+  local denominator = animation.progressDenominator or 1
   local progressed = self.isReversed
     and (animation.endFrame - self.currentFrame)
     or  (self.currentFrame - animation.startFrame)
   local progress = progressed / denominator
 
   if progress >= exitTime then
+    self._completeFired = true
+
     -- Fire onComplete once we reach exitTime
     if type(animation.onCompleteCallback) == "function" then
       animation.onCompleteCallback()
+    end
+
+    if self.currentAnimation ~= animation then
+      return
     end
 
     if animation.next then

--- a/core/transitions/CrossDissolve.lua
+++ b/core/transitions/CrossDissolve.lua
@@ -11,7 +11,6 @@ local Config    <const> = r.Config
 local Assets    <const> = r.Assets
 local Registry  <const> = r.AssetPoolRegistry
 local Ease      <const> = r.EasingFunctions
-local Scene     <const> = r.Scene
 
 -- Config
 local getTransitionConfig <const> = Config.getTransitionConfig
@@ -45,16 +44,8 @@ local STACK_OP_POP      <const> = RoxyTransition.STACK_OP_POP
 -- Transition binding cache
 local transitionBindingCache = {}
 
-local function resolveTransitionBinding(bindingName)
-  local fn = transitionBindingCache[bindingName]
-  if fn then return fn end
-
-  local transition = roxy and roxy.Transition
-  fn = transition and transition[bindingName]
-  assert(type(fn) == "function", "[TransitionBinding] missing roxy.Transition." .. bindingName)
-  transitionBindingCache[bindingName] = fn
-  return fn
-end
+-- CrossDissolve pattern cache
+local patternCache = {}
 
 -- Graphics constants
 local COLOR_BLACK       <const> = Graphics.kColorBlack
@@ -62,7 +53,6 @@ local COLOR_WHITE       <const> = Graphics.kColorWhite
 local DITHER_BAYER_8X8  <const> = Image.kDitherTypeBayer8x8
 
 -- Easing constants
-local FLAT_EASING    <const> = Ease.flat
 local LINEAR_EASING <const> = Ease.linear
 
 -- Defaults
@@ -96,12 +86,43 @@ local EMPTY_TABLE       <const> = {}
 -- Helpers
 --------------------------------------------------------------------------------
 
+-- ! Resolve Transition Binding
+-- Resolve and cache a transition draw binding
+local function resolveTransitionBinding(bindingName)
+  local fn = transitionBindingCache[bindingName]
+  if fn then return fn end
+
+  local transition = roxy and roxy.Transition
+  fn = transition and transition[bindingName]
+  assert(type(fn) == "function", "[TransitionBinding] missing roxy.Transition." .. bindingName)
+  transitionBindingCache[bindingName] = fn
+  return fn
+end
+
+-- ! Get Pattern Cache Bucket
+-- Return the pattern cache bucket for an effective dither and patch size
+local function getPatternCacheBucket(dither, patchSize)
+  local byDither = patternCache[dither]
+  if not byDither then
+    byDither = {}
+    patternCache[dither] = byDither
+  end
+
+  local byPatchSize = byDither[patchSize]
+  if not byPatchSize then
+    byPatchSize = {}
+    byDither[patchSize] = byPatchSize
+  end
+
+  return byPatchSize
+end
+
 -- ! Initialize Asset Pool
 -- Initialize asset pools (called once per module)
 local function initializeAssetPool()
   ensurePool(
-    SEQUENCE_POOL_KEY,  -- key
-    1,                  -- initialCount
+    SEQUENCE_POOL_KEY,  -- Key
+    1,                  -- Initial Count
     function() return RoxySequence() end, {
       maxSize = 4,
       growthFactor = 1
@@ -166,6 +187,7 @@ function CrossDissolve:init(opts)
 
   -- Screenshots
   self._screenshot = nil
+  self._drawFrame = nil
 end
 
 --------------------------------------------------------------------------------
@@ -179,6 +201,10 @@ function CrossDissolve:_createPatternArray()
   local dither = self.dither
   local fadeSteps = self.fadeSteps
   local patchSize = self.patchSize
+  local patternBucket = getPatternCacheBucket(dither, patchSize)
+  local cachedPatterns = patternBucket[fadeSteps]
+  if cachedPatterns then return cachedPatterns end
+
   local oneOverSteps = 1 / (fadeSteps - 1)
   local tiles = ceil(TILE_SIZE / patchSize)
 
@@ -207,6 +233,7 @@ function CrossDissolve:_createPatternArray()
     patterns[i] = tileImage
   end
 
+  patternBucket[fadeSteps] = patterns
   return patterns
 end
 
@@ -265,6 +292,7 @@ end
 function CrossDissolve:execute(newScene, currentScene)
   CrossDissolve.super.execute(self, newScene, currentScene)
 
+  self._drawFrame = resolveTransitionBinding("crossDissolveDrawFrame")
   self:_setupSequence()
   self._screenshot = getDisplayImage()
   self:_onStart()
@@ -290,7 +318,11 @@ function CrossDissolve:draw()
   -- Calculate pattern index based on alpha value
   local idx = min(fadeSteps, floor(alpha * fadeStepsMinus1) + 1)
   local pattern = patterns[idx]
-  local drawFrame = resolveTransitionBinding("crossDissolveDrawFrame")
+  local drawFrame = self._drawFrame
+  if not drawFrame then
+    drawFrame = resolveTransitionBinding("crossDissolveDrawFrame")
+    self._drawFrame = drawFrame
+  end
   drawFrame(screenshot, pattern)
 end
 
@@ -305,6 +337,7 @@ function CrossDissolve:cleanup()
 
   self.patterns = nil
   self._screenshot = nil
+  self._drawFrame = nil
 
   Log.debug("Transition '" .. self.name .. "' cleanup completed") --#DEBUG
 end
@@ -314,3 +347,50 @@ end
 function CrossDissolve:warmUpAssetPool()
   initializeAssetPool()
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+CrossDissolve mixes scene swaps with tiled dither masks.
+Masks are cached internally for matching effective dither, fadeSteps, and patchSize values.
+
+-- Basic Scene Change
+roxy.Transition.replaceScene(GameplayScene, "CrossDissolve", {
+  duration = 0.35,
+  dither = playdate.graphics.image.kDitherTypeBayer4x4,
+  fadeSteps = 17,
+  patchSize = 8,
+})
+
+-- Push / Pop Flow
+roxy.Transition.pushScene(PauseScene, "CrossDissolve", {
+  duration = 0.25,
+  captureScreenshot = true,
+})
+roxy.Transition.popScene("CrossDissolve", {
+  duration = 0.2,
+})
+
+-- Config-Driven Defaults
+roxy.Config.applyOverrides({
+  transitions = {
+    overrides = {
+      CrossDissolve = {
+        duration = 0.4,
+        dither = playdate.graphics.image.kDitherTypeBayer8x8,
+        fadeSteps = 32,
+        patchSize = 8,
+      },
+    },
+  },
+})
+roxy.Transition.reloadTransitionsWithNewConfig()
+roxy.Transition.replaceScene(TitleScene, "CrossDissolve")
+
+-- Optional Asset Pool Warm-Up
+CrossDissolve:warmUpAssetPool()
+
+--]]


### PR DESCRIPTION
### Overview
This release fixes non-looping animation completion behavior and reduces CrossDissolve transition overhead. Playdate games should see more predictable animation callbacks and lower repeated allocation/lookup cost when using CrossDissolve transitions frequently.

### Key Changes
- Fixed non-looping `RoxyAnimation` completion so completion callbacks fire once per playback instead of repeating after the exit point.
- Kept completed non-looping animations pinned on their terminal frame after completion.
- Cached CrossDissolve dither pattern arrays for matching effective transition configs to avoid rebuilding the same bitmap masks repeatedly.
- Resolved the CrossDissolve draw binding before the render loop to avoid a per-frame binding lookup.
- Refreshed CrossDissolve usage examples for scene changes, push/pop flows, config defaults, and pool warm-up.

### Breaking Changes
None.

### Challenges/Notes
No migration is required. Existing CrossDissolve options and animation call patterns remain compatible.