### PR TITLE
Harden Sequence Lifecycle and Native Returns

### DIFF
--- a/core/sequences/RoxySequence.lua
+++ b/core/sequences/RoxySequence.lua
@@ -10,8 +10,31 @@
 local pd      <const> = playdate
 local Object  <const> = pd.object
 
-local addSequence     <const> = roxy.Sequencer.add
-local removeSequence  <const> = roxy.Sequencer.remove
+local r         <const> = roxy
+local Sequencer <const> = r.Sequencer
+
+local addSequence     <const> = Sequencer.add
+local removeSequence  <const> = Sequencer.remove
+
+--------------------------------------------------------------------------------
+-- Private Helper Functions
+--------------------------------------------------------------------------------
+
+-- ! Helper: Reset Current Value To Start
+local function _resetCurrentValueToStart(sequence)
+  local easingArray = sequence.easingArray
+  sequence.currentValue = (#easingArray > 0) and easingArray:getValue(0) or 0
+end
+
+-- ! Helper: Reset Current Value If Changed
+local function _resetCurrentValueIfChanged(sequence, didChange)
+  if didChange then
+    _resetCurrentValueToStart(sequence)
+    return
+  end
+
+  Log.warn("[RoxySequence] Native mutation failed") --#DEBUG
+end
 
 --------------------------------------------------------------------------------
 -- ! Class Definition & Init
@@ -26,15 +49,11 @@ function RoxySequence:init(scene)
   self.easingArray  = RoxySequenceC.new()
   self.callbacks    = {}
   self.currentValue = 0
-  self.completed    = false
 
   -- Attach to a scene immediately (optional)
   if scene and scene.addSequence then
     scene:addSequence(self)
   end
-
-  self.updateAndGetValue = self.easingArray.updateAndGetValue
-  self.getTotalDuration = self.easingArray.getTotalDuration
 end
 
 --------------------------------------------------------------------------------
@@ -53,7 +72,7 @@ function RoxySequence:setPacing(pacing)
   return self
 end
 
--- ! Get and Set Pacing
+-- ! Get Pacing
 function RoxySequence:getPacing()
   return self.pacing
 end
@@ -64,15 +83,17 @@ end
 
 -- ! Add
 function RoxySequence:add()
-  if #self.easingArray == 0 then return end
+  if #self.easingArray == 0 then return self end
   addSequence(self)
   self.isRunning = true
+  return self
 end
 
 -- ! Remove
 function RoxySequence:remove()
   removeSequence(self)
   self.isRunning = false
+  return self
 end
 
 -- ! Clear
@@ -80,15 +101,19 @@ function RoxySequence:clear(clearEasings)
   self:reset()  -- Stop and reset the sequence
   self.callbacks = {}
   if clearEasings then
-    self.easingArray:clear()
+    if self.easingArray:clear() then
+      self.currentValue = 0
+    end
   end
 
   if self.scene then
     local scene = self.scene
     self.scene = nil
-    -- Guard against double‑removal
+    -- Guard against double-removal
     if scene.removeSequence then scene:removeSequence(self) end
   end
+
+  return self
 end
 
 --------------------------------------------------------------------------------
@@ -97,52 +122,65 @@ end
 
 -- ! Add Easing
 function RoxySequence:addEasing(timestamp, from, to, duration, easeFn)
-  self.easingArray:addEasing(timestamp, from, to, duration, easeFn)
+  local didChange = self.easingArray:addEasing(timestamp, from, to, duration, easeFn)
+  _resetCurrentValueIfChanged(self, didChange)
+  return self
 end
 
 -- ! Set Easing At
 function RoxySequence:setEasingAt(idx, timestamp, from, to, duration, easeFn)
-  self.easingArray:setEasingAt(idx, timestamp, from, to, duration, easeFn)
+  local didChange = self.easingArray:setEasingAt(idx, timestamp, from, to, duration, easeFn)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! From
 function RoxySequence:from(from)
-  self.easingArray:from(from or 0)
+  local value = from or 0
+  local didChange = self.easingArray:from(value)
+  if didChange then
+    self.currentValue = value
+  end
+  --#DEBUG START
+  if not didChange then Log.warn("[RoxySequence:from] Native mutation failed") end
+  --#DEBUG END
   return self
 end
 
 -- ! To
 function RoxySequence:to(to, duration, easeFn)
   if #self.easingArray == 0 then return self end
-  self.easingArray:to(to, duration, easeFn)
+  local didChange = self.easingArray:to(to, duration, easeFn)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! Set
 function RoxySequence:set(value)
   if #self.easingArray == 0 then return self end
-  self.easingArray:set(value)
+  local didChange = self.easingArray:set(value)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! Sleep
 function RoxySequence:sleep(duration)
   if #self.easingArray == 0 then return self end
-  self.easingArray:sleep(duration)
+  local didChange = self.easingArray:sleep(duration)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! Callback
 function RoxySequence:callback(callback, timeOffset)
   local easingArray = self.easingArray
-  local numEasingArray = #easingArray
-  if numEasingArray == 0 or not callback then
+  local easingCount = #easingArray
+  if easingCount == 0 or not callback then
     return self
   end
 
   local getEasingData = easingArray.getEasingData
-  local lastTimestamp, _, _, lastDuration = getEasingData(easingArray, numEasingArray)
+  local lastTimestamp, _, _, lastDuration = getEasingData(easingArray, easingCount)
   local timestamp = lastTimestamp + lastDuration + (timeOffset or 0)
 
   self.callbacks[#self.callbacks + 1] = { callback, timestamp, false }
@@ -158,7 +196,8 @@ end
 -- Set sequence to loop continuously
 function RoxySequence:loop(loopCount)
   self.loopType = 1
-  self.easingArray:setLoopType(self.loopType, loopCount)
+  local didChange = self.easingArray:setLoopType(self.loopType, loopCount)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
@@ -166,28 +205,32 @@ end
 -- Set sequence to alternate direction after each completion
 function RoxySequence:pingPong(loopCount)
   self.loopType = 2
-  self.easingArray:setLoopType(self.loopType, loopCount)
+  local didChange = self.easingArray:setLoopType(self.loopType, loopCount)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! Again
 function RoxySequence:again(repeatCount)
   if #self.easingArray == 0 then return self end
-  self.easingArray:again(repeatCount)
+  local didChange = self.easingArray:again(repeatCount)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
 -- ! Reverse
 function RoxySequence:reverse(appendNew)
   if #self.easingArray == 0 then return self end
-  self.easingArray:reverse(appendNew)
+  local didChange = self.easingArray:reverse(appendNew)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
--- ! Disable loop
+-- ! Disable Loop
 function RoxySequence:disableLoop()
   self.loopType = 0
-  self.easingArray:setLoopType(self.loopType)
+  local didChange = self.easingArray:setLoopType(self.loopType)
+  _resetCurrentValueIfChanged(self, didChange)
   return self
 end
 
@@ -237,6 +280,7 @@ function RoxySequence:restart()
   if #self.easingArray == 0 then return self end
   self:remove()
   self.easingArray:reset()
+  _resetCurrentValueToStart(self)
   self:add()
   return self
 end
@@ -245,6 +289,7 @@ end
 function RoxySequence:reset()
   self:remove()
   self.easingArray:reset()
+  _resetCurrentValueToStart(self)
   for i = 1, #self.callbacks do
     self.callbacks[i][3] = false -- Reset triggered flags
   end
@@ -286,7 +331,73 @@ function RoxySequence:update(dt)
   if done then self:remove() end
 end
 
--- ! Get Value (Value Calculation/Progress)
+-- ! Get Value
 function RoxySequence:getValue(time)
   return time and self.easingArray:getValue(time) or self.currentValue
 end
+
+-- ! Get Total Duration
+function RoxySequence:getTotalDuration()
+  return self.easingArray:getTotalDuration()
+end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+RoxySequence builds fluent numeric timelines for scene-owned or standalone playback.
+
+-- Scene-Owned Position Tween
+function GameplayScene:enter()
+  self.playerX = 40
+  self.playerMove = self:spawnSequence()
+    :setName("PlayerMove")
+    :from(self.playerX)
+    :to(220, 0.35, EasingMap.outCubic)
+    :callback(function()
+      self.playerState = "idle"
+    end)
+    :play()
+end
+
+function GameplayScene:update(dt)
+  self.playerX = self.playerMove:getValue()
+end
+
+-- Looping UI Pulse
+self.cursorPulse = RoxySequence()
+  :from(0.8)
+  :to(1.0, 0.2, EasingMap.inOutSine)
+  :pingPong()
+  :play()
+
+-- Reuse and Cleanup
+self.fade = RoxySequence()
+  :from(0)
+  :to(1, 0.25, EasingMap.linear)
+
+self.fadeDuration = self.fade:getTotalDuration()
+self.fade:play()
+
+function GameplayScene:exit()
+  self.fade:clear(true)
+  self.cursorPulse:stop()
+end
+
+-- Rebuild After Completion or Mid-Play
+self.fade:reset()
+  :from(1)
+  :sleep(0.1)
+  :to(0, 0.25, EasingMap.outQuad)
+  :play()
+
+-- Build Repeated or Mirrored Segments
+local patrol = RoxySequence()
+  :from(20)
+  :to(180, 1.0, EasingMap.inOutCubic)
+  :again(1)
+  :reverse(true)
+  :loop()
+  :play()
+--]]

