### PR TITLE
[0.17.3] - Harden Assets and Optimize Tilemaps

### DIFF
--- a/core/modules/AssetPoolRegistry.lua
+++ b/core/modules/AssetPoolRegistry.lua
@@ -1,57 +1,35 @@
 -- core/modules/AssetPoolRegistry.lua
 
---------------------------------------------------------------------------------
--- AssetPoolRegistry - Asset Pool Registration and Lifecycle Management
---------------------------------------------------------------------------------
---
--- Provides centralized pool registration for Roxy asset types, including
--- tracking mechanisms for identifying pooled assets and ensuring consistent
--- pool initialization across the framework.
---
--- Key Features:
---  - Pool registration with lazy initialization
---  - Weak-reference tagging for pool-sourced assets
---  - Ownership tracking by origin pool key
---  - Convenience wrappers for path-based and object-based pools
---  - Integration with roxy.Assets core pooling system
---
--- Pool Key Contract:
---  - key must be a non-empty string
---  - key cannot have leading/trailing whitespace
---
---------------------------------------------------------------------------------
+-- Tracks asset pool ownership with weak keys and wraps pool registration
+-- Pool keys must be non-empty strings without leading or trailing whitespace
 
 roxy = roxy or {}
 roxy.AssetPoolRegistry = roxy.AssetPoolRegistry or {}
 local Registry <const> = roxy.AssetPoolRegistry
 
---------------------------------------------------------------------------------
--- Roxy Framework Function Aliases
---------------------------------------------------------------------------------
+-- Imported by Assets.lua after asset pool functions exist, so these aliases
+-- intentionally capture the current Assets table and methods
+local r       <const> = roxy
+local Assets  <const> = r.Assets
 
--- Asset functions
-local Assets              <const> = roxy.Assets
+local stringFormat <const> = string.format --#DEBUG
+
 local getIsPoolRegistered <const> = Assets.getIsPoolRegistered
 local registerPool        <const> = Assets.registerPool
 
--- String functions
-local stringFormat        <const> = string.format
-
---------------------------------------------------------------------------------
--- Local State Variables
---------------------------------------------------------------------------------
-
--- Weak-key map to remember pooled ownership by origin pool key.
--- value: string pool key (owned)
+-- Weak-key map to remember pooled ownership by origin pool key
+-- Value: string pool key (owned)
 local poolTag = setmetatable({}, { __mode = "k" })
 
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
+--#DEBUG START
 local function _formatPoolKeyValue(key)
   return stringFormat("%q", tostring(key))
 end
+--#DEBUG END
 
 local function _isValidPoolKey(key)
   if type(key) ~= "string" then return false end
@@ -138,7 +116,7 @@ end
 function Registry.markFromPoolDirect(asset, key)
   --#DEBUG START
   if type(key) ~= "string" then
-    Log.warn("[AssetPoolRegistry.markFromPoolDirect] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
+    Log.warn("[AssetPoolRegistry.markFromPoolDirect] invalid pool key: " .. _formatPoolKeyValue(key))
     return asset
   end
   --#DEBUG END
@@ -152,8 +130,8 @@ end
 --  @param asset Asset instance to check
 --
 --  @return originKey, isPooled (two values)
---    (string, true)  — asset is owned by the named pool
---    (nil,    false) — asset is not tagged at all
+--    (string, true)  - asset is owned by the named pool
+--    (nil,    false) - asset is not tagged at all
 
 function Registry.getOriginKey(asset)
   local tag = poolTag[asset]
@@ -163,7 +141,7 @@ end
 
 -- ! Clear From Pool Direct
 -- Fast-path tag removal. Skips nil-asset guard.
--- Caller contract: asset ~= nil.
+-- Caller contract: asset ~= nil
 --  @param asset Asset instance to untag
 
 function Registry.clearFromPoolDirect(asset)
@@ -217,7 +195,7 @@ function Registry.ensurePool(key, initialCount, loader, options)
 end
 
 -- ! Ensure For Path
--- Convenience wrapper for path-based asset pools (images, sounds, etc)
+-- Convenience wrapper for path-based asset pools (images, sounds, and similar)
 --  @param key         Non-empty string key for the pool (no leading/trailing whitespace)
 --  @param assetPath   File path to the asset resource
 --  @param constructor Function that creates the asset (e.g., playdate.graphics.image.new)
@@ -248,3 +226,62 @@ function Registry.ensureForObject(key, object, opts)
     opts
   )
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+AssetPoolRegistry wraps pool registration and tracks asset ownership.
+
+local Registry <const> = roxy.AssetPoolRegistry
+local Assets   <const> = roxy.Assets
+
+-- Register or Ensure a Pool
+Registry.ensurePool("particles/smoke", 2, function()
+  return playdate.graphics.image.new("images/particle-smoke")
+end, {
+  maxSize = 6,
+  growthFactor = 2,
+})
+
+local smoke = Assets.getAsset("particles/smoke")
+if Registry.isFromPool(smoke) then
+  Assets.recycleAsset(Registry.getPoolKey(smoke), smoke)
+end
+
+-- Path-Based Pool
+Registry.ensureForPath(
+  "ui/button",
+  "images/ui-button",
+  playdate.graphics.image.new,
+  {
+    initialCount = 1,
+    maxSize = 3,
+  }
+)
+
+local buttonImage = Assets.getAsset("ui/button")
+Assets.recycleAsset("ui/button", buttonImage)
+
+-- Object Pool
+local sharedBadge = playdate.graphics.image.new("images/badge")
+Registry.ensureForObject("ui/badge", sharedBadge, {
+  initialCount = 1,
+  maxSize = 1,
+})
+
+local badge = Assets.getAsset("ui/badge")
+Assets.recycleAsset("ui/badge", badge)
+
+-- Manual Ownership Tags
+local previewImage = playdate.graphics.image.new("images/preview")
+Registry.markFromPool(previewImage, "manual/preview")
+
+local originKey, isPooled = Registry.getOriginKey(previewImage)
+if isPooled then
+  Registry.clearFromPool(previewImage)
+end
+
+--]]

