### PR TITLE
Fix Playdate System Lifecycle Callback Coordination

### DIFF
--- a/core/modules/Debug.lua
+++ b/core/modules/Debug.lua
@@ -1,37 +1,52 @@
 -- core/modules/Debug.lua
 
-local pd  = playdate
+local pd <const> = playdate
 
 roxy = roxy or {}
-local Debug = roxy.Debug or {}
-roxy.Debug = Debug
+roxy.Debug = roxy.Debug or {}
+local Debug <const> = roxy.Debug
 
 local max   <const> = math.max
 local floor <const> = math.floor
 
 local performAfterDelay <const> = pd.timer.performAfterDelay
 
-local c_heapGuardVerifyAll  <const> = roxy.heapGuardVerifyAll
-local c_heapGuardDumpActive <const> = roxy.heapGuardDumpActive
-local c_heapGuardSnap       <const> = roxy.heapGuardSnap
+-- C heap guard bindings are optional in non-debug builds.
+local heapGuardVerifyAll_C  <const> = roxy.heapGuardVerifyAll
+local heapGuardDumpActive_C <const> = roxy.heapGuardDumpActive
+local heapGuardSnap_C       <const> = roxy.heapGuardSnap
 
-local HG_ON = (type(c_heapGuardVerifyAll) == "function")
-Debug.heapGuardEnabled = HG_ON
+local HEAP_GUARD_ENABLED <const> = (type(heapGuardVerifyAll_C) == "function")
+Debug.heapGuardEnabled = HEAP_GUARD_ENABLED
 
-local debugCheckingEnabled = false
-local debugChecksActive    = false
+local debugCheckingEnabled  = false
+local debugChecksActive     = false
 
 Debug.visualDebug = false
 
 -- ! Capture Original Functions
--- Store original Playdate SDK functions for tamper detection
+-- Store expected Playdate SDK handlers for tamper detection.
+--
+-- 'roxy.*' values are read inside this function, never aliased at module scope:
+-- Debug is imported near the start of roxy.lua, before the lifecycle forwarders
+-- are defined, so a load-time alias would capture nil. By the time this runs --
+-- from roxy.init() via enableDebugChecking() -- they exist.
 local debugFunctions = {}
 local function captureOriginalFunctions()
+  -- 'pd.update' and the crank callbacks have no Roxy-owned counterpart, so the
+  -- installed value is the only available baseline.
   debugFunctions.update = pd.update
   debugFunctions.crankDocked = pd.crankDocked
   debugFunctions.crankUndocked = pd.crankUndocked
-  debugFunctions.gameWillPause = pd.gameWillPause
-  debugFunctions.gameWillResume = pd.gameWillResume
+
+  -- Roxy owns these, so the baseline is Roxy's own function, not whatever is
+  -- currently installed. Reading a pd.* value here would canonize a game's
+  -- pre-init override and defeat the check entirely.
+  debugFunctions.gameWillPause = roxy.gameWillPause
+  debugFunctions.gameWillResume = roxy.gameWillResume
+  debugFunctions.gameWillTerminate = roxy.gameWillTerminate
+  debugFunctions.deviceWillSleep = roxy.deviceWillSleep
+  debugFunctions.deviceWillLock = roxy.deviceWillLock
 end
 
 --------------------------------------------------------------------------------
@@ -64,27 +79,27 @@ end
 
 -- ! Heap Guard Verify All
 function Debug.heapGuardVerify()
-  if HG_ON then c_heapGuardVerifyAll() end
+  if HEAP_GUARD_ENABLED then heapGuardVerifyAll_C() end
 end
 
 -- ! Heap Guard Dump Active
 function Debug.heapGuardDump()
-  if HG_ON then c_heapGuardDumpActive() end
+  if HEAP_GUARD_ENABLED then heapGuardDumpActive_C() end
 end
 
 -- ! Heap Guard Snap
 function Debug.heapGuardSnap(tag)