--- a/core/sequences/roxy_sequence.c
+++ b/core/sequences/roxy_sequence.c
@@ -33,22 +33,68 @@ static const int DEFAULT_REPEAT_COUNT  = 1;
  *  Helpers
  ***********************************************/
 
+static float durationOrDefault(float duration)
+{
+    return (!isfinite(duration) || duration <= 0.0f) ? DEFAULT_DURATION : duration;
+}
+
+static float durationOrZero(float duration)
+{
+    return (!isfinite(duration) || duration < 0.0f) ? 0.0f : duration;
+}
+
+static void resetPlaybackState(EasingArray* ea)
+{
+    ea->currentTime = 0.0f;
+    ea->completed   = 0;
+    ea->travelAccum = 0.0f;
+    ea->isForward   = 1;
+}
+
+static void resetLoopConfiguration(EasingArray* ea)
+{
+    ea->loopType  = 0;
+    ea->loopCount = 0.0f;
+    resetPlaybackState(ea);
+}
+
+static void recomputeTimelineMetadata(EasingArray* ea)
+{
+    ea->isSorted = 1;
+    float maxEnd = 0.0f;
+    for (int i = 0; i < ea->count; ++i) {
+        if (i > 0 && ea->segments[i].timestamp < ea->segments[i - 1].timestamp) ea->isSorted = 0;
+        if (ea->segments[i].endTime > maxEnd) maxEnd = ea->segments[i].endTime;
+    }
+    ea->totalDuration = maxEnd;
+}
+
+static int ensureCapacity(EasingArray* ea, size_t needed)
+{
+    if (needed > (SIZE_MAX / sizeof(EasingSegment)) || needed > (size_t)INT_MAX) return 0;
+    if (needed <= (size_t)ea->capacity) return 1;
+
+    int newCap = ea->capacity;
+    while ((size_t)newCap < needed) {
+        if (newCap > INT_MAX / 2) return 0;
+        newCap *= 2;
+    }
+
+    EasingSegment* newPtr = (EasingSegment*)roxy_realloc(
+        ea->segments, (size_t)newCap * sizeof(EasingSegment));
+    if (!newPtr) return 0;
+
+    ea->segments = newPtr;
+    ea->capacity = newCap;
+    ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
+    return 1;
+}
+
 // ! Ensure Capacity and Insert
 static EasingSegment* ensureCapacityAndInsert(EasingArray* ea)
 {
-    if (ea->count == ea->capacity) {
-        int newCap = ea->capacity * 2;
-        // overflow guard
-        if ((size_t)newCap > (SIZE_MAX / sizeof(EasingSegment))) return NULL;
+    if (!ensureCapacity(ea, (size_t)ea->count + 1)) return NULL;
 
-        EasingSegment* newPtr = (EasingSegment*)roxy_realloc(
-            ea->segments, (size_t)newCap * sizeof(EasingSegment));
-        if (!newPtr) return NULL;
-
-        ea->segments = newPtr;
-        ea->capacity = newCap;
-        ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
-    }
     // Return pointer to the next slot, but also increment
     EasingSegment* seg = &ea->segments[ea->count];
     ea->count++;
@@ -157,14 +203,15 @@ static char* duplicateString(const char* source)
 }
 
 // ! Evaluate At Time