--- a/core/modules/AssetStore.lua
+++ b/core/modules/AssetStore.lua
@@ -1,62 +1,24 @@
 -- core/modules/AssetStore.lua
 
---------------------------------------------------------------------------------
--- AssetStore - Reference-Counted Asset Management
---------------------------------------------------------------------------------
---
--- Provides high-level asset loading and lifecycle management with automatic
--- reference counting. Integrates with roxy.Cache for storage and implements
--- retain/release semantics for memory-efficient asset sharing.
---
--- Key Features:
---  - Reference counting for shared asset lifecycle management
---  - Loader function support for asset initialization
---  - Cached image and imagetable loading with path validation
---  - Integration with roxy.Cache for centralized asset storage
---
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
--- Global Table Initialization
---------------------------------------------------------------------------------
+-- Provides reference-counted asset caching with image and imagetable helpers
 
 roxy = roxy or {}
 roxy.AssetStore = roxy.AssetStore or {}
 local AssetStore <const> = roxy.AssetStore
 
---------------------------------------------------------------------------------
--- Playdate SDK Aliases
---------------------------------------------------------------------------------
-
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
-
---------------------------------------------------------------------------------
--- Playdate SDK Function Aliases
---------------------------------------------------------------------------------
 
 local newImage      <const> = Graphics.image.new
 local newImagetable <const> = Graphics.imagetable.new
 
---------------------------------------------------------------------------------
--- Roxy Framework Aliases
---------------------------------------------------------------------------------
-
 local r     <const> = roxy
 local Cache <const> = r.Cache
-
---------------------------------------------------------------------------------
--- Roxy Framework Function Aliases
---------------------------------------------------------------------------------
 
 local getCachedAsset    <const> = Cache.getCachedAsset
 local cacheAsset        <const> = Cache.cacheAsset
 local evictAsset        <const> = Cache.evictAsset
 local getIsAssetCached  <const> = Cache.getIsAssetCached
-
---------------------------------------------------------------------------------
--- Local State Variables
---------------------------------------------------------------------------------
 
 -- Reference count table for asset retention tracking
 local referenceCount = {}
@@ -67,10 +29,9 @@ local referenceCount = {}
 
 -- ! Retain Asset
 -- Increments the reference count for an asset and caches it if not already stored
---  @param path          Unique path string identifying the asset
---  @param assetOrThunk  Either a concrete asset value or a thunk function that creates it
---
---  @return Boolean true on success
+-- @param path Unique path string identifying the asset
+-- @param assetOrThunk Concrete asset value or thunk function that creates it
+-- @return Boolean true on success
 
 function AssetStore.retain(path, assetOrThunk)
   if type(path) ~= "string" or path == "" then
@@ -103,11 +64,15 @@ end
 
 -- ! Release Asset
 -- Decrements the reference count for an asset and evicts it when count reaches zero
---  @param path Unique path string identifying the asset to release
---
---  @return None
+-- @param path Non-empty path string identifying the asset to release
+-- @return None
 
 function AssetStore.release(path)
+  if type(path) ~= "string" or path == "" then
+    Log.warn("[AssetStore.release] Invalid or missing path: " .. tostring(path)) --#DEBUG
+    return
+  end
+
   local count = referenceCount[path]
   if not count then return end
 
@@ -121,9 +86,8 @@ end
 
 -- ! Get Imagetable
 -- Loads and caches an imagetable asset
---  @param path File path string to the imagetable resource
---
---  @return The imagetable instance, or nil if path is invalid or loading fails
+-- @param path File path string to the imagetable resource
+-- @return Imagetable instance, or nil if path is invalid or loading fails
 
 function AssetStore.getImagetable(path)
   if type(path) ~= "string" or path == "" then
@@ -148,9 +112,8 @@ end
 
 -- ! Get Image Cached
 -- Loads and caches an image asset