-  if HG_ON then c_heapGuardSnap(tag) end
+  if HEAP_GUARD_ENABLED then heapGuardSnap_C(tag) end
 end
 
 -- ! Heap Guard Verify For (Frames)
 -- Verify for N frames without touching pd.update
 function Debug.heapGuardVerifyFor(frames)
-  if not HG_ON then return end
+  if not HEAP_GUARD_ENABLED then return end
   local n = max(1, floor(frames or 60))
   local function tick()
     if n <= 0 then return end
-    c_heapGuardVerifyAll()
+    heapGuardVerifyAll_C()
     n = n - 1
     performAfterDelay(0, tick) -- Schedule next frame
   end
@@ -160,10 +175,17 @@ function Debug.runChecks()
   end
   if debugChecksActive then
     check(pd.update, debugFunctions.update, "playdate.update")
+    -- 'crankDocked' / 'crankUndocked' are never assigned by the engine: those
+    -- events reach scenes through 'playdate.inputHandlers', so installing the
+    -- globals would double-fire. The checks are kept for games that install
+    -- them.
     check(pd.crankDocked, debugFunctions.crankDocked, "playdate.crankDocked")
     check(pd.crankUndocked, debugFunctions.crankUndocked, "playdate.crankUndocked")
     check(pd.gameWillPause, debugFunctions.gameWillPause, "playdate.gameWillPause")
     check(pd.gameWillResume, debugFunctions.gameWillResume, "playdate.gameWillResume")
+    check(pd.gameWillTerminate, debugFunctions.gameWillTerminate, "playdate.gameWillTerminate")
+    check(pd.deviceWillSleep, debugFunctions.deviceWillSleep, "playdate.deviceWillSleep")
+    check(pd.deviceWillLock, debugFunctions.deviceWillLock, "playdate.deviceWillLock")
   end
 end
 
@@ -173,3 +195,33 @@ function Debug.update()
     Debug.runChecks()
   end
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+Debug provides runtime diagnostics for debug builds.
+
+-- Enable Checks Through Roxy Configuration
+roxy.init({
+  debugging = {
+    enableDebugChecks = true,
+    enableVisualDebugChecks = true,
+  },
+})
+
+-- Toggle Visual Diagnostics at Runtime
+Debug.toggleVisualDebug()
+Debug.disableVisualDebug()
+
+-- Inspect Native Heap Guards When Available
+if Debug.heapGuardEnabled then
+  Debug.heapGuardSnap("before-level-load")
+  loadLevel()
+  Debug.heapGuardVerifyFor(120)
+  Debug.heapGuardDump()
+end
+
+--]]

--- a/core/modules/GameData.lua
+++ b/core/modules/GameData.lua
@@ -9,32 +9,26 @@ local pd        <const> = playdate
 local File      <const> = pd.file
 local Datastore <const> = pd.datastore
 
--- Time helpers
+local r       <const> = roxy
+local Config  <const> = r.Config
+local Table   <const> = r.Table
+
+local max           <const> = math.max
+local stringFormat  <const> = string.format
+
+local cloneDeep <const> = Table.cloneWithCycles
+
 local getTime       <const> = pd.getGMTTime
 local epochFromTime <const> = pd.epochFromGMTTime
 local timeFromEpoch <const> = pd.timeFromEpoch
+local fileExists    <const> = File.exists
+local renameFile    <const> = File.rename
+local writeData     <const> = Datastore.write
+local readData      <const> = Datastore.read
+local deleteData    <const> = Datastore.delete
 
-local stringFormat <const> = string.format
-
-local max <const> = math.max
-
--- Roxy utilities
-local clamp     <const> = roxy.Math.clamp
-local cloneDeep <const> = roxy.Table.cloneWithCycles
-
-local getConfig <const> = roxy.Config.get
-
--- File I/O
-local fileExists <const> = File.exists
-local renameFile <const> = File.rename
-local writeData  <const> = Datastore.write
-local readData   <const> = Datastore.read
-local deleteData <const> = Datastore.delete
-
--- Timer for zero-delay batching
 local performAfterDelay <const> = pd.timer.performAfterDelay