-// Evaluate value at an absolute time (uses same search logic as getValue)
-static float evalAtTime(const EasingArray* ea, float t)
+static const EasingSegment* findSegmentForTime(const EasingArray* ea, float t, float* clampedOut)
 {
-    if (!ea || ea->count == 0) return 0.0f;
+    if (!ea || ea->count == 0) return NULL;
 
     float clamped = roxy_math_clamp(t, 0.0f, ea->totalDuration);
+    if (clampedOut) *clampedOut = clamped;
+
     int last = ea->count - 1;
-    if (clamped >= ea->segments[last].endTime) return ea->segments[last].to;
+    if (ea->isSorted && clamped >= ea->segments[last].endTime) return &ea->segments[last];
 
     const EasingSegment* easing = NULL;
 
@@ -191,6 +238,12 @@ static float evalAtTime(const EasingArray* ea, float t)
     if (!easing)
         easing = (clamped < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[last];
 
+    return easing;
+}
+
+static float evaluateSegmentAtTime(const EasingArray* ea, const EasingSegment* easing, float clamped)
+{
+    if (!ea || !easing) return 0.0f;
     if (easing->duration <= 0.0f) return easing->to;
 
     float timeOffset = clamped - easing->timestamp;
@@ -217,6 +270,14 @@ static float evalAtTime(const EasingArray* ea, float t)
         easing->duration,
         0.0f, 0.0f
     );
+}
+
+// Evaluate value at an absolute time (uses same search logic as getValue)
+static float evalAtTime(const EasingArray* ea, float t)
+{
+    float clamped = 0.0f;
+    const EasingSegment* easing = findSegmentForTime(ea, t, &clamped);
+    return evaluateSegmentAtTime(ea, easing, clamped);
 }
 
 // Compute the correct boundary time when the sequence is completed.