---  @param path File path string to the image resource
---
---  @return The image instance, or nil if path is invalid or loading fails
+-- @param path File path string to the image resource
+-- @return Image instance, or nil if path is invalid or loading fails
 
 function AssetStore.getImageCached(path)
   if type(path) ~= "string" or path == "" then

--- a/core/modules/Assets.lua
+++ b/core/modules/Assets.lua
@@ -1,52 +1,16 @@
 -- core/modules/Assets.lua
 
---------------------------------------------------------------------------------
--- Assets - Roxy Asset Pool Management System
---------------------------------------------------------------------------------
---
--- Provides object pooling for efficient reuse of expensive game assets like
--- sprites, images, and other resources. Reduces garbage collection pressure
--- and improves performance by pre-allocating and recycling objects.
---
--- Key Features:
---  - Dynamic pool registration with custom loader functions
---  - Automatic pool growth up to configurable max size
---  - Configurable initial size, max size, and growth factor
---  - Asset recycling to minimize allocations
---  - Pool availability and capacity tracking
---  - Integration with AssetPoolRegistry for declarative setup
---
--- Usage Pattern:
---  1. Register pool with Assets.registerPool(key, count, loader, options)
---  2. Acquire asset with Assets.getAsset(key)
---  3. Use asset in game logic
---  4. Return asset with Assets.recycleAsset(key, asset)
---
--- Pool Key Contract:
---  - key must be a non-empty string
---  - key cannot have leading/trailing whitespace
---  - key-shape validation in getAsset/recycleAsset is debug-only in stripped
---    release builds; production still fails soft via pool lookup/ownership checks
---
---------------------------------------------------------------------------------
+-- Manages reusable asset pools with lazy growth and ownership checks
+-- Pool keys must be non-empty strings without leading or trailing whitespace
+-- Key-shape checks in getAsset/recycleAsset strip from release; lookups fail soft
 
 roxy = roxy or {}
 roxy.Assets = roxy.Assets or {}
 local Assets <const> = roxy.Assets
 
---------------------------------------------------------------------------------
--- Standard Lua Function Aliases
---------------------------------------------------------------------------------
-
--- Math functions
 local min <const> = math.min
 
--- String functions
-local stringFormat <const> = string.format
-
---------------------------------------------------------------------------------
--- Local State Variables
---------------------------------------------------------------------------------
+local stringFormat <const> = string.format --#DEBUG
 
 -- Asset pool registry (indexed by pool key)
 local pools = {}
@@ -59,9 +23,11 @@ local Registry
 -- Helpers
 --------------------------------------------------------------------------------
 
+--#DEBUG START
 local function _formatPoolKeyValue(key)
   return stringFormat("%q", tostring(key))
 end
+--#DEBUG END
 
 local function _isValidPoolKey(key)
   if type(key) ~= "string" then return false end
@@ -76,12 +42,11 @@ end
 
 -- ! Register Pool
 -- Registers a new asset pool with initial allocation and growth configuration
---  @param key            Non-empty string key (no leading/trailing whitespace)
---  @param initialCount   Number of assets to pre-allocate (default 1)
---  @param loaderFunction Function that creates and returns a new asset instance
---  @param options        Optional table with maxSize and growthFactor fields
---
---  @return Boolean true if registration succeeded, false on invalid key/duplicate/invalid loader
+-- @param key Non-empty string key with no leading/trailing whitespace
+-- @param initialCount Number of assets to pre-allocate, defaults to 1
+-- @param loaderFunction Function that creates and returns a new asset instance
+-- @param options Optional table with maxSize and positive integer growthFactor fields
+-- @return Boolean true if registration succeeded
 
 function Assets.registerPool(key, initialCount, loaderFunction, options)
   if not _isValidPoolKey(key) then