-
-local getConfig <const> = roxy.Config.get
+local getConfig         <const> = Config.get
 
 --------------------------------------------------------------------------------
 -- Configurable slot count (no hard limit)
@@ -424,15 +418,59 @@ function GameData.setCurrentSlot(slot)
 end
 
 --------------------------------------------------------------------------------
--- Auto-save on quit/pause
+-- Autosave
 --------------------------------------------------------------------------------
 
--- ! Get Will Terminate
-function playdate.gameWillTerminate()
-  GameData.saveAll(true)
+-- ! Autosave
+-- Force-save every existing slot. Roxy calls this from the system lifecycle
+-- handlers it owns; see roxy.lua. GameData deliberately does not claim
+-- 'playdate.gameWillPause' / 'gameWillTerminate' itself -- import order decided
+-- the winner and the last writer silently dropped the other handler.
+function GameData.autosave()
+  return GameData.saveAll(true)
 end
 
--- ! Get Will Pause
-function playdate.gameWillPause()
-  GameData.saveAll(true)
-end
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+GameData manages typed save data across one or more slots.
+
+-- Define Defaults and Create Three Slots
+GameData.setup({
+  level = 1,
+  score = 0,
+  inventory = {},
+}, 3)
+
+-- Read and Update a Slot
+local score = GameData.get("score", 1)
+local inventory = GameData.get("inventory", 1)
+GameData.set("score", score + 500, 1, {
+  updateTimestamp = true,
+  save = true,
+})
+
+-- Replace and Select a Slot
+GameData.setSlot({
+  level = 4,
+  score = 6800,
+  inventory = { "observatory-key" },
+}, 2, {
+  updateTimestamp = true,
+  save = true,
+})
+GameData.setCurrentSlot(2)
+local activeSlot = GameData.getSlot()
+
+-- Read Without a Defensive Copy on Performance-Sensitive Paths
+local inventoryView = GameData.getFast("inventory")
+-- Treat inventoryView as read-only; direct mutations bypass dirty tracking.
+
+-- Restore Defaults
+GameData.reset("score", 2, { updateTimestamp = true, save = true })
+GameData.resetSlot(3, { updateTimestamp = true, save = true })
+
+--]]

--- a/core/modules/Input.lua
+++ b/core/modules/Input.lua
@@ -4,27 +4,31 @@ roxy = roxy or {}
 roxy.Input = roxy.Input or {}
 local Input <const> = roxy.Input
 
-local pd  <const> = playdate
-local r   <const> = roxy
+local pd              <const> = playdate
+local CrankIndicator  <const> = pd.ui.crankIndicator
+
+local r       <const> = roxy
+local Config  <const> = r.Config
 
 local tableInsert <const> = table.insert
 local tableRemove <const> = table.remove
 local tableSort   <const> = table.sort
 
+local max <const> = math.max
+
 local getButtonState    <const> = pd.getButtonState
 local pushInputHandlers <const> = pd.inputHandlers.push
 local popInputHandlers  <const> = pd.inputHandlers.pop
-local CrankIndicator    <const> = pd.ui.crankIndicator
 
-local getConfig <const> = roxy.Config.get
+local getConfig <const> = Config.get
 
 -- Configuration constants
-local BUTTON_HOLD_BUFFER_DEFAULT <const> = 3
-local CRANK_DIRECTION_DEFAULT    <const> = 1
+local BUTTON_HOLD_BUFFER_DEFAULT  <const> = 3
+local CRANK_DIRECTION_DEFAULT     <const> = 1
 
 -- Pre-defined array for efficient iteration instead of pairs()