@@ -283,8 +344,6 @@ static int easingArray_newobject(lua_State* L)
     ea->loopType            = 0;
     ea->loopCount           = 0.0f;
     ea->travelAccum         = 0.0f;
-    ea->loopCounter         = 0;
-    ea->pingPongHalfCycles  = 0;
     ea->isForward           = 1;
     ea->isSorted            = 1;
 
@@ -344,7 +403,11 @@ static int easingArray_setEasingAt(lua_State* L)
 {
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     int idx = lua->getArgInt(2);
-    if (!ea || idx <= 0 || idx > ea->count) { lua->pushBool(0); return 1; }
+    if (!ea || idx <= 0 || idx > ea->count) {
+        lua->pushNil();
+        lua->pushString("invalid index");
+        return 2;
+    }
 
     // NOTE: Modifying a segment in the middle can result in overlapping or
     // out-of-order segments. It is the user's responsibility to maintain
@@ -354,18 +417,13 @@ static int easingArray_setEasingAt(lua_State* L)
     seg->timestamp    = lua->getArgFloat(3);
     seg->from         = lua->getArgFloat(4);
     seg->to           = lua->getArgFloat(5);
-    seg->duration     = lua->getArgFloat(6);
+    seg->duration     = durationOrZero(lua->getArgFloat(6));
     seg->endTime      = seg->timestamp + seg->duration;
     seg->easeFunction = lua->getArgInt(7);
 
     // Re-evaluate sortedness and totalDuration
-    ea->isSorted = 1;
-    float maxEnd = 0.0f;
-    for (int i = 0; i < ea->count; ++i) {
-        if (i > 0 && ea->segments[i].timestamp < ea->segments[i-1].timestamp) ea->isSorted = 0;
-        if (ea->segments[i].endTime > maxEnd) maxEnd = ea->segments[i].endTime;
-    }
-    ea->totalDuration = maxEnd;
+    recomputeTimelineMetadata(ea);
+    resetPlaybackState(ea);
 
     lua->pushBool(1);
     return 1;
@@ -429,7 +487,7 @@ static int easingArray_addEasing(lua_State* L)
     float duration    = lua->getArgFloat(5);
     int easeFunction  = lua->getArgInt(6);
 
-    if (duration < 0.0f) duration = 0.0f;
+    duration = durationOrZero(duration);
 
     // NOTE: For best performance, add easings in increasing timestamp order.
     //       Segments should be non-overlapping and in increasing order.
@@ -452,7 +510,7 @@ static int easingArray_addEasing(lua_State* L)
     ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
 
     if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
-    ea->completed = 0;
+    resetPlaybackState(ea);
 
     lua->pushBool(1);
     return 1;
@@ -465,10 +523,9 @@ static int easingArray_from(lua_State* L)
     if (!ea) { lua->pushNil(); return 1; }
 
     ea->count         = 0;
-    ea->currentTime   = 0.0f;
-    ea->completed     = 0;
     ea->totalDuration = 0.0f;
     ea->isSorted      = 1;
+    resetPlaybackState(ea);
 
     float fromVal = lua->getArgFloat(2);
 
@@ -482,7 +539,7 @@ static int easingArray_from(lua_State* L)
     seg->endTime      = 0.0f;
     seg->easeFunction = 0;
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -497,18 +554,19 @@ static int easingArray_to(lua_State* L)
     float duration      = (argc >= 3) ? lua->getArgFloat(3) : DEFAULT_DURATION;
     int easeFunction    = (argc >= 4) ? lua->getArgInt(4) : DEFAULT_EASE_FUNCTION;
 
-    if (duration <= 0.0f) duration = DEFAULT_DURATION;
+    duration = durationOrDefault(duration);
     if (easeFunction <= 0) easeFunction = DEFAULT_EASE_FUNCTION;
 
     int lastIdx = ea->count - 1;
-    EasingSegment* lastSeg = &ea->segments[lastIdx];
+    float lastEnd = ea->segments[lastIdx].endTime;
+    float lastTo  = ea->segments[lastIdx].to;
 
     // Append new segment
     EasingSegment* seg = ensureCapacityAndInsert(ea);
     if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
 
-    seg->timestamp    = lastSeg->endTime;
-    seg->from         = lastSeg->to;
+    seg->timestamp    = lastEnd;
+    seg->from         = lastTo;
     seg->to           = newTo;
     seg->duration     = duration;
     seg->endTime      = seg->timestamp + seg->duration;
@@ -519,9 +577,9 @@ static int easingArray_to(lua_State* L)
     ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
 
     if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
-    ea->completed = 0;
+    resetPlaybackState(ea);
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -545,11 +603,11 @@ static int easingArray_set(lua_State* L)
     seg->endTime      = newTimestamp;
     seg->easeFunction = 0;
 
-    ea->completed     = 0;
     if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
+    resetPlaybackState(ea);
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -559,24 +617,26 @@ static int easingArray_sleep(lua_State* L)
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
 
-    float duration         = lua->getArgFloat(2);
-    EasingSegment* lastSeg = &ea->segments[ea->count - 1];
+    float duration = durationOrZero(lua->getArgFloat(2));
+    int lastIdx = ea->count - 1;
+    float lastEnd = ea->segments[lastIdx].endTime;
+    float lastTo  = ea->segments[lastIdx].to;
 
     EasingSegment* seg = ensureCapacityAndInsert(ea);
     if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
 
-    seg->timestamp    = lastSeg->endTime;
-    seg->from         = lastSeg->to;
-    seg->to           = lastSeg->to;
+    seg->timestamp    = lastEnd;
+    seg->from         = lastTo;
+    seg->to           = lastTo;
     seg->duration     = duration;
     seg->endTime      = seg->timestamp + seg->duration;
     seg->easeFunction = 0;
 
-    ea->completed     = 0;
     if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
+    resetPlaybackState(ea);
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -594,10 +654,8 @@ static int easingArray_setLoopType(lua_State* L)
     if (loopType < 0) loopType = 0;
     if (loopType > 2) loopType = 2;
     ea->loopType    = loopType;
-    ea->loopCount   = (loopCount < 0.0f) ? 0.0f : loopCount;
-    ea->travelAccum = 0.0f;
-    ea->loopCounter = 0;
-    ea->isForward   = 1;
+    ea->loopCount   = (!isfinite(loopCount) || loopCount < 0.0f) ? 0.0f : loopCount;
+    resetPlaybackState(ea);
 
     lua->pushBool(1);
     return 1;
@@ -611,28 +669,17 @@ static int easingArray_again(lua_State* L)
 
     long long rc = (long long)lua->getArgInt(2);
     if (rc <= 0) rc = DEFAULT_REPEAT_COUNT;
+    if (rc > INT_MAX) { lua->pushNil(); lua->pushString("repeat overflow"); return 2; }
+    int repeatCount = (int)rc;
 
     // Needed elements (count + rc) may overflow int; use size_t
-    size_t needed = (size_t)ea->count + (size_t)rc;
+    size_t needed = (size_t)ea->count + (size_t)repeatCount;
     if (needed < (size_t)ea->count) { // overflow wrap
         lua->pushNil(); lua->pushString("repeat overflow"); return 2;
     }
 
-    if ((int)needed > ea->capacity) {
-        int newCap = ea->capacity;
-        while ((int)needed > newCap) {
-            if (newCap > INT_MAX/2) { lua->pushNil(); lua->pushString("capacity overflow"); return 2; }
-            newCap *= 2;
-        }
-        if ((size_t)newCap > SIZE_MAX/sizeof(EasingSegment)) {
-            lua->pushNil(); lua->pushString("size overflow"); return 2;
-        }
-        EasingSegment* newPtr = (EasingSegment*)roxy_realloc(ea->segments, (size_t)newCap * sizeof(EasingSegment));
-        if (!newPtr) { lua->pushNil(); lua->pushString("oom"); return 2; }
-        ea->segments = newPtr;
-        ea->capacity = newCap;
-        ROXY_LABEL(ea->segments, "RoxySequenceC.segments");
-    }
+    if (needed > (size_t)INT_MAX) { lua->pushNil(); lua->pushString("capacity overflow"); return 2; }
+    if (!ensureCapacity(ea, needed)) { lua->pushNil(); lua->pushString("oom"); return 2; }
 
     int lastIdx = ea->count - 1;
     EasingSegment* lastSeg = &ea->segments[lastIdx];
@@ -642,7 +689,7 @@ static int easingArray_again(lua_State* L)
     float newDuration   = lastSeg->duration;
     int newEaseFunction = lastSeg->easeFunction;
 
-    for (int r = 0; r < rc; r++) {
+    for (int r = 0; r < repeatCount; r++) {
         EasingSegment* seg = ensureCapacityAndInsert(ea);
         if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
 
@@ -657,10 +704,10 @@ static int easingArray_again(lua_State* L)
         if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     }
 
-    ea->completed = 0;
     ea->isSorted = 1; // Appends preserve order
+    resetPlaybackState(ea);
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -671,33 +718,39 @@ static int easingArray_reverse(lua_State* L)
     if (!ea || ea->count == 0) { lua->pushNil(); return 1; }
 
     int appendNew          = lua->getArgBool(2);
-    EasingSegment* lastSeg = &ea->segments[ea->count - 1];
+    int lastIdx            = ea->count - 1;
+    EasingSegment* lastSeg = &ea->segments[lastIdx];
 
     if (!appendNew) {
-        float elapsed = ea->currentTime - lastSeg->timestamp;
         float temp    = lastSeg->from;
         lastSeg->from = lastSeg->to;
         lastSeg->to   = temp;
-        ea->currentTime = lastSeg->timestamp + (lastSeg->duration - elapsed);
-        lua->pushObject(ea, "RoxySequenceC", 0);
+        resetPlaybackState(ea);
+        lua->pushBool(1);
         return 1;
     }
+
+    float lastEnd      = lastSeg->endTime;
+    float lastFrom     = lastSeg->from;
+    float lastTo       = lastSeg->to;
+    float lastDuration = lastSeg->duration;
+    int lastEase       = lastSeg->easeFunction;
 
     EasingSegment* seg = ensureCapacityAndInsert(ea);
     if (!seg) { lua->pushNil(); lua->pushString("oom"); return 2; }
 
-    seg->timestamp    = lastSeg->endTime;
-    seg->from         = lastSeg->to;
-    seg->to           = lastSeg->from;
-    seg->duration     = lastSeg->duration;
+    seg->timestamp    = lastEnd;
+    seg->from         = lastTo;
+    seg->to           = lastFrom;
+    seg->duration     = lastDuration;
     seg->endTime      = seg->timestamp + seg->duration;
-    seg->easeFunction = lastSeg->easeFunction;
+    seg->easeFunction = lastEase;
 
-    ea->completed     = 0;
     if (seg->endTime > ea->totalDuration) ea->totalDuration = seg->endTime;
     ea->isSorted &= (ea->count <= 1 || ea->segments[ea->count-1].timestamp >= ea->segments[ea->count-2].timestamp);
+    resetPlaybackState(ea);
 
-    lua->pushObject(ea, "RoxySequenceC", 0);
+    lua->pushBool(1);
     return 1;
 }
 
@@ -755,7 +808,6 @@ static int easingArray_updateAndGetValue(lua_State* L)
         return 4;
     }
 
