### PR TITLE
Warn Before Replacing Lifecycle Callbacks

### DIFF
--- a/core/modules/Debug.lua
+++ b/core/modules/Debug.lua
@@ -175,10 +175,10 @@ function Debug.runChecks()
   end
   if debugChecksActive then
     check(pd.update, debugFunctions.update, "playdate.update")
-    -- 'crankDocked' / 'crankUndocked' are never assigned by the engine: those
-    -- events reach scenes through 'playdate.inputHandlers', so installing the
-    -- globals would double-fire. The checks are kept for games that install
-    -- them.
+    -- Roxy does not assign 'crankDocked' / 'crankUndocked': scenes receive
+    -- those events through 'playdate.inputHandlers', so globals would
+    -- double-fire. Debug checking snapshots their values when checks begin and
+    -- treats a later replacement as tampering.
     check(pd.crankDocked, debugFunctions.crankDocked, "playdate.crankDocked")
     check(pd.crankUndocked, debugFunctions.crankUndocked, "playdate.crankUndocked")
     check(pd.gameWillPause, debugFunctions.gameWillPause, "playdate.gameWillPause")

--- a/roxy.lua
+++ b/roxy.lua
@@ -229,6 +229,18 @@ end
 -- 'GameData' is a '<const>' table alias, but 'autosave' is intentionally looked
 -- up on that table at each call.
 
+--#DEBUG START
+-- A repeated import may encounter the forwarders from the prior Roxy import.
+-- Preserve them so the migration diagnostic does not mistake them for game code.
+local priorLifecycleForwarders <const> = {
+  gameWillPause     = r.gameWillPause,
+  gameWillResume    = r.gameWillResume,
+  gameWillTerminate = r.gameWillTerminate,
+  deviceWillSleep   = r.deviceWillSleep,
+  deviceWillLock    = r.deviceWillLock,
+}
+--#DEBUG END
+
 -- Records the exact scene this module paused, so a system resume never
 -- un-pauses a scene that game code paused itself. System resume requires the
 -- RoxyScene boolean 'isPaused' state to distinguish partial pause work from a
@@ -322,6 +334,34 @@ end
 -- Install at file scope after GameData is imported so Roxy is the last writer,
 -- and before 'roxy.init()' so Debug.captureOriginalFunctions snapshots these as
 -- the originals. Same seam as 'pd.update' below.
+
+--#DEBUG START
+local lifecycleCallbacks <const> = {
+  { playdateName = "gameWillPause",     forwarderName = "gameWillPause",     hookName = "onGameWillPause" },
+  { playdateName = "gameWillResume",    forwarderName = "gameWillResume",    hookName = "onGameWillResume" },
+  { playdateName = "gameWillTerminate", forwarderName = "gameWillTerminate", hookName = "onGameWillTerminate" },
+  { playdateName = "deviceWillSleep",   forwarderName = "deviceWillSleep",   hookName = "onDeviceWillSleep" },
+  { playdateName = "deviceWillLock",    forwarderName = "deviceWillLock",    hookName = "onDeviceWillLock" },
+}
+
+local replacedLifecycleCallbacks = {}
+for i = 1, #lifecycleCallbacks do
+  local callback = lifecycleCallbacks[i]
+  local existingCallback = pd[callback.playdateName]
+  if existingCallback ~= nil and existingCallback ~= priorLifecycleForwarders[callback.forwarderName] then
+    replacedLifecycleCallbacks[#replacedLifecycleCallbacks + 1] =
+      "playdate." .. callback.playdateName .. " (use roxy." .. callback.hookName .. ")"
+  end
+end
+
+if #replacedLifecycleCallbacks > 0 then
+  Log.warn(
+    "[Roxy] Roxy owns these Playdate lifecycle globals and will replace their pre-existing values: "
+      .. table.concat(replacedLifecycleCallbacks, ", ") .. "."
+  )
+end
+--#DEBUG END
+
 pd.gameWillPause      = r.gameWillPause
 pd.gameWillResume     = r.gameWillResume
 pd.gameWillTerminate  = r.gameWillTerminate


### PR DESCRIPTION
### Overview
Adds debug-only migration guidance when Roxy replaces pre-existing Playdate lifecycle callbacks, helping games move to Roxy lifecycle hooks without changing Roxy’s ownership model.

### Key Changes
- Warn once before replacing pre-existing `playdate.gameWillPause`, `gameWillResume`, `gameWillTerminate`, `deviceWillSleep`, or `deviceWillLock` values.
- List only affected callbacks and pair each with its corresponding `roxy.on…` hook.
- Treat non-`nil` values, including `false`, as replaced callbacks while avoiding warnings during repeated Roxy imports.
- Clarify that crank handler globals are baseline-checked for tampering rather than owned by Roxy.

### Challenges/Notes
Roxy continues to own the Playdate lifecycle globals. Games should use the corresponding `roxy.on…` hooks instead of assigning those globals directly.