-local BUTTON_NAMES <const> = { "A", "B", "up", "down", "left", "right" }
-local BUTTON_COUNT <const> = #BUTTON_NAMES
+local BUTTON_NAMES  <const> = { "A", "B", "up", "down", "left", "right" }
+local BUTTON_COUNT  <const> = #BUTTON_NAMES
 
 -- Input event keys - kept in sync with handler merging system
 local INPUT_KEYS <const> = {
@@ -61,6 +65,11 @@ local handlerRegistry = {}
 local activeMergedHandler = nil
 local persistentMergedHandler = {} -- Reused table to avoid allocation
 
+-- Monotonic registration counter. Breaks priority ties deterministically:
+-- table.sort is not stable, so equal-priority handlers would otherwise swap
+-- precedence whenever the registry is rebuilt.
+local handlerSeq = 0
+
 -- Cache hold callbacks to avoid repeated table lookups in hot path
 local cachedHoldCallbacks = {}
 
@@ -88,9 +97,14 @@ Input._paused = false  -- Pauses all input callbacks until resumed
 --------------------------------------------------------------------------------
 
 -- ! Priority Comparator
--- Cached comparison function to avoid creating closures repeatedly
+-- Cached comparison function to avoid creating closures repeatedly.
+-- Ties break on registration order so precedence is deterministic across the
+-- unstable sort in mergeHandlers().
 local function priorityComparator(a, b)
-  return a.priority > b.priority
+  if a.priority ~= b.priority then
+    return a.priority > b.priority
+  end
+  return a.seq < b.seq
 end
 
 -- ! Reset Button Flags
@@ -221,6 +235,7 @@ function Input.init()
   Input._paused = false
 
   handlerRegistry = {}
+  handlerSeq = 0
   activeMergedHandler = nil
   autoFlushEnabled = true
   pendingRegistryDirty = false
@@ -228,20 +243,21 @@ function Input.init()
   resetButtonFlags()
 end
 
--- ! Add Handler
--- Register or update a handler with given priority (higher = more important)
-function Input.addHandler(owner, tbl, priority)
-  Log.assert(owner and tbl, "[Input.addHandler] Must provide owner and table.", 2) --#DEBUG
-  priority = priority or 0
-
-  -- Replace existing handler in-place to avoid array shifts
+-- ! Helper: Register Handler
+-- Shared path for Input.addHandler and Input._restoreHandler. A nil 'seq' mints
+-- a fresh registration sequence; a non-nil 'seq' reinstates a captured one.
+local function registerHandler(owner, tbl, priority, seq)
+  -- Replace existing handler in-place to avoid array shifts. Mutating the
+  -- record (rather than rebuilding it) preserves 'seq' for free.
   for i = 1, #handlerRegistry do
-    if handlerRegistry[i].owner == owner then
-      handlerRegistry[i] = {
-        owner = owner,
-        tbl = tbl,
-        priority = priority
-      }
+    local existing = handlerRegistry[i]
+    if existing.owner == owner then
+      existing.tbl = tbl
+      existing.priority = priority
+      if seq then
+        existing.seq = seq
+        handlerSeq = max(handlerSeq, seq + 1)
+      end
       if autoFlushEnabled then
         Input.flush()
       else
@@ -252,16 +268,50 @@ function Input.addHandler(owner, tbl, priority)
   end
 
   -- Add new handler
+  local assigned = seq or handlerSeq
   tableInsert(handlerRegistry, {
     owner = owner,
     tbl = tbl,
-    priority = priority
+    priority = priority,
+    seq = assigned
   })
+  -- Keep the counter ahead of any restored sequence so a future registration
+  -- can never tie an existing one.
+  handlerSeq = max(handlerSeq, assigned + 1)
 
   if autoFlushEnabled then
     Input.flush()
   else
     pendingRegistryDirty = true
+  end
+end
+
+-- ! Add Handler
+-- Register or update a handler with given priority (higher = more important).
+-- New owners mint a registration sequence; updating an existing owner preserves
+-- it. A removed-then-re-added owner therefore sorts last among equal priorities.
+function Input.addHandler(owner, tbl, priority)
+  Log.assert(owner and tbl, "[Input.addHandler] Must provide owner and table.", 2) --#DEBUG
+  registerHandler(owner, tbl, priority or 0, nil)
+end
+
+-- ! Restore Handler (internal)
+-- Lifecycle-only: re-registers an owner at a previously captured priority and
+-- sequence so precedence survives a pause/resume cycle. Registration sequence is
+-- engine bookkeeping, not a game-facing contract -- games use Input.addHandler.
+function Input._restoreHandler(owner, tbl, priority, seq)
+  Log.assert(owner and tbl, "[Input._restoreHandler] Must provide owner and table.", 2) --#DEBUG
+  registerHandler(owner, tbl, priority or 0, seq)
+end
+
+-- ! Get Handler Registration (internal)
+-- Returns priority, seq for an owner; nil, nil when not registered.
+function Input._getHandlerRegistration(owner)
+  for i = 1, #handlerRegistry do
+    local entry = handlerRegistry[i]
+    if entry.owner == owner then
+      return entry.priority, entry.seq
+    end
   end
 end
 
@@ -558,16 +608,42 @@ function Input.setIsEnabled(value)
   Log.debug("[Input.setIsEnabled] Set to " .. tostring(value)) --#DEBUG
 end
 
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
 --[[
-USAGE EXAMPLE:
+
+Input merges prioritized handlers and centralizes hold, crank, and pause state.
+
+-- Register Gameplay Controls
+local playerControls = {
+  AButtonDown = function() player:jump() end,
+  AButtonHold = function() player:chargeJump() end,
+  cranked = function(change) player:turnCrank(change) end,
+}
+
+Input.setButtonHoldBufferAmount(4)
 Input.addHandler(player, playerControls, 0)
-Input.addHandler(menu, menuControls, 100) -- Higher priority
+Input.addHandler(companion, companionControls, 0)
+-- Earlier registration wins shared keys when priorities are equal.
+
+-- Add a Modal Menu Above Gameplay
+local menuControls = Input.makeModalHandler({
+  BButtonDown = function() menu:close() end,
+})
+Input.addHandler(menu, menuControls, 100)
 Input.removeHandler(menu)
 
--- Batch operations for better performance
+-- Batch Handler Changes into One Rebuild
 Input.suspendAutoFlush()
 for _, widget in ipairs(widgets) do
   Input.addHandler(widget, widget:getInputTable(), 20)
 end
 Input.resumeAutoFlush()
-]]--
+
+-- Pause Input and Wait for Released Buttons Before Resuming
+Input.pause()
+Input.resume(true)
+
+--]]

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -10,11 +10,12 @@ local Input   <const> = r.Input
 local Camera  <const> = r.Camera
 local Scene   <const> = r.Scene
 