-    int lastIdx = ea->count - 1;
     float oldTime = ea->currentTime;
 
     // If already completed, return boundary-correct value (handles fractional loop counts).
@@ -789,23 +841,8 @@ static int easingArray_updateAndGetValue(lua_State* L)
         return 4;
     }
 
-    // Use isSorted and fall back to linear if not sorted
-    EasingSegment* easing = NULL;
-    if (!ea->isSorted || ea->count <= 4) {
-        for (int i = 0; i < ea->count; i++) {
-            EasingSegment* seg = &ea->segments[i];
-            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) { easing = seg; break; }
-        }
-    } else {
-        int left = 0, right = lastIdx;
-        while (left <= right) {
-            int mid = left + (right - left) / 2;
-            EasingSegment* seg = &ea->segments[mid];
-            if (ea->currentTime >= seg->timestamp && ea->currentTime <= seg->endTime) { easing = seg; break; }
-            if (ea->currentTime < seg->timestamp) right = mid - 1; else left = mid + 1;
-        }
-    }
-    if (!easing) easing = (ea->currentTime < ea->segments[0].timestamp) ? &ea->segments[0] : &ea->segments[lastIdx];
+    float clamped = 0.0f;
+    const EasingSegment* easing = findSegmentForTime(ea, ea->currentTime, &clamped);
 
     if (easing->duration <= 0.0f) {
         lua->pushFloat(oldTime);
@@ -817,7 +854,7 @@ static int easingArray_updateAndGetValue(lua_State* L)
 
     lua->pushFloat(oldTime);
     lua->pushFloat(ea->currentTime);
-    lua->pushFloat(evalAtTime(ea, ea->currentTime));
+    lua->pushFloat(evaluateSegmentAtTime(ea, easing, clamped));
     lua->pushBool(0);
     return 4;
 }
