### PR TITLE
Preserve Input Updates Across Scene Pause and Resume

### DIFF
--- a/core/modules/Input.lua
+++ b/core/modules/Input.lua
@@ -244,19 +244,23 @@ function Input.init()
 end
 
 -- ! Helper: Register Handler
--- Shared path for Input.addHandler and Input._restoreHandler. A nil 'seq' mints
--- a fresh registration sequence; a non-nil 'seq' reinstates a captured one.
+-- Shared path for Input.addHandler and Input._restoreHandler. A nil 'seq'
+-- performs an ordinary add/update; a non-nil 'seq' reconciles lifecycle state.
 local function registerHandler(owner, tbl, priority, seq)
   -- Replace existing handler in-place to avoid array shifts. Mutating the
-  -- record (rather than rebuilding it) preserves 'seq' for free.
+  -- record (rather than rebuilding it) preserves ordinary update ordering.
   for i = 1, #handlerRegistry do
     local existing = handlerRegistry[i]
     if existing.owner == owner then
-      existing.tbl = tbl
-      existing.priority = priority
-      if seq then
+      if seq ~= nil then
+        -- The owner was explicitly re-registered while lifecycle code held a
+        -- snapshot. Preserve that visible handler/priority change while
+        -- returning the owner to its captured equal-priority position.
         existing.seq = seq
         handlerSeq = max(handlerSeq, seq + 1)
+      else
+        existing.tbl = tbl
+        existing.priority = priority
       end
       if autoFlushEnabled then
         Input.flush()
@@ -296,21 +300,22 @@ function Input.addHandler(owner, tbl, priority)
 end
 
 -- ! Restore Handler (internal)
--- Lifecycle-only: re-registers an owner at a previously captured priority and
--- sequence so precedence survives a pause/resume cycle. Registration sequence is
--- engine bookkeeping, not a game-facing contract -- games use Input.addHandler.
+-- Lifecycle-only: restores a missing owner from captured state. If the owner
+-- was explicitly re-registered, preserves its handler and priority while
+-- reinstating captured sequence precedence. Registration sequence is engine
+-- bookkeeping, not a game-facing contract -- games use Input.addHandler.
 function Input._restoreHandler(owner, tbl, priority, seq)
   Log.assert(owner and tbl, "[Input._restoreHandler] Must provide owner and table.", 2) --#DEBUG
   registerHandler(owner, tbl, priority or 0, seq)
 end
 
 -- ! Get Handler Registration (internal)
--- Returns priority, seq for an owner; nil, nil when not registered.
+-- Returns priority, seq, handler table for an owner; nil values when absent.
 function Input._getHandlerRegistration(owner)
   for i = 1, #handlerRegistry do
     local entry = handlerRegistry[i]
     if entry.owner == owner then
-      return entry.priority, entry.seq
+      return entry.priority, entry.seq, entry.tbl
     end
   end
 end

--- a/core/scenes/RoxyScene.lua
+++ b/core/scenes/RoxyScene.lua
@@ -1206,9 +1206,9 @@ function RoxyScene:pause()
     _pauseSceneSequence(self, sequences[i])
   end
 
-  -- Capture the exact registration so resume() can reinstate precedence.
-  -- removeHandler discards the record, so a plain re-add would mint a later
-  -- sequence and hand equal-priority peers the shared keys.
+  -- Capture registration metadata so resume() can reinstate precedence.
+  -- removeHandler discards the record, so lifecycle restoration must recover
+  -- the sequence without overwriting an explicit paused-time registration.
   self._pausedHandlerPriority, self._pausedHandlerSeq = getHandlerRegistration(self)
   removeHandler(self)
 end
@@ -1321,10 +1321,11 @@ function RoxyScene:resume()
     self._roxyScenePauseCameraSnapshot = nil
   end
 
-  -- Restore only when pause() actually captured a registration. A nil sequence
-  -- means the scene was not registered at pause time, and 'inputHandler'
-  -- defaults to {}, so an unconditional add would register a handler that did
-  -- not exist before.
+  -- Reconcile only when pause() captured a registration. A missing owner is
+  -- restored from the snapshot; an explicit paused-time registration keeps its
+  -- handler and priority while recovering captured sequence precedence. A nil
+  -- sequence means the scene was not registered at pause time, so resume leaves
+  -- any current registration untouched.
   local pausedPriority, pausedSeq = self._pausedHandlerPriority, self._pausedHandlerSeq
   self._pausedHandlerPriority, self._pausedHandlerSeq = nil, nil
   if pausedSeq then
@@ -1774,9 +1775,14 @@ function RoxyScene:addHandler()
 end
 
 -- ! Restore Input Handler (internal)
--- Lifecycle-only: reinstates the exact registration captured by pause().
+-- Lifecycle-only: restores missing captured state or reconciles the captured
+-- sequence with an explicit paused-time handler and priority.
 function RoxyScene:_restoreHandler(priority, seq)
+  -- Prefer a handler explicitly registered while paused. The scene property may
+  -- have changed or been cleared, but the live registry entry remains valid.
+  local _, registeredSeq, registeredHandler = getHandlerRegistration(self)
   local inputHandler = self.inputHandler
+  if registeredSeq ~= nil then inputHandler = registeredHandler end
   if inputHandler and (luaType(inputHandler) == "table" or luaType(inputHandler) == "function") then
     restoreHandler(self, inputHandler, priority or 0, seq)
   end


### PR DESCRIPTION
### Overview
This PR preserves explicit input handler and priority changes that exist before scene lifecycle restoration, while restoring the captured registration sequence so equal-priority dispatch order remains stable.

### Key Changes
- Preserve the current handler and priority when lifecycle restoration finds the same owner already registered.
- Restore only the captured sequence for an existing owner, maintaining its pre-pause equal-priority position.
- Continue restoring the captured handler, priority, and sequence when the owner is absent.
- Preserve ordinary `Input.addHandler()` replacement behavior and use the live registered handler during scene resume.

### Challenges/Notes
- The reconciliation behavior is independent of Playdate System Menu callback ordering and does not guarantee a particular platform callback sequence.
- No public API changes or migration steps are required.