### PR TITLE
Fix Sequence Double Registration

### DIFF
--- a/core/modules/Sequencer.lua
+++ b/core/modules/Sequencer.lua
@@ -11,8 +11,6 @@ roxy = roxy or {}
 roxy.Sequencer = roxy.Sequencer or {}
 local Sequencer <const> = roxy.Sequencer
 
-local pd <const> = playdate
-
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
 
@@ -24,13 +22,13 @@ function Sequencer.init()
 end
 
 -- ! Add
--- Adds a sequence to the list of running sequences.
+-- Adds a sequence to the list of running sequences
 function Sequencer.add(sequence)
   tableInsert(runningSequences, sequence)
 end
 
 -- ! Remove
--- Removes a specific sequence from the list of running sequences.
+-- Removes a specific sequence from the list of running sequences
 function Sequencer.remove(sequenceToRemove)
   for i = #runningSequences, 1, -1 do
     if runningSequences[i] == sequenceToRemove then
@@ -41,15 +39,19 @@ function Sequencer.remove(sequenceToRemove)
 end
 
 -- ! Remove All
--- Clears all sequences from the list of running sequences.
+-- Clears all sequences from the list of running sequences
 function Sequencer.removeAll()
   for i = #runningSequences, 1, -1 do
+    local sequence = runningSequences[i]
+    if type(sequence) == "table" and sequence.isRunning ~= nil then
+      sequence.isRunning = false
+    end
     runningSequences[i] = nil
   end
 end
 
 -- ! Stop All
--- Stops all currently running sequences.
+-- Stops all currently running sequences
 function Sequencer.stopAll()
   for i = #runningSequences, 1, -1 do
     local sequence = runningSequences[i]
@@ -58,10 +60,33 @@ function Sequencer.stopAll()
 end
 
 -- ! Update
--- Updates all running sequences with the given delta time.
+-- Updates all running sequences with the given delta time
 function Sequencer.update(dt)
   for i = #runningSequences, 1, -1 do
     local sequence = runningSequences[i]
     sequence:update(dt)
   end
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Sequencer owns the global update list for active sequences. Most gameplay code uses RoxySequence:play() and :stop(), which register and remove themselves.
+
+local Sequencer <const> = roxy.Sequencer
+
+-- Manual Loop Integration
+Sequencer.init()
+
+function updateGame(dt)
+  Sequencer.update(dt)
+end
+
+-- Cleanup
+Sequencer.stopAll()   -- Gives each running sequence a chance to stop itself
+Sequencer.removeAll() -- Clears any remaining entries and running flags
+
+--]]

--- a/core/sequences/RoxySequence.lua
+++ b/core/sequences/RoxySequence.lua
@@ -84,6 +84,7 @@ end
 -- ! Add
 function RoxySequence:add()
   if #self.easingArray == 0 then return self end
+  if self.isRunning then return self end
   addSequence(self)
   self.isRunning = true
   return self


### PR DESCRIPTION
### Overview
This PR fixes a sequence lifecycle bug where calling `RoxySequence:add()` more than once could register the same sequence repeatedly with the shared `Sequencer`, causing it to update more than once per frame. It also keeps bulk sequencer cleanup from leaving tracked sequence objects marked as running so they can be reused normally after `removeAll()`.

### Key Changes
- Guarded `RoxySequence:add()` so already-running sequences are not inserted into the `Sequencer` multiple times.
- Updated `Sequencer.removeAll()` to clear running state on tracked sequence objects while clearing the update list.
- Added compact `Sequencer` usage examples and aligned lightweight comments with the local Lua style.

### Challenges/Notes
- `Sequencer.add()` remains a low-level insertion helper; normal gameplay code should continue using `RoxySequence:play()` and `:stop()` for lifecycle management.