@@ -848,12 +885,7 @@ static int easingArray_reset(lua_State* L)
     EasingArray* ea = lua->getArgObject(1, "RoxySequenceC", NULL);
     if (!ea) return 0;
 
-    ea->currentTime         = 0.0f;
-    ea->completed           = 0;
-    ea->travelAccum         = 0.0f;
-    ea->loopCounter         = 0;
-    ea->pingPongHalfCycles  = 0;
-    ea->isForward           = 1;
+    resetPlaybackState(ea);
 
     lua->pushBool(1);
     return 1;
@@ -866,16 +898,9 @@ static int easingArray_clear(lua_State* L)
     if (!ea) return 0;
 
     ea->count               = 0;
-    ea->currentTime         = 0.0f;
-    ea->completed           = 0;
     ea->totalDuration       = 0.0f;
-    ea->loopType            = 0;
-    ea->loopCount           = 0.0f;
-    ea->travelAccum         = 0.0f;
-    ea->loopCounter         = 0;
-    ea->pingPongHalfCycles  = 0;
-    ea->isForward           = 1;
     ea->isSorted            = 1;
+    resetLoopConfiguration(ea);
 
     lua->pushBool(1);
     return 1;

--- a/core/sequences/roxy_sequence.h
+++ b/core/sequences/roxy_sequence.h
@@ -36,14 +36,14 @@ typedef struct
     int loopType;           // 0=none,1=loop,2=pingpong
     float loopCount;        // Number of loops; 0.0f = infinite (supports fractions)
     float travelAccum;      // Total forward "path" distance consumed (seconds)
