### PR TITLE
Fix Sequence Clear Loop State

### DIFF
--- a/core/sequences/RoxySequence.lua
+++ b/core/sequences/RoxySequence.lua
@@ -104,6 +104,7 @@ function RoxySequence:clear(clearEasings)
   if clearEasings then
     if self.easingArray:clear() then
       self.currentValue = 0
+      self.loopType = 0
     end
   end
 


### PR DESCRIPTION
### Overview
This PR fixes sequence reuse after `clear(true)` by keeping the Lua `RoxySequence` loop-state mirror aligned with the native clear path. Cleared sequences no longer retain stale loop configuration after their easing data is removed.

### Key Changes
- Resets the Lua sequence loop state when `clear(true)` successfully clears native easing data.
- Keeps native clear behavior and the non-clearing `clear(false)` path unchanged.

### Breaking Changes
None.

### Challenges/Notes
None.