### PR TITLE
Avoid Empty Isometric Chunk-Warming Allocations

### DIFF
--- a/core/tilemaps/RoxyIsoTilemap.lua
+++ b/core/tilemaps/RoxyIsoTilemap.lua
@@ -373,6 +373,8 @@ end
 -- ! Warm Some Chunks
 -- Amortize chunk builds across frames
 function RoxyIsoTilemap:_warmSomeChunks()
+  if #self._warmQueue == 0 then return end
+
   local built = 0
   local centerCache = {}
   while built < BUILD_BUDGET and #self._warmQueue > 0 do

--- a/core/tilemaps/RoxyStagTilemap.lua
+++ b/core/tilemaps/RoxyStagTilemap.lua
@@ -425,6 +425,8 @@ end
 -- ! Warm Some Chunks
 -- Amortize chunk builds across frames
 function RoxyStagTilemap:_warmSomeChunks()
+  if #self._warmQueue == 0 then return end
+
   local built = 0
   local centerCache = {}
   while built < BUILD_BUDGET and #self._warmQueue > 0 do


### PR DESCRIPTION
### Overview
This PR avoids an unnecessary table allocation when isometric and staggered-isometric tilemaps reach chunk warming with no queued work, reducing garbage on active draw frames without changing queued chunk behavior.

### Key Changes
- Return immediately from Iso and Stag chunk warming when their warm queues are empty.
- Allocate the per-batch center cache only when queued chunks need scoring and building.
- Preserve existing build budgets, nearest-job selection, cache insertion, and redraw behavior for non-empty queues.

### Challenges/Notes
- No public API or migration changes.
- Orthographic tilemaps are unaffected because they do not use this warm-queue path.