@@ -123,10 +88,10 @@ function Assets.registerPool(key, initialCount, loaderFunction, options)
 
   -- Create pool metadata structure
   local pool = {
-    assets = {},                -- Array of available assets
-    loader = loaderFunction,    -- Factory function for new assets
-    availableCount = 0,         -- Number of assets currently available
-    totalSize = 0,              -- Total allocated assets (in-use + available)
+    assets = {},              -- Array of available assets
+    loader = loaderFunction,  -- Factory function for new assets
+    availableCount = 0,       -- Number of assets currently available
+    totalSize = 0,            -- Total allocated assets (in-use + available)
     initialCount = initialCountValue,
     maxSize = maxSizeValue,
     growthFactor = growthFactorValue,
@@ -161,14 +126,14 @@ end
 
 -- ! Get Asset
 -- Retrieves an available asset from the pool, growing the pool if needed
---  @param key Non-empty string key for the pool (no leading/trailing whitespace)
---
---  @return Asset instance if available, nil if key invalid/pool exhausted/unregistered
+-- @param key Non-empty string key with no leading/trailing whitespace
+-- @return Asset instance if available, otherwise nil
 
 function Assets.getAsset(key)
+  -- Hot path: release builds rely on pool lookup to fail soft
   --#DEBUG START
   if not _isValidPoolKey(key) then
-    Log.warn("[Assets.getAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
+    Log.warn("[Assets.getAsset] invalid pool key: " .. _formatPoolKeyValue(key))
     return nil
   end
   --#DEBUG END
@@ -188,7 +153,7 @@ function Assets.getAsset(key)
     assets[i] = nil
 
     pool.availableCount -= 1
-    return Registry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
+    return Registry.markFromPoolDirect(asset, key) -- Internal: key already validated, asset guaranteed non-nil
   else
     -- Pool exhausted, attempt to grow if under max capacity
     if pool.totalSize < pool.maxSize then
@@ -212,7 +177,7 @@ function Assets.getAsset(key)
         assets[i] = nil
 
         pool.availableCount -= 1
-        return Registry.markFromPoolDirect(asset, key) -- INTERNAL: key already validated, asset guaranteed non-nil
+        return Registry.markFromPoolDirect(asset, key) -- Internal: key already validated, asset guaranteed non-nil
       else
         Log.warn("[Assets.getAsset] Pool '" .. tostring(key) .. "' is empty after attempting to grow.") --#DEBUG
         return nil
@@ -226,15 +191,15 @@ end
 
 -- ! Recycle Asset
 -- Returns an asset to the pool for reuse
---  @param key   Non-empty string key for the pool (no leading/trailing whitespace)
---  @param asset Asset instance to return to the pool
---
---  @return Boolean true if recycled successfully, false on invalid key/reject conditions
+-- @param key Non-empty string key with no leading/trailing whitespace
+-- @param asset Asset instance to return to the pool
+-- @return Boolean true if recycled successfully
 
 function Assets.recycleAsset(key, asset)
+  -- Hot path: release builds rely on lookup and ownership checks to fail soft
   --#DEBUG START
   if not _isValidPoolKey(key) then
-    Log.warn("[Assets.recycleAsset] invalid pool key: " .. _formatPoolKeyValue(key)) --#DEBUG
+    Log.warn("[Assets.recycleAsset] invalid pool key: " .. _formatPoolKeyValue(key))
     return false
   end
   --#DEBUG END
@@ -249,8 +214,9 @@ function Assets.recycleAsset(key, asset)
     Log.warn("[Assets.recycleAsset] Attempted to recycle a nil asset to pool: " .. tostring(key)) --#DEBUG
     return false
   end
+
   -- Prevent double-recycle and foreign assets from entering the wrong pool.
-  -- INTERNAL: single-lookup replaces isFromPool + getPoolKey + clearFromPool sequence
+  -- Internal: single-lookup replaces isFromPool + getPoolKey + clearFromPool sequence
   local originKey, isPooled = Registry.getOriginKey(asset)
   if not isPooled or originKey == nil then
     Log.warn("[Assets.recycleAsset] Attempted to recycle a non-pooled asset to pool: " .. tostring(key)) --#DEBUG
@@ -272,19 +238,14 @@ end
 
 -- ! Get Is Pool Registered
 -- Checks if a pool with the given key exists
---  @param key Non-empty string key for the pool (no leading/trailing whitespace)
---
---  @return Boolean true if pool is registered, false otherwise
+-- @param key Pool key to check
+-- @return Boolean true if pool is registered
 
 function Assets.getIsPoolRegistered(key)
   return pools[key] ~= nil
 end
 
---------------------------------------------------------------------------------
--- Roxy Framework Imports
---------------------------------------------------------------------------------
-
--- Asset Pool Registry helper
+-- AssetPoolRegistry depends on the asset pool functions above at import time.
 import "libraries/roxy/core/modules/AssetPoolRegistry"
 Registry = roxy.AssetPoolRegistry
 

--- a/core/tilemaps/LayerManager.lua
+++ b/core/tilemaps/LayerManager.lua
@@ -10,13 +10,12 @@ local AssetStore  <const> = r.AssetStore
 local Camera      <const> = r.Camera
 local Scene       <const> = r.Scene
 
-local round <const> = r.Math.round
-
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
 
-local newSprite <const> = Sprite.new
+local round <const> = r.Math.round
 
+local newSprite <const> = Sprite.new
 local retain    <const> = AssetStore.retain
 local release   <const> = AssetStore.release
 local getTable  <const> = AssetStore.getImagetable
@@ -26,16 +25,13 @@ local getTable  <const> = AssetStore.getImagetable
 --------------------------------------------------------------------------------
 
 -- ! Helper: Create Parallax Update
--- Parallax updater (same behavior as in RoxyTilemap)
-local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY)
-  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
-  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
-
+-- Parallax updater with stable factors and a mutable origin holder
+local function _createParallaxUpdate(origin, parallaxX, parallaxY, pivotAdjustX, pivotAdjustY)
   return function(sprite)
     local cameraX, cameraY = Camera.getPosition()
 
-    local screenX = round(worldX + pivotAdjustX - cameraX * parallaxX)
-    local screenY = round(worldY + pivotAdjustY - cameraY * parallaxY)
+    local screenX = round(origin.x + pivotAdjustX - cameraX * parallaxX)
+    local screenY = round(origin.y + pivotAdjustY - cameraY * parallaxY)
 
     local currentX, currentY = sprite:getPosition()
     if screenX ~= currentX or screenY ~= currentY then
@@ -44,10 +40,40 @@ local function _createParallaxUpdate(worldX, worldY, parallaxX, parallaxY, paral
   end
 end
 
+-- ! Helper: Configure Managed Parallax Sprite
+local function _configureManagedParallaxSprite(layer, sprite, parallaxX, parallaxY)
+  local parallaxOriginX = layer.parallaxoriginx or 0
+  local parallaxOriginY = layer.parallaxoriginy or 0
+  local pivotAdjustX = parallaxOriginX * (1 - parallaxX)
+  local pivotAdjustY = parallaxOriginY * (1 - parallaxY)
+  local origin = layer._managedParallaxOrigin or {}
+  origin.x, origin.y = layer.originX or 0, layer.originY or 0
+
+  sprite:setIgnoresDrawOffset(true)
+  sprite:setUpdatesEnabled(true)
+  sprite.update = _createParallaxUpdate(origin, parallaxX, parallaxY, pivotAdjustX, pivotAdjustY)
+  layer._managedParallaxOrigin = origin
+  layer._managedParallaxSprite = sprite
+  sprite._roxyLayerManagedParallax = true
+end
+
+-- ! Helper: Clear Managed Parallax Sprite
+local function _clearManagedParallaxSprite(layer)
+  local sprite = layer._managedParallaxSprite
+  if sprite and sprite == layer.sprite then
+    sprite.update = nil
+    sprite._roxyLayerManagedParallax = nil
+  end
+  layer._managedParallaxOrigin = nil
+  layer._managedParallaxSprite = nil
+end
+
 -- ! Helper: Remove Sprites From Scene
--- Uses the scene batch unregister path when available; otherwise removes directly.
+-- Uses the scene batch unregister path when available; otherwise removes directly
 local function _removeSpritesFromScene(scene, sprites)
-  if not sprites or #sprites == 0 then return end
+  if not sprites or #sprites == 0 then
+    return
+  end
 
   if scene and scene._unregisterSprites then
     scene:_unregisterSprites(sprites, true)
@@ -101,22 +127,32 @@ end
 -- ! Add Layer
 -- Register or replace layer data without creating a sprite yet
 function LayerManager:addLayer(layerData)
-  if layerData.visible == nil then layerData.visible = true end
+  if layerData.visible == nil then
+    layerData.visible = true
+  end
   self.layers[layerData.name] = layerData
 end
 
 -- ! Ensure Sprite
 -- Creates if needed and returns the sprite for a layer
+-- @param name Layer name
+-- @return Sprite instance, or nil if the layer is missing or wrapping is disabled
 function LayerManager:ensureSprite(name)
-  local layer = self.layers[name]; if not layer then return nil end
-  if self._opts.wrapInSprites == false then return layer.sprite end
+  local layer = self.layers[name]
+  if not layer then
+    return nil
+  end
+
+  if self._opts.wrapInSprites == false then
+    return layer.sprite
+  end
 
   local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
   local useParallax = (not layer.layerOptions) or (layer.layerOptions.parallax ~= false)
   local hasParallax = useParallax and (parallaxX ~= 1 or parallaxY ~= 1)
 
   if layer.sprite then
-    -- Keep classification current before addSprite's same-owner fast path.
+    -- Keep classification current before addSprite's same-owner fast path
     _setScenePauseClassification(layer.sprite, false, hasParallax, false)
     if self._autoAdd and self._sceneHasAdd then
       self.scene:addSprite(layer.sprite)
@@ -126,20 +162,19 @@ function LayerManager:ensureSprite(name)
 
   local sprite = newSprite()
   sprite:setTilemap(layer.tilemap)
-  if (layer.anchor or self._opts.anchor) == "topLeft" then sprite:setCenter(0, 0) else sprite:setCenter(0.5, 0.5) end
+  if (layer.anchor or self._opts.anchor) == "topLeft" then
+    sprite:setCenter(0, 0)
+  else
+    sprite:setCenter(0.5, 0.5)
+  end
   sprite:setZIndex(layer.zIndex or 0)
-  -- Keep classification current before addSprite's same-owner fast path.
+  -- Keep classification current before addSprite's same-owner fast path
   _setScenePauseClassification(sprite, false, hasParallax, false)
 
   if hasParallax then
-    sprite:setIgnoresDrawOffset(true)
-    sprite:setUpdatesEnabled(true)
-    sprite.update = _createParallaxUpdate(
-      layer.originX or 0, layer.originY or 0,
-      parallaxX, parallaxY,
-      layer.parallaxoriginx or 0, layer.parallaxoriginy or 0
-    )
+    _configureManagedParallaxSprite(layer, sprite, parallaxX, parallaxY)
   else
+    _clearManagedParallaxSprite(layer)
     sprite:moveTo(layer.originX or 0, layer.originY or 0)
   end
 
@@ -155,7 +190,9 @@ end
 
 -- ! Ensure Sprites for All
 function LayerManager:ensureSpritesForAll()
-  for name, _ in pairs(self.layers) do self:ensureSprite(name) end
+  for name, _ in pairs(self.layers) do
+    self:ensureSprite(name)
+  end
 end
 
 --
@@ -182,40 +219,62 @@ end
 --
 
 -- ! Hide
+-- @param name Layer name
+-- @return Boolean true if the layer exists
 function LayerManager:hide(name)
   local layer = self.layers[name]
-  if not layer then return false end
+  if not layer then
+    return false
+  end
 
   layer.visible = false
-  if layer.sprite then layer.sprite:setVisible(false) end
+  if layer.sprite then
+    layer.sprite:setVisible(false)
+  end
   return true
 end
 
 -- ! Show
+-- @param name Layer name
+-- @return Boolean true if the layer exists
 function LayerManager:show(name)
   local layer = self.layers[name]
-  if not layer then return false end
+  if not layer then
+    return false
+  end
 
   layer.visible = true
   local sprite = self:ensureSprite(name)
-  if sprite then sprite:setVisible(true) end
+  if sprite then
+    sprite:setVisible(true)
+  end
   return true
 end
 
 -- ! Remove
 -- Remove layer + sprites + collision sprites + retained paths from swaps
+-- @param name Layer name
+-- @return Boolean true if the layer existed and was removed
 function LayerManager:remove(name)
   local layer = self.layers[name]
-  if not layer then return false end
+  if not layer then
+    return false
+  end
 
   if layer.sprite then
     local sprite = layer.sprite
     _removeSpritesFromScene(self.scene, { sprite })
     -- Remove from external list if present
     for i = #self._spritesList, 1, -1 do
-      if self._spritesList[i] == sprite then tableRemove(self._spritesList, i); break end
+      if self._spritesList[i] == sprite then
+        tableRemove(self._spritesList, i)
+        break
+      end
     end
+    _clearManagedParallaxSprite(layer)
     layer.sprite = nil
+  else
+    _clearManagedParallaxSprite(layer)
   end
 
   if layer.collisionSprites then
@@ -235,9 +294,15 @@ end
 
 -- ! Set Image Table
 -- Runtime image table swap with index remap and proper retention accounting
+-- @param name Layer name
+-- @param newImageTableOrPath Imagetable instance or image-table path
+-- @param remapFn Optional remap function or lookup table for tile indices
+-- @return Boolean true when the image table was applied
 function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   local layer = self.layers[name]
-  if not layer or not layer.tilemap then return false end
+  if not layer or not layer.tilemap then
+    return false
+  end
 
   local newPath, newTable
   if type(newImageTableOrPath) == "string" then
@@ -246,10 +311,14 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
     local base = filename:gsub("%-table%-%d+%-%d+%.png$", "")
     newPath = "assets/images/" .. base
     newTable = getTable(newPath)
-    if not newTable then return false end
+    if not newTable then
+      return false
+    end
   else
     newTable = newImageTableOrPath
-    if not newTable then return false end
+    if not newTable then
+      return false
+    end
   end
 
   if remapFn then
@@ -298,7 +367,8 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
   local maxHeight, count = 0, newTable and newTable:getLength() or 0
   for i = 1, count do
     local img = newTable:getImage(i)
-    if img then local _, height = img:getSize()
+    if img then
+      local _, height = img:getSize()
       if height and height > maxHeight then
         maxHeight = height
       end
@@ -311,7 +381,7 @@ function LayerManager:setImageTable(name, newImageTableOrPath, remapFn)
     if not self._retainedPaths[newPath] then
       if retain(newPath, newTable) then
         self._retainedPaths[newPath] = true
-      else
+      else --#DEBUG
         Log.warn("[LayerManager:setImageTable] Failed to retain image table: " .. tostring(newPath)) --#DEBUG
       end
     end
@@ -345,21 +415,33 @@ end
 
 -- ! Set Origin
 -- Keep origin/sprite in sync (parallax-aware)
+-- @param name Layer name
+-- @param x New origin x, defaults to 0
+-- @param y New origin y, defaults to 0
+-- @return Boolean true if the layer exists
 function LayerManager:setOrigin(name, x, y)
   local layer = self.layers[name]
-  if not layer then return false end
+  if not layer then
+    return false
+  end
 
   x, y = x or 0, y or 0
-  if layer.originX == x and layer.originY == y then return true end
+  local sprite = layer.sprite
+  if layer._managedParallaxSprite and layer._managedParallaxSprite ~= sprite then
+    _clearManagedParallaxSprite(layer)
+  end
+
+  if layer.originX == x and layer.originY == y then
+    return true
+  end
 
   layer.originX, layer.originY = x, y
-  local sprite = layer.sprite
   if sprite then
-    local parallaxX, parallaxY = layer.parallaxx or 1, layer.parallaxy or 1
-    local parallaxOriginX, parallaxOriginY = layer.parallaxoriginx or 0, layer.parallaxoriginy or 0
-    if sprite.update and sprite.setUpdatesEnabled then
-      sprite.update = _createParallaxUpdate(layer.originX, layer.originY, parallaxX, parallaxY, parallaxOriginX, parallaxOriginY)
-      sprite:setIgnoresDrawOffset(true); sprite:setUpdatesEnabled(true)
+    if layer._managedParallaxSprite == sprite then
+      local origin = layer._managedParallaxOrigin
+      if origin then
+        origin.x, origin.y = layer.originX, layer.originY
+      end
     else
       sprite:moveTo(layer.originX, layer.originY)
     end
@@ -369,7 +451,9 @@ end
 
 -- ! Set Origin for All
 function LayerManager:setOriginForAll(x, y)
-  for name, _ in pairs(self.layers) do self:setOrigin(name, x, y) end
+  for name, _ in pairs(self.layers) do
+    self:setOrigin(name, x, y)
+  end
 end
 
 --------------------------------------------------------------------------------
@@ -377,7 +461,7 @@ end
 --------------------------------------------------------------------------------
 
 -- ! Detach
--- Remove layer and collision sprites without releasing retained swap paths.
+-- Remove layer and collision sprites without releasing retained swap paths
 function LayerManager:detach()
   -- Collect layer sprites so the scene can unregister them in one batch
   local layerSprites = nil
@@ -403,7 +487,10 @@ function LayerManager:destroy()
     if layer.sprite then
       layerSprites = layerSprites or {}
       tableInsert(layerSprites, layer.sprite)
+      _clearManagedParallaxSprite(layer)
       layer.sprite = nil
+    else
+      _clearManagedParallaxSprite(layer)
     end
     if layer.collisionSprites then
       for _, collisionSprite in ipairs(layer.collisionSprites) do
@@ -416,7 +503,9 @@ function LayerManager:destroy()
   end
   _removeSpritesFromScene(self.scene, layerSprites)
   _removeSpritesFromScene(self.scene, collisionSprites)
-  for path, _ in pairs(self._retainedPaths) do release(path) end
+  for path, _ in pairs(self._retainedPaths) do
+    release(path)
+  end
   self._retainedPaths = {}
   self._spritesList = {}
 end
@@ -442,18 +531,18 @@ local manager = LayerManager({
   anchor = "topLeft",
 }, scene, layers, sprites)
 
--- Register a Layer
+-- Register Static and Parallax Layers
 local imageTable = Graphics.imagetable.new("images/terrain")
-local tilemap = Graphics.tilemap.new()
-tilemap:setImageTable(imageTable)
-tilemap:setTiles({
+local groundTilemap = Graphics.tilemap.new()
+groundTilemap:setImageTable(imageTable)
+groundTilemap:setTiles({
   1, 1, 0,
   2, 2, 1,
 }, 3)
 
 manager:addLayer({
   name = "Ground",
-  tilemap = tilemap,
+  tilemap = groundTilemap,
   imageTable = imageTable,
   tileWidth = 16,
   tileHeight = 16,
@@ -462,8 +551,28 @@ manager:addLayer({
   zIndex = 0,
   visible = true,
   anchor = "topLeft",
+})
+
+local cloudsTilemap = Graphics.tilemap.new()
+cloudsTilemap:setImageTable(imageTable)
+cloudsTilemap:setTiles({
+  0, 1, 0,
+  1, 0, 1,
+}, 3)
+
+manager:addLayer({
+  name = "Clouds",
+  tilemap = cloudsTilemap,
+  imageTable = imageTable,
+  tileWidth = 16,
+  tileHeight = 16,
+  originX = 0,
+  originY = 0,
+  zIndex = 20,
+  visible = true,
+  anchor = "topLeft",
   parallaxx = 0.5,
-  parallaxy = 1,
+  parallaxy = 0.75,
   parallaxoriginx = 200,
   parallaxoriginy = 120,
 })
@@ -471,13 +580,14 @@ manager:addLayer({
 -- Sprite Lifecycle and Visibility
 manager:ensureSpritesForAll()
 local groundSprite = manager:getSprite("Ground")
-local groundTilemap = manager:getTilemap("Ground")
-local allLayerSprites = manager:getAllSprites()
+local cloudsSprite = manager:getSprite("Clouds")
 
 manager:hide("Ground")
 manager:show("Ground")
 manager:setOrigin("Ground", 32, 16)
-manager:setOriginForAll(0, 0)
+
+roxy.Camera.setPosition(40, 16)
+manager:setOrigin("Clouds", 12, 8) -- Applied on the next parallax sprite update
 
 -- Runtime Image Table Swap
 local winterTiles = Graphics.imagetable.new("images/terrain-winter")
@@ -488,7 +598,7 @@ manager:setImageTable("Ground", winterTiles, {
 
 -- Cleanup
 manager:detach()
-manager:remove("Ground")
+manager:remove("Clouds")
 manager:destroy()
 
 --]]

--- a/core/tilemaps/TilemapHelpers.lua
+++ b/core/tilemaps/TilemapHelpers.lua
@@ -4,7 +4,8 @@ roxy = roxy or {}
 roxy.TilemapHelpers = roxy.TilemapHelpers or {}
 local TilemapHelpers <const> = roxy.TilemapHelpers
 
-local r <const> = roxy
+local r             <const> = roxy
+local RoxyGraphics  <const> = r.Graphics
 
 local floor <const> = math.floor
 local abs   <const> = math.abs
@@ -15,13 +16,17 @@ local stringRep   <const> = string.rep
 local stringPack  <const> = string.pack
 
 local tableUnpack <const> = table.unpack
+local tableCreate <const> = table.create
 
-local DISPLAY_WIDTH  <const> = r.Graphics.displayWidth
-local DISPLAY_HEIGHT <const> = r.Graphics.displayHeight
+local DISPLAY_WIDTH  <const> = RoxyGraphics.displayWidth
+local DISPLAY_HEIGHT <const> = RoxyGraphics.displayHeight
 
 local NATIVE_SYNC_CHUNK_CELLS <const> = 512
 local MAX_PACK_FORMAT_CACHE_CELLS <const> = 2048
+
 local packU16Formats = {}
+-- Shared scratch for the single-threaded native range sync path
+local packTilesU16RangeScratch = tableCreate and tableCreate(NATIVE_SYNC_CHUNK_CELLS, 0) or {}
 
 local function packU16Format(count)
   if count <= MAX_PACK_FORMAT_CACHE_CELLS then
@@ -81,7 +86,7 @@ end
 function TilemapHelpers.packTilesU16Range(tiles, startIndex, count)
   if not tiles or not startIndex or startIndex < 1 or not count or count <= 0 then return nil end
   local format = packU16Format(count)
-  local temp = {}
+  local temp = count <= NATIVE_SYNC_CHUNK_CELLS and packTilesU16RangeScratch or {}
   local sourceIndex = startIndex
   for outputIndex = 1, count do
     local v = tiles[sourceIndex] or 0

--- a/utilities/Ease.lua
+++ b/utilities/Ease.lua
@@ -54,7 +54,7 @@ roxy.EasingMap = {
 
 -- ! Component Phase Mappings
 -- Maps compound easings (e.g., inOut) to their enter/exit components.
-local componentFunctions = {
+local componentFunctions <const> = {
   [Ease.inOutQuad]    = { enter = Ease.inQuad,      exit = Ease.outQuad     },
   [Ease.inOutCubic]   = { enter = Ease.inCubic,     exit = Ease.outCubic    },
   [Ease.inOutQuart]   = { enter = Ease.inQuart,     exit = Ease.outQuart    },
@@ -80,7 +80,7 @@ local componentFunctions = {
 
 -- ! Reverse Function Map
 -- Maps 'in' <--> 'out' easing variants for reversing direction.
-local reverseFunctions = {
+local reverseFunctions <const> = {
   [Ease.inQuad]     = Ease.outQuad,
   [Ease.inCubic]    = Ease.outCubic,
   [Ease.inQuart]    = Ease.outQuart,

--- a/utilities/TableBuilder.lua
+++ b/utilities/TableBuilder.lua
@@ -3,8 +3,12 @@
 local pd      <const> = playdate
 local Object  <const> = pd.object
 
-local tableInsert     <const> = table.insert
-local mergeImmutable  <const> = roxy.Table.mergeImmutable
+local r     <const> = roxy
+local Table <const> = r.Table
+
+local tableInsert <const> = table.insert
+
+local mergeImmutable <const> = Table.mergeImmutable
 
 class("TableBuilder").extends(Object)
 


### PR DESCRIPTION
### Overview
This release hardens asset release handling and reduces tilemap allocation pressure during runtime updates. It keeps the public engine surface stable while improving asset lifecycle safety, parallax layer update behavior, and developer-facing inline documentation around asset ownership.

### Key Changes
- Guarded `AssetStore.release` against invalid or empty paths before touching reference counts.
- Reused scratch storage for native tile range packing to reduce per-chunk allocation pressure while preserving existing tile byte output.
- Reused managed parallax layer update closures so origin changes refresh lightweight state instead of replacing updater functions.
- Preserved parallax sprite paused-update classification and cleanup ownership when layers are removed or destroyed.
- Tightened asset pool registry, asset pool debug, and utility top-of-file documentation without changing utility behavior.

### Challenges/Notes
- No breaking changes are expected for Playdate developers.