### PR TITLE
Optimize Sprite Culling Center Lookups

### DIFF
--- a/core/sprites/RoxySprite.lua
+++ b/core/sprites/RoxySprite.lua
@@ -150,6 +150,9 @@ function RoxySprite:init(options, scene)
   self._collisionsActive        = true
   self._restoreCollisionsOnAdd  = false
   self._destroyed               = false -- Prevent use-after-destroy
+  -- Authoritative Roxy culling anchor; center changes must route through setCenter.
+  self._centerX                 = 0.5
+  self._centerY                 = 0.5
 
   -- Parallax (optional; only active if configured)
   self.worldX, self.worldY        = nil, nil
@@ -259,6 +262,8 @@ function RoxySprite:setCenter(x, y)
   end
 
   RoxySprite.super.setCenter(self, x, y)
+  self._centerX = x
+  self._centerY = y
   return self
 end
 
@@ -1046,7 +1051,8 @@ function RoxySprite:isOnScreen(cachedCamX, cachedCamY)
   local spriteY = self.y or 0
   local spriteWidth = self.width or 0
   local spriteHeight = self.height or 0
-  local centerX, centerY = self:getCenter()
+  local centerX = self._centerX or 0.5
+  local centerY = self._centerY or 0.5
 
   -- Calculate actual bounds based on center anchor
   local left = spriteX - spriteWidth * centerX


### PR DESCRIPTION
### Overview
This PR caches each RoxySprite center anchor on the Lua object so on-screen culling no longer calls the Playdate sprite center getter during repeated animation update checks. The change reduces per-frame Lua-to-SDK work in animated sprite-heavy scenes while preserving the existing setCenter API.

### Key Changes
- Cache the default sprite center anchor on RoxySprite initialization.
- Keep the cached anchor synchronized when RoxySprite:setCenter succeeds.
- Use the cached center fields in RoxySprite:isOnScreen instead of calling getCenter during culling.

### Challenges/Notes
- No public API changes are intended.
- Roxy-managed center changes should continue to route through RoxySprite:setCenter so culling stays synchronized with the cached anchor.