-local tableInsert <const> = table.insert
-local tableRemove <const> = table.remove
-local setMetatable <const> = setmetatable
-local rawGet <const> = rawget
-local rawSet <const> = rawset
+local tableInsert   <const> = table.insert
+local tableRemove   <const> = table.remove
+local setMetatable  <const> = setmetatable
+local rawGet        <const> = rawget
+local rawSet        <const> = rawset
+local luaType       <const> = type
 
 local clearScreen         <const> = Graphics.clear
 local setColor            <const> = Graphics.setColor
@@ -30,6 +31,11 @@ local addHandler    <const> = Input.addHandler
 local pauseHandler  <const> = Input.pause
 local resumeHandler <const> = Input.resume
 local removeHandler <const> = Input.removeHandler
+
+local restoreHandler          <const> = Input._restoreHandler
+local getHandlerRegistration  <const> = Input._getHandlerRegistration
+
+local getSpritePauseMask <const> = Scene._getSpritePauseMask
 
 local resetCamera           <const> = Camera.reset
 local setCameraBounds       <const> = Camera.setBounds
@@ -71,9 +77,7 @@ local SNAPSHOT_COLLISIONS_OFF <const> = SCENE_PAUSE_COLLISIONS << SNAPSHOT_STATE
 local SNAPSHOT_COLLISIONS_ON  <const> = SNAPSHOT_COLLISIONS_OFF + RESTORE_COLLISIONS
 local SNAPSHOT_ALL_BASE       <const> = SCENE_PAUSE_ALL << SNAPSHOT_STATE_BITS
 
