### PR TITLE
Harden Native Sequence Capacity Guards

### DIFF
--- a/core/sequences/roxy_sequence.c
+++ b/core/sequences/roxy_sequence.c
@@ -71,10 +71,13 @@ static void recomputeTimelineMetadata(EasingArray* ea)
 
 static int ensureCapacity(EasingArray* ea, size_t needed)
 {
+    if (!ea || !ea->segments) return 0;
     if (needed > (SIZE_MAX / sizeof(EasingSegment)) || needed > (size_t)INT_MAX) return 0;
-    if (needed <= (size_t)ea->capacity) return 1;
 
     int newCap = ea->capacity;
+    if (newCap <= 0) return 0;
+    if (needed <= (size_t)newCap) return 1;
+
     while ((size_t)newCap < needed) {
         if (newCap > INT_MAX / 2) return 0;
         newCap *= 2;
@@ -93,6 +96,7 @@ static int ensureCapacity(EasingArray* ea, size_t needed)
 // ! Ensure Capacity and Insert
 static EasingSegment* ensureCapacityAndInsert(EasingArray* ea)
 {
+    if (!ea || ea->count < 0 || ea->count >= INT_MAX) return NULL;
     if (!ensureCapacity(ea, (size_t)ea->count + 1)) return NULL;
 
     // Return pointer to the next slot, but also increment


### PR DESCRIPTION
### Overview
This PR hardens the native `RoxySequenceC` allocation path so invalid internal sequence storage fails through existing mutation error paths instead of relying on unsafe signed-to-unsigned casts.

### Key Changes
- Rejects null native sequence storage before capacity growth.
- Rejects nonpositive capacity values before comparing capacity as `size_t`.
- Guards invalid signed segment counts before computing the next insert slot.

### Challenges/Notes
- This is defensive hardening for private native state; normal sequences initialized through `RoxySequenceC.new()` should behave the same.
- No public Lua API changes are included.
- Verified with sequence-focused Busted coverage, the full Busted suite, `make release`, and simulator smoke checks for the loader/ImageTable path, `SequenceCIntegrationTest`, and `SequencerTest`.