-    int loopCounter;
-    int pingPongHalfCycles;
     int isForward;          // 1 = forward, 0 = backward
     int isSorted;           // 1 = timestamps non-decreasing
 } EasingArray;
 
 typedef void (*LoopHandler)(EasingArray*, float*, float);
 
+// RoxySequenceC is the internal native backing object for RoxySequence.
+// Gameplay code should use the Lua RoxySequence wrapper.
 void registerRoxySequenceC(PlaydateAPI* pd);
 
 #endif /* ROXY_SEQUENCE_H */


### PR DESCRIPTION
### Overview
This PR tightens `RoxySequence` lifecycle handling and native sequence mutation behavior so completed, looped, reversed, and rebuilt sequences restart predictably while preserving the public Lua wrapper's fluent API.

### Key Changes
- Keeps `RoxySequence` as the public chainable gameplay API, including consistent `addEasing()` and `clear()` chaining.
- Treats `RoxySequenceC` as the internal native backing object and changes native mutators to return `true` or `nil` with a reason instead of duplicate native userdata.
- Resets native playback bookkeeping when the timeline is rebuilt so reuse after completion, loop completion, and mid-play mutation starts from a consistent state.
- Normalizes invalid and non-finite durations for sequence mutations.
- Removes redundant per-frame segment lookup by reusing the active native segment during update evaluation.
- Removes stale Lua and C sequence state and adds focused usage examples for common sequence workflows.

### Challenges/Notes
- Direct `RoxySequenceC` access remains unsupported/internal; gameplay code should continue to use the `RoxySequence` wrapper.
- Public callback dispatch remains owned by `RoxySequence:update()` and is not changed by the native return-value cleanup.