-local NO_OP_BG_DRAW       <const> = function(x, y, width, height) end
-local getSpritePauseMask  <const> = Scene._getSpritePauseMask
-local luaType             <const> = type
+local NO_OP_BG_DRAW <const> = function(x, y, width, height) end
 
 local _colorCallbacks = {} -- Cache: color --> fn
 local _imageCallbacks = setMetatable({}, { __mode = "k" }) -- Cache: image --> fn, weak keys
@@ -913,6 +917,8 @@ function RoxyScene:init(background)
   self._spriteAutoAddIndex = {}
   self._pauseSpriteSnapshots = {}
   self._pauseSpriteSnapshotList = {}
+  self._pausedHandlerPriority = nil
+  self._pausedHandlerSeq = nil
   self._sceneStackSpritesHidden = false
   self._sceneStackVisibilitySnapshotList = {}
   self._sequenceAutoStartQueue = {}
@@ -1200,6 +1206,10 @@ function RoxyScene:pause()
     _pauseSceneSequence(self, sequences[i])
   end
 
+  -- Capture the exact registration so resume() can reinstate precedence.
+  -- removeHandler discards the record, so a plain re-add would mint a later
+  -- sequence and hand equal-priority peers the shared keys.
+  self._pausedHandlerPriority, self._pausedHandlerSeq = getHandlerRegistration(self)
   removeHandler(self)
 end
 
@@ -1311,7 +1321,15 @@ function RoxyScene:resume()
     self._roxyScenePauseCameraSnapshot = nil
   end
 
-  self:addHandler()
+  -- Restore only when pause() actually captured a registration. A nil sequence
+  -- means the scene was not registered at pause time, and 'inputHandler'
+  -- defaults to {}, so an unconditional add would register a handler that did
+  -- not exist before.
+  local pausedPriority, pausedSeq = self._pausedHandlerPriority, self._pausedHandlerSeq
+  self._pausedHandlerPriority, self._pausedHandlerSeq = nil, nil
+  if pausedSeq then
+    self:_restoreHandler(pausedPriority, pausedSeq)
+  end
 end
 
 -- ! Exit
@@ -1346,6 +1364,8 @@ function RoxyScene:cleanup()
   self._sequenceAutoStartQueue = {}
   self._sceneStackSpritesHidden = false
   self._sceneStackVisibilitySnapshotList = {}
+  self._pausedHandlerPriority = nil
+  self._pausedHandlerSeq = nil
 
   self.backgroundColor = nil
   self.backgroundImage = nil
@@ -1750,6 +1770,15 @@ function RoxyScene:addHandler()
   local inputHandler = self.inputHandler
   if inputHandler and (luaType(inputHandler) == "table" or luaType(inputHandler) == "function") then
     addHandler(self, inputHandler, 0)
+  end
+end
+
+-- ! Restore Input Handler (internal)
+-- Lifecycle-only: reinstates the exact registration captured by pause().
+function RoxyScene:_restoreHandler(priority, seq)
+  local inputHandler = self.inputHandler
+  if inputHandler and (luaType(inputHandler) == "table" or luaType(inputHandler) == "function") then
+    restoreHandler(self, inputHandler, priority or 0, seq)
   end
 end
 

--- a/roxy.lua
+++ b/roxy.lua
@@ -61,13 +61,13 @@ import "libraries/roxy/core/scenes/RoxyScene"
 roxy = roxy or {}
 
 -- Aliases
-
 local pd        <const> = playdate
 local Graphics  <const> = pd.graphics
 local Sprite    <const> = Graphics.sprite
 
 local r           <const> = roxy
 local Debug       <const> = r.Debug
+local GameData    <const> = r.GameData
 local Cache       <const> = r.Cache
 local Config      <const> = r.Config
 local Input       <const> = r.Input
@@ -216,24 +216,107 @@ function r.start(startingSceneFn)
 end
 
 --------------------------------------------------------------------------------
--- Pause and Resume
+-- System Lifecycle
 --------------------------------------------------------------------------------
+
+-- Roxy owns the Playdate system-event globals. Every forwarder runs an optional
+-- game hook. Pause, terminate, sleep, and lock force a GameData autosave; pause
+-- and resume also drive the current scene. Games set 'roxy.onGameWillPause' etc.
+-- instead of assigning the corresponding Playdate globals, which would bypass
+-- Roxy's autosave or scene forwarding and, when debug checks are enabled, trip
+-- the tamper check.
+--
+-- 'GameData' is a '<const>' table alias, but 'autosave' is intentionally looked
+-- up on that table at each call.
+
+-- Records the exact scene this module paused, so a system resume never
+-- un-pauses a scene that game code paused itself. Cleared on every resume.
+local systemPausedScene = nil
+
+-- ! Utility: Call Game Hook
+-- Runs an optional game hook under protection so a broken hook cannot defeat
+-- autosave or scene pause. Returns pcall's success flag and value separately:
+-- 'error(nil)' and 'error(false)' are legal, so branching on the value alone
+-- would swallow those failures.
+local function callGameHook(hook)
+  if not hook then return true, nil end
+  return pcall(hook)
+end
 
 -- ! Game Will Pause
 function r.gameWillPause()
+  -- Hook first: GameData mutations are synchronous but the save I/O defers
+  -- through a zero-delay timer that cannot fire while paused, so the autosave
+  -- below must be the thing that observes whatever the hook staged.
+  local hookOk, hookErr = callGameHook(r.onGameWillPause)
+
+  GameData.autosave()
+
   local currentScene = Scene.currentScene
-  if currentScene.pause then
+  if currentScene and not currentScene.isPaused and currentScene.pause then
     currentScene:pause()
+    systemPausedScene = currentScene
   end
+
+  -- Rethrow only after persistence and scene pause are complete.
+  if not hookOk then error(hookErr, 0) end
 end
 
 -- ! Game Will Resume
 function r.gameWillResume()
-  local currentScene = Scene.currentScene
-  if currentScene.resume then
-    currentScene:resume()
+  -- Clear first so a stale reference can never drive a later resume and never
+  -- anchors a replaced scene's sprite graph.
+  local pausedScene = systemPausedScene
+  systemPausedScene = nil
+
+  if pausedScene and pausedScene == Scene.currentScene and pausedScene.resume then
+    pausedScene:resume()
   end
+
+  -- Unprotected: the scene is already restored, so an error can propagate.
+  local onGameWillResume = r.onGameWillResume
+  if onGameWillResume then onGameWillResume() end
 end
+
+-- ! Game Will Terminate
+function r.gameWillTerminate()
+  local hookOk, hookErr = callGameHook(r.onGameWillTerminate)
+  GameData.autosave()
+  if not hookOk then error(hookErr, 0) end
+end
+
+-- ! Device Will Sleep
+-- Save point only: Roxy has no paired wake callback to resume the scene.
+function r.deviceWillSleep()
+  local hookOk, hookErr = callGameHook(r.onDeviceWillSleep)
+  GameData.autosave()
+  if not hookOk then error(hookErr, 0) end
+end
+
+-- ! Device Will Lock
+-- Save point only: Playdate provides deviceDidUnlock, but Roxy does not use
+-- lock/unlock to drive scene pause state.
+function r.deviceWillLock()
+  local hookOk, hookErr = callGameHook(r.onDeviceWillLock)
+  GameData.autosave()
+  if not hookOk then error(hookErr, 0) end
+end
+
+--#DEBUG START
+-- ! Reset System Pause State (unit tests)
+function r._resetSystemPauseState()
+  systemPausedScene = nil
+end
+--#DEBUG END
+
+-- Install at file scope after GameData is imported so Roxy is the last writer,
+-- and before 'roxy.init()' so Debug.captureOriginalFunctions snapshots these as
+-- the originals. Same seam as 'pd.update' below.
+pd.gameWillPause      = r.gameWillPause
+pd.gameWillResume     = r.gameWillResume
+pd.gameWillTerminate  = r.gameWillTerminate
+pd.deviceWillSleep    = r.deviceWillSleep
+pd.deviceWillLock     = r.deviceWillLock
 
 --------------------------------------------------------------------------------
 -- Main Game Loop
@@ -298,3 +381,39 @@ function pd.update()
   updateDebug() --#DEBUG
   if showFPS then drawFPS(fpsX, fpsY) end --#DEBUG
 end
+
+--------------------------------------------------------------------------------
+-- Usage Examples
+--------------------------------------------------------------------------------
+
+--[[
+
+-- Extend Roxy's lifecycle handling; do not replace the playdate callbacks.
+local function stageSessionState()
+  roxy.GameData.set({
+    room = currentRoom,
+    checkpoint = currentCheckpoint,
+  })
+end
+
+roxy.onGameWillPause = stageSessionState
+roxy.onGameWillTerminate = stageSessionState
+roxy.onDeviceWillSleep = stageSessionState
+roxy.onDeviceWillLock = stageSessionState
+
+roxy.onGameWillResume = function()
+  refreshControllerState()
+end
+
+-- Keep scene-specific pause behavior on the scene.
+function GameplayScene:pause()
+  GameplayScene.super.pause(self)
+  self.ambientTrack:pause()
+end
+
+function GameplayScene:resume()
+  GameplayScene.super.resume(self)
+  self.ambientTrack:play()
+end
+
+--]]


### PR DESCRIPTION
### Overview
This PR centralizes Playdate lifecycle callback ownership in Roxy so game hooks, `GameData` autosaves, scene pause state, input precedence, and debug checks stay coordinated across system events.

### Key Changes
- Installed Roxy-owned forwarders for `gameWillPause`, `gameWillResume`, `gameWillTerminate`, `deviceWillSleep`, and `deviceWillLock`.
- Added matching `roxy.on...` extension hooks while preserving required autosave and scene work before hook errors propagate.
- Added `GameData.autosave()` to force-save existing slots from lifecycle callbacks without competing for Playdate callback ownership.
- Track the exact scene paused by the system so Roxy does not resume a scene paused by game code or a replacement scene selected while the system menu is open.
- Preserve input priority and deterministic equal-priority precedence across `RoxyScene` pause and resume cycles.
- Expanded debug tamper detection for every lifecycle callback owned by Roxy and refreshed the affected usage examples.

### Breaking Changes
Roxy now owns the five Playdate lifecycle callbacks listed above. Games that assign those callbacks directly must move custom behavior to the matching Roxy hook.

**Before**
```lua
function playdate.gameWillPause()
  stageSessionState()
end
```

**Now**
```lua
roxy.onGameWillPause = function()
  stageSessionState()
end
```

The same pattern applies to `onGameWillResume`, `onGameWillTerminate`, `onDeviceWillSleep`, and `onDeviceWillLock`.

### Challenges/Notes
Sleep and lock remain save-only events. Roxy intentionally does not use lock or unlock events to drive